### PR TITLE
Fix in getOutputDir Function

### DIFF
--- a/process.py
+++ b/process.py
@@ -437,7 +437,7 @@ def getOutputDir():
     # Override if we have a file.
     if args.file != None:
         return os.path.dirname(args.file.name)
-    return tracesDir
+    return args.outputDir
 
 
 class PVal:


### PR DESCRIPTION
Images in criticalPath.html is broken in current version.
Fixed flame graph output directory. It will fix criticalPath.html.