### PR TITLE
Fix: Align file-level licenses with repository Apache LICENSE

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -1,11 +1,16 @@
-#Copyright (c) 2021  Uber Technologies, Inc.
+# Copyright (c) 2021 Uber Technologies, Inc.
 #
-#Licensed under the Uber Non-Commercial License (the "License");
-#you may not use this file except in compliance with the License.
-#You may obtain a copy of the License at the root directory of this project.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#See the License for the specific language governing permissions and
-#limitations under the License.
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import logging
 

--- a/process.py
+++ b/process.py
@@ -1,11 +1,16 @@
-#Copyright (c) 2021  Uber Technologies, Inc.
+# Copyright (c) 2021 Uber Technologies, Inc.
 #
-#Licensed under the Uber Non-Commercial License (the "License");
-#you may not use this file except in compliance with the License.
-#You may obtain a copy of the License at the root directory of this project.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#See the License for the specific language governing permissions and
-#limitations under the License.
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import json
 import glob


### PR DESCRIPTION
This PR updates the license headers in two specific files to match the Apache License defined in the root LICENSE file of the repository.

Currently, the license headers in these two files (graph.py and process.py) contradict the repository's main Apache license. Clarifying this discrepancy ensures that downstream users and open-source projects can confidently use this repository without facing ambiguity or permission issues.