### PR TITLE
feat(crisp/utils): port dict_utils, singleton_wrapper, span_utils

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,7 +10,6 @@ py_library(
         "process.py",
         "tb_client.py",
         "yaml_merger.py",
-        "utils/singleton_wrapper.py",
     ],
     imports = ["."],
     visibility = ["//visibility:private"],
@@ -33,6 +32,7 @@ py_test(
     data = glob(["tests/**"]) + ["pyproject.toml"],
     deps = [
         ":crisp_lib",
+        "//crisp:pkg",
         "@pypi//pytest",
     ],
     env = {"MPLBACKEND": "Agg"},

--- a/crisp/LAYERS.md
+++ b/crisp/LAYERS.md
@@ -23,3 +23,13 @@ must not import from higher layers. Each PR in the port maintains this invariant
 If you find yourself adding a `crisp.process_trace` import inside
 `crisp/output/`, stop — the dependency is inverted. Move the shared piece
 down to `crisp.shared` instead.
+
+## Naming convention during the port
+
+Most public functions in `crisp/` (e.g. `accumulateInDict`, `isProxyNode`,
+`getCPSize`) are `camelCase`. This violates PEP 8 but is **deliberate**:
+the port preserves the exact names used by the upstream internal codebase
+so that every call site migrates with a single-line import change rather
+than a rename sweep. Renaming to `snake_case` is a cross-cutting concern
+that deserves its own dedicated PR once the port has stabilized — please
+don't do it as a drive-by in an unrelated change.

--- a/crisp/utils/BUILD.bazel
+++ b/crisp/utils/BUILD.bazel
@@ -2,7 +2,12 @@ load("@rules_python//python:py_library.bzl", "py_library")
 
 py_library(
     name = "utils",
-    srcs = ["__init__.py"],
+    srcs = [
+        "__init__.py",
+        "dict_utils.py",
+        "singleton_wrapper.py",
+        "span_utils.py",
+    ],
     imports = ["../.."],
     visibility = ["//visibility:public"],
 )

--- a/crisp/utils/dict_utils.py
+++ b/crisp/utils/dict_utils.py
@@ -1,0 +1,45 @@
+"""Dictionary utility functions for critical path analysis."""
+
+from typing import Any
+
+
+def accumulateInDict(dictName: dict[Any, Any], key: Any, value: Any) -> None:
+    """Add value to existing key in dictName or insert new key and value.
+
+    ``value`` must support ``__add__`` with the existing dict entry (e.g.
+    numbers, or any custom class implementing ``__add__``). No copy is
+    made; the accumulator is stored by reference.
+    """
+    if key in dictName:
+        # add value to existing key in dictName
+        dictName[key] = dictName[key] + value
+    else:
+        # insert new key and value into dictName
+        dictName[key] = value
+
+
+def maxExample(
+    dictName: dict[Any, tuple[Any, Any]], key: Any, sid: Any, value: Any
+) -> None:
+    """Remember ``(sid, value)`` in ``dictName[key]`` if this is the worst case seen.
+
+    Tie-break: comparison is strict ``>``, so the *first* ``sid`` written
+    for a given ``value`` wins on equality. Callers that depend on a
+    specific tie-break order should not rely on a later-inserted sid
+    overriding an earlier one with the same value.
+    """
+    if key in dictName:
+        if value > dictName[key][1]:
+            # remember if this is the worst case seen
+            dictName[key] = (sid, value)
+    else:
+        # remember since this is the first case seen
+        dictName[key] = (sid, value)
+
+
+def getCPSize(cct: dict[str, int]) -> int:
+    """Calculate the size of the critical path profile string representation."""
+    res = 0
+    for k, v in cct.items():
+        res += len("\n" + k.replace("->", ";") + " " + str(v))
+    return res

--- a/crisp/utils/singleton_wrapper.py
+++ b/crisp/utils/singleton_wrapper.py
@@ -1,4 +1,7 @@
+"""Decorator that turns a class into a lazily-initialized singleton."""
+
 from typing import ClassVar
+
 
 class SingletonWrapper:
     _instances: ClassVar[dict[type, object]] = {}

--- a/crisp/utils/span_utils.py
+++ b/crisp/utils/span_utils.py
@@ -1,0 +1,138 @@
+"""
+Utility functions for span classification and validation.
+
+Several of these helpers consult small per-deployment allow-lists
+(e.g. "which spans should be treated as proxies that don't faithfully
+forward their child's error?") that are inherently site-specific.
+
+The lists ship empty by default. Downstream users can extend them
+without monkey-patching by appending to the module-level globals:
+
+    from crisp.utils import span_utils
+
+    span_utils.PROXY_SERVICE_OP_PAIRS.append(("my-proxy", "relay"))
+    span_utils.TEST_TRACE_OP_PREFIXES.append("[mytests.Run]")
+
+Note that ``TEST_TRACE_OP_PREFIXES`` is matched with ``str.startswith``,
+so a shorter entry like ``"[mytests."`` would match every op name in
+that family (``[mytests.Run]``, ``[mytests.Setup]``, ...) in a single
+line.
+
+Entry shapes (enforced only at match time — appending the wrong shape
+will silently do nothing until the first classification call):
+
+* ``PROXY_SERVICE_OP_PAIRS``    — ``(serviceName: str, opName: str)``
+* ``PROXY_ONLY_OPS``            — ``opName: str``
+* ``ERR_PROP_SERVICE_OP_PAIRS`` — ``(serviceName: str, opName: str)``
+* ``TEST_TRACE_SERVICES``       — ``serviceName: str``
+* ``TEST_TRACE_OP_PREFIXES``    — ``opNamePrefix: str``
+"""
+
+# --- Proxy-node configuration ---------------------------------------------
+# (serviceName, opName) pairs that should be treated as proxies whose span
+# does not faithfully reflect the error state of its child.
+PROXY_SERVICE_OP_PAIRS: list[tuple[str, str]] = []
+# opNames that should be treated as proxies regardless of serviceName.
+# Useful for instrumentation wrappers that appear under many services.
+PROXY_ONLY_OPS: list[str] = []
+
+# --- Error-propagation-node configuration ---------------------------------
+# (serviceName, opName) pairs where errors are reported on the caller side
+# rather than surfaced in the proxy's own span, so analysis should propagate
+# the child's error upward.
+ERR_PROP_SERVICE_OP_PAIRS: list[tuple[str, str]] = []
+
+# --- Test-trace heuristics -------------------------------------------------
+# Service names that identify synthetic/test traffic rather than production.
+TEST_TRACE_SERVICES: list[str] = []
+# Operation-name prefixes that identify synthetic/test traffic. Match is
+# performed with str.startswith.
+TEST_TRACE_OP_PREFIXES: list[str] = []
+
+
+def isProxyNode(serviceName: str, opName: str) -> bool:
+    """
+    Check if a span represents a proxy node based on service and op name.
+
+    A span is a "proxy node" when it forwards work to a child but does not
+    faithfully reflect the child's timing or error state (e.g. an auth
+    wrapper or instrumentation relay). The match is driven by
+    ``PROXY_SERVICE_OP_PAIRS`` and ``PROXY_ONLY_OPS``; both are empty by
+    default and intended to be populated per deployment.
+
+    Args:
+        serviceName: The name of the service.
+        opName: The operation name.
+
+    Returns:
+        True if the span is identified as a proxy node, False otherwise.
+    """
+    for s, o in PROXY_SERVICE_OP_PAIRS:
+        if (serviceName == s) and (opName == o):
+            return True
+    for o in PROXY_ONLY_OPS:
+        if opName == o:
+            return True
+    return False
+
+
+def isErrPropNode(serviceName: str, opName: str) -> bool:
+    """
+    Return True if this span should have its child's error propagated up.
+
+    Some proxies always succeed at the network layer because the error is
+    materialized on the client side. The child's error then has to be
+    carried up through the proxy's span. The match is driven by
+    ``ERR_PROP_SERVICE_OP_PAIRS``, empty by default.
+
+    Args:
+        serviceName: The name of the service.
+        opName: The operation name.
+
+    Returns:
+        True if errors should be propagated from this node, False otherwise.
+    """
+    for s, o in ERR_PROP_SERVICE_OP_PAIRS:
+        if (serviceName == s) and (opName == o):
+            return True
+    return False
+
+
+def isTestTraceByServiceName(serviceName: str) -> bool:
+    """
+    Return True if ``serviceName`` identifies a synthetic/test trace.
+
+    Match is exact equality against ``TEST_TRACE_SERVICES`` (empty by
+    default). Extend that list to exclude your own test-framework
+    services from production analysis.
+
+    Args:
+        serviceName: The name of the service to check.
+
+    Returns:
+        True if the service is identified as a test service, False otherwise.
+    """
+    for name in TEST_TRACE_SERVICES:
+        if serviceName == name:
+            return True
+    return False
+
+
+def isTestTraceByOpName(operationName: str) -> bool:
+    """
+    Return True if ``operationName`` identifies a synthetic/test trace.
+
+    Match is ``startswith`` against ``TEST_TRACE_OP_PREFIXES`` (empty by
+    default). Extend that list to exclude your own test-framework
+    operations from production analysis.
+
+    Args:
+        operationName: The operation name to check.
+
+    Returns:
+        True if the operation is identified as a test operation, False otherwise.
+    """
+    for prefix in TEST_TRACE_OP_PREFIXES:
+        if operationName.startswith(prefix):
+            return True
+    return False

--- a/tests/utils/test_dict_utils.py
+++ b/tests/utils/test_dict_utils.py
@@ -1,0 +1,120 @@
+"""Unit tests for crisp.utils.dict_utils."""
+
+import unittest
+
+from crisp.utils.dict_utils import accumulateInDict, getCPSize, maxExample
+
+
+class TestDictUtils(unittest.TestCase):
+    """Test cases for dictionary utility functions."""
+
+    def test_accumulateInDict_new_key(self):
+        """Test adding a new key to an empty dict."""
+        test_dict = {}
+        accumulateInDict(test_dict, "key1", 10)
+        self.assertEqual(test_dict["key1"], 10)
+
+    def test_accumulateInDict_existing_key(self):
+        """Test accumulating to an existing key."""
+        test_dict = {"key1": 5}
+        accumulateInDict(test_dict, "key1", 10)
+        self.assertEqual(test_dict["key1"], 15)
+
+    def test_accumulateInDict_multiple_keys(self):
+        """Test accumulating multiple keys."""
+        test_dict = {}
+        accumulateInDict(test_dict, "key1", 10)
+        accumulateInDict(test_dict, "key2", 20)
+        accumulateInDict(test_dict, "key1", 5)
+
+        self.assertEqual(test_dict["key1"], 15)
+        self.assertEqual(test_dict["key2"], 20)
+
+    def test_accumulateInDict_with_objects(self):
+        """Test accumulating with custom objects that support addition."""
+
+        class TestObj:
+            def __init__(self, value):
+                self.value = value
+
+            def __add__(self, other):
+                return TestObj(self.value + other.value)
+
+            def __eq__(self, other):
+                return self.value == other.value
+
+        test_dict = {}
+        obj1 = TestObj(10)
+        obj2 = TestObj(20)
+
+        accumulateInDict(test_dict, "key1", obj1)
+        accumulateInDict(test_dict, "key1", obj2)
+
+        self.assertEqual(test_dict["key1"].value, 30)
+
+    def test_maxExample_new_key(self):
+        """Test adding a new key to maxExample dict."""
+        test_dict = {}
+        maxExample(test_dict, "key1", "span123", 100)
+        self.assertEqual(test_dict["key1"], ("span123", 100))
+
+    def test_maxExample_better_value(self):
+        """Test updating with a better (higher) value."""
+        test_dict = {"key1": ("span123", 50)}
+        maxExample(test_dict, "key1", "span456", 100)
+        self.assertEqual(test_dict["key1"], ("span456", 100))
+
+    def test_maxExample_worse_value(self):
+        """Test that worse (lower) values don't update."""
+        test_dict = {"key1": ("span123", 100)}
+        maxExample(test_dict, "key1", "span456", 50)
+        self.assertEqual(test_dict["key1"], ("span123", 100))
+
+    def test_maxExample_equal_value(self):
+        """Test that equal values don't update."""
+        test_dict = {"key1": ("span123", 100)}
+        maxExample(test_dict, "key1", "span456", 100)
+        self.assertEqual(test_dict["key1"], ("span123", 100))
+
+    def test_getCPSize_empty_dict(self):
+        """Test getCPSize with empty dict."""
+        result = getCPSize({})
+        self.assertEqual(result, 0)
+
+    def test_getCPSize_single_entry(self):
+        """Test getCPSize with a single entry."""
+        test_dict = {"service->operation": 100}
+        # Expected: "\nservice;operation 100" = 21 characters
+        expected_length = len("\nservice;operation 100")
+        result = getCPSize(test_dict)
+        self.assertEqual(result, expected_length)
+
+    def test_getCPSize_multiple_entries(self):
+        """Test getCPSize with multiple entries."""
+        test_dict = {"service1->operation1": 100, "service2->operation2": 200}
+        # Expected: "\nservice1;operation1 100" + "\nservice2;operation2 200"
+        expected_length = len("\nservice1;operation1 100") + len(
+            "\nservice2;operation2 200"
+        )
+        result = getCPSize(test_dict)
+        self.assertEqual(result, expected_length)
+
+    def test_getCPSize_arrow_replacement(self):
+        """Test that arrows are properly replaced with semicolons."""
+        test_dict = {"a->b->c": 123}
+        # Expected: "\na;b;c 123"
+        expected_length = len("\na;b;c 123")
+        result = getCPSize(test_dict)
+        self.assertEqual(result, expected_length)
+
+    def test_getCPSize_large_numbers(self):
+        """Test getCPSize with large numbers."""
+        test_dict = {"service->operation": 123456789}
+        # Expected: "\nservice;operation 123456789"
+        expected_length = len("\nservice;operation 123456789")
+        result = getCPSize(test_dict)
+        self.assertEqual(result, expected_length)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_singleton_wrapper.py
+++ b/tests/utils/test_singleton_wrapper.py
@@ -1,0 +1,91 @@
+"""Unit tests for crisp.utils.singleton_wrapper."""
+
+import unittest
+
+from crisp.utils.singleton_wrapper import SingletonWrapper
+
+
+@SingletonWrapper
+class _SampleClass:
+    def __init__(self, value):
+        self.value = value
+
+
+class SingletonWrapperTests(unittest.TestCase):
+    def tearDown(self):
+        # Clear the singleton instances after each test so tests are
+        # independent and ordering-insensitive.
+        SingletonWrapper._instances.clear()
+
+    def testSingletonInstance(self):
+        instance1 = _SampleClass(10)
+        instance2 = _SampleClass(20)
+
+        self.assertIs(
+            instance1,
+            instance2,
+            "SingletonWrapper did not return the same instance",
+        )
+
+        # The value should come from the first construction; the second
+        # call's args must be discarded.
+        self.assertEqual(
+            instance1.value,
+            10,
+            "SingletonWrapper did not preserve the first initialized value",
+        )
+        self.assertEqual(
+            instance2.value,
+            10,
+            "SingletonWrapper did not preserve the first initialized value",
+        )
+
+    def testDifferentClasses(self):
+        @SingletonWrapper
+        class _AnotherClass:
+            def __init__(self, name):
+                self.name = name
+
+        sample_instance = _SampleClass(30)
+        another_instance_1 = _AnotherClass("test1")
+        another_instance_2 = _AnotherClass("test2")
+
+        self.assertNotEqual(
+            sample_instance,
+            another_instance_1,
+            "SingletonWrapper should not mix instances of different classes",
+        )
+        self.assertIs(
+            another_instance_1,
+            another_instance_2,
+            "SingletonWrapper did not return the same instance for _AnotherClass",
+        )
+        self.assertEqual(
+            another_instance_1.name,
+            "test1",
+            "SingletonWrapper did not preserve first value for _AnotherClass",
+        )
+        self.assertEqual(
+            another_instance_2.name,
+            "test1",
+            "SingletonWrapper did not preserve first value for _AnotherClass",
+        )
+
+    def testSingletonAcrossMultipleCalls(self):
+        first_call = _SampleClass(100)
+        second_call = _SampleClass(200)
+
+        self.assertIs(
+            first_call,
+            second_call,
+            "SingletonWrapper did not return the same instance on multiple calls",
+        )
+        self.assertEqual(
+            first_call.value,
+            100,
+            "SingletonWrapper should retain value of the first call",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_span_utils.py
+++ b/tests/utils/test_span_utils.py
@@ -1,0 +1,171 @@
+"""Unit tests for crisp.utils.span_utils."""
+
+import unittest
+
+from crisp.utils import span_utils
+from crisp.utils.span_utils import (
+    isErrPropNode,
+    isProxyNode,
+    isTestTraceByOpName,
+    isTestTraceByServiceName,
+)
+
+
+class _ConfigIsolation(unittest.TestCase):
+    """Base TestCase that snapshots & restores the module-level lists.
+
+    span_utils exposes its classification lists as mutable module globals
+    so users can extend them for their deployment. Tests extend those
+    lists and must not leak state across tests, so we snapshot on setUp
+    and restore on tearDown.
+    """
+
+    _LIST_ATTRS = (
+        "PROXY_SERVICE_OP_PAIRS",
+        "PROXY_ONLY_OPS",
+        "ERR_PROP_SERVICE_OP_PAIRS",
+        "TEST_TRACE_SERVICES",
+        "TEST_TRACE_OP_PREFIXES",
+    )
+
+    def setUp(self):
+        self._snapshots = {
+            name: list(getattr(span_utils, name)) for name in self._LIST_ATTRS
+        }
+
+    def tearDown(self):
+        for name, original in self._snapshots.items():
+            getattr(span_utils, name)[:] = original
+
+
+class DefaultsAreEmptyTests(_ConfigIsolation):
+    """Out of the box, every classifier list is empty.
+
+    This matters because the open-source distribution intentionally
+    ships without any site-specific service / op names. Leaking real
+    infrastructure identifiers here would be a regression.
+
+    Inherits from ``_ConfigIsolation`` purely as defense-in-depth: the
+    cases here are read-only today, but if a future contributor adds
+    an ``.append(...)`` inside one of them the snapshot/restore will
+    stop it from bleeding into other tests.
+    """
+
+    def test_proxy_lists_empty(self):
+        self.assertEqual(span_utils.PROXY_SERVICE_OP_PAIRS, [])
+        self.assertEqual(span_utils.PROXY_ONLY_OPS, [])
+
+    def test_err_prop_list_empty(self):
+        self.assertEqual(span_utils.ERR_PROP_SERVICE_OP_PAIRS, [])
+
+    def test_test_trace_lists_empty(self):
+        self.assertEqual(span_utils.TEST_TRACE_SERVICES, [])
+        self.assertEqual(span_utils.TEST_TRACE_OP_PREFIXES, [])
+
+    def test_no_matches_with_empty_config(self):
+        # With empty configs, everything is non-proxy / non-err-prop /
+        # non-test. Reviewers: if this starts failing after a port PR,
+        # someone has re-introduced a hardcoded default.
+        self.assertFalse(isProxyNode("any-service", "any-op"))
+        self.assertFalse(isErrPropNode("any-service", "any-op"))
+        self.assertFalse(isTestTraceByServiceName("any-service"))
+        self.assertFalse(isTestTraceByOpName("any-op"))
+
+
+class IsProxyNodeTests(_ConfigIsolation):
+    def test_service_op_pair_match(self):
+        span_utils.PROXY_SERVICE_OP_PAIRS.append(("svc-a", "op-a"))
+        self.assertTrue(isProxyNode("svc-a", "op-a"))
+
+    def test_service_op_pair_requires_both(self):
+        span_utils.PROXY_SERVICE_OP_PAIRS.append(("svc-a", "op-a"))
+        self.assertFalse(isProxyNode("svc-a", "different-op"))
+        self.assertFalse(isProxyNode("different-svc", "op-a"))
+
+    def test_only_ops_match_any_service(self):
+        span_utils.PROXY_ONLY_OPS.append("op-x")
+        self.assertTrue(isProxyNode("svc-a", "op-x"))
+        self.assertTrue(isProxyNode("svc-b", "op-x"))
+
+    def test_only_ops_exact_match(self):
+        span_utils.PROXY_ONLY_OPS.append("op-x")
+        self.assertFalse(isProxyNode("svc-a", "op-x-suffix"))
+
+    def test_empty_strings_with_empty_config(self):
+        self.assertFalse(isProxyNode("", ""))
+
+    def test_empty_strings_with_empty_config_match(self):
+        # An empty-string entry in the config would match empty inputs —
+        # this documents the (somewhat sharp) behavior rather than
+        # endorsing it.
+        span_utils.PROXY_ONLY_OPS.append("")
+        self.assertTrue(isProxyNode("any", ""))
+
+
+class IsErrPropNodeTests(_ConfigIsolation):
+    def test_service_op_pair_match(self):
+        span_utils.ERR_PROP_SERVICE_OP_PAIRS.append(("svc-a", "op-a"))
+        self.assertTrue(isErrPropNode("svc-a", "op-a"))
+
+    def test_service_alone_does_not_match(self):
+        span_utils.ERR_PROP_SERVICE_OP_PAIRS.append(("svc-a", "op-a"))
+        self.assertFalse(isErrPropNode("svc-a", "other-op"))
+
+    def test_op_alone_does_not_match(self):
+        # Unlike isProxyNode, there is no op-only fallback list for
+        # error propagation.
+        span_utils.ERR_PROP_SERVICE_OP_PAIRS.append(("svc-a", "op-a"))
+        self.assertFalse(isErrPropNode("other-svc", "op-a"))
+
+    def test_multiple_entries(self):
+        span_utils.ERR_PROP_SERVICE_OP_PAIRS.extend(
+            [("svc-a", "op-a"), ("svc-b", "op-b")]
+        )
+        self.assertTrue(isErrPropNode("svc-a", "op-a"))
+        self.assertTrue(isErrPropNode("svc-b", "op-b"))
+        self.assertFalse(isErrPropNode("svc-a", "op-b"))
+
+
+class IsTestTraceByServiceNameTests(_ConfigIsolation):
+    def test_exact_match(self):
+        span_utils.TEST_TRACE_SERVICES.append("test-svc")
+        self.assertTrue(isTestTraceByServiceName("test-svc"))
+
+    def test_prefix_does_not_match(self):
+        # Intentionally exact equality, not startswith.
+        span_utils.TEST_TRACE_SERVICES.append("test-svc")
+        self.assertFalse(isTestTraceByServiceName("test-svc-extra"))
+
+    def test_multiple_entries(self):
+        span_utils.TEST_TRACE_SERVICES.extend(["a", "b", "c"])
+        for name in ("a", "b", "c"):
+            with self.subTest(name=name):
+                self.assertTrue(isTestTraceByServiceName(name))
+        self.assertFalse(isTestTraceByServiceName("d"))
+
+
+class IsTestTraceByOpNameTests(_ConfigIsolation):
+    def test_prefix_match(self):
+        span_utils.TEST_TRACE_OP_PREFIXES.append("[prefix]")
+        self.assertTrue(isTestTraceByOpName("[prefix]"))
+        self.assertTrue(isTestTraceByOpName("[prefix]::detail"))
+
+    def test_case_sensitive(self):
+        # Matching is case-sensitive.
+        span_utils.TEST_TRACE_OP_PREFIXES.append("[prefix]")
+        self.assertFalse(isTestTraceByOpName("[PREFIX]"))
+
+    def test_middle_of_string_does_not_match(self):
+        # Must be a prefix, not an arbitrary substring.
+        span_utils.TEST_TRACE_OP_PREFIXES.append("[prefix]")
+        self.assertFalse(isTestTraceByOpName("leading[prefix]"))
+
+    def test_multiple_prefixes(self):
+        span_utils.TEST_TRACE_OP_PREFIXES.extend(["[a]", "[b]"])
+        self.assertTrue(isTestTraceByOpName("[a]foo"))
+        self.assertTrue(isTestTraceByOpName("[b]bar"))
+        self.assertFalse(isTestTraceByOpName("[c]baz"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First content-bearing port PR. Drops the stdlib-only utility layer
into `crisp/utils/`, mirroring the internal `critical_path.utils/`
module. These modules have **zero `crisp.*` imports** and sit at the
bottom of the layering in `crisp/LAYERS.md` — everything later PRs
add will depend on them.

Three files ported, three tests added, root `utils/` deleted, one
documentation section added. No caller migration — that happens in
PR 9 (`crisp/graph.py`) and PR 14 (root shims).

## Source modules

| Module | Purpose |
| --- | --- |
| `crisp/utils/dict_utils.py` | `accumulateInDict`, `maxExample`, `getCPSize` |
| `crisp/utils/singleton_wrapper.py` | `SingletonWrapper` decorator |
| `crisp/utils/span_utils.py` | Proxy / err-prop / test-trace classifiers |

Ported verbatim from internal, with two minor improvements and one
intentional behavior change:

- **Improvement (`dict_utils`)**: added type hints and a tie-break
  docstring note for `maxExample` (strict `>` comparison → first
  `sid` written wins on ties; documenting this so future "bugfixes"
  don't flip the semantics by accident).
- **Intentional change (`span_utils`)**: see next section.

## `span_utils`: classifier lists moved out of the source

The internal version hardcodes Uber-specific service and op names
(`galileo`, `mp-proxy`, `wayfare-eats`, `ctf-*`) as the default match
lists. Those identifiers don't belong in an open-source release.

This PR extracts them into five module-level mutable globals that
ship **empty**:

```python
PROXY_SERVICE_OP_PAIRS: list[tuple[str, str]] = []
PROXY_ONLY_OPS:         list[str] = []
ERR_PROP_SERVICE_OP_PAIRS: list[tuple[str, str]] = []
TEST_TRACE_SERVICES:       list[str] = []
TEST_TRACE_OP_PREFIXES:    list[str] = []
```

Downstream users extend them at import time:

```python
from crisp.utils import span_utils
span_utils.PROXY_SERVICE_OP_PAIRS.append(("my-proxy", "relay"))
span_utils.TEST_TRACE_OP_PREFIXES.append("[mytests.Run]")
```

Function signatures and return semantics are **unchanged**, so call
sites in later port PRs (PR 9, PR 13*) compile without modification;
they simply see "no match" until a deployment populates the lists.
Module docstring documents tuple shapes for each entry.

## Tests

Live under `tests/utils/` mirroring the package tree:

- **`test_dict_utils.py`** — direct port of internal counterpart,
  imports rewritten. 12 cases.
- **`test_singleton_wrapper.py`** — port of internal
  `tests/test_utils.py`; renamed to match the module under test.
  Internal helper classes (`TestClass`, `AnotherClass`) renamed to
  `_SampleClass` / `_AnotherClass` so pytest doesn't auto-collect
  them as `TestCase` subclasses via the `Test` prefix.
- **`test_span_utils.py`** — **new**, no internal counterpart.
  21 cases:
  - `DefaultsAreEmptyTests` — asserts every classifier list is empty
    by default so we catch any future regression that re-introduces
    a hardcoded Uber identifier.
  - Matching tests populate the module globals inside a
    `_ConfigIsolation` base class that snapshots/restores state on
    `setUp` / `tearDown`. **Every** test class (including
    `DefaultsAreEmptyTests`) inherits from it as defense-in-depth —
    if someone adds an `.append(...)` in a read-only-today test, it
    won't leak.

## Removal of legacy root `utils/`

The previous harness shipped an unused `utils/singleton_wrapper.py`
and empty `utils/__init__.py`. A grep across the repo shows **zero**
callers of `utils.singleton_wrapper`. This PR deletes the directory
outright rather than converting it to a shim.

Rationale: keeping a shim alongside the canonical copy would create
a foot-gun where two `SingletonWrapper` classes could end up with
two independent `_instances` dicts — silently breaking the singleton
contract the first time both import paths are reached from different
modules. Deletion eliminates the ambiguity; there is now exactly one
canonical class at `crisp.utils.singleton_wrapper`.

We are pre-1.0 (`0.1.0.dev0`) and there are no known out-of-tree
callers. Anyone surprised by this gets a clear `ModuleNotFoundError`
pointing at the new location.

## BUILD wiring

- `crisp/utils/BUILD.bazel` — `srcs` extended with the three new files.
- Root `BUILD.bazel`:
  - `//:pytest` gains `//crisp:pkg` as a dep, so future sub-package
    ports don't each need to re-wire the top-level test target.
  - `crisp_lib.srcs` loses `utils/singleton_wrapper.py` alongside the
    file's deletion.

## Naming policy documented

`crisp/LAYERS.md` gains a "Naming convention during the port" section
explaining that public functions use `camelCase` **deliberately** to
keep the port diffs minimal. A dedicated `snake_case` rename pass is
deferred until the port stabilizes, so it can be done atomically with
all the `graph.py` / `process_trace.py` call sites. This prevents
well-meaning drive-by PEP-8 cleanups that would fork the names during
the port.

## What's deliberately **not** in this PR

- **No migration of `graph.py` callers.** Root `graph.py` still
  contains its own local copies of `accumulateInDict` and `maxExample`.
  Those go away in PR 9 when `crisp/graph.py` is introduced; root
  `graph.py` becomes a re-export shim in PR 14.
- **No rename pass.** Per the naming policy note above.
- **No runtime type validation** on the `span_utils` lists — keeping
  the globals as plain `list` is intentional (a wrapper class that
  validates on `append` is overkill for a handful of private-ish
  globals). Docstring documents the tuple shape instead.

## Test plan

- [x] `python -m pytest` — **89 passed, 3 subtests** (37 new in `tests/utils/`, 52 pre-existing).
- [x] `bazel test //:pytest` — **PASSED in 1.9s**.
- [x] `bazel build //crisp/utils:utils //crisp:pkg` — OK.
- [x] `rg -i 'galileo|wayfare|mp-proxy|ctf\.|ctf-|e2e-test' crisp/ tests/` — **zero hits** (no leaked internal identifiers).
- [x] `rg 'from utils\.singleton_wrapper|from utils import singleton_wrapper'` — **zero hits** (no stale imports of the removed path).
- [x] No lint errors on any new file.