### PR TITLE
feat(crisp): port shared models, constants, utils + tests

### DIFF
--- a/crisp/shared/BUILD.bazel
+++ b/crisp/shared/BUILD.bazel
@@ -2,7 +2,12 @@ load("@rules_python//python:py_library.bzl", "py_library")
 
 py_library(
     name = "shared",
-    srcs = ["__init__.py"],
+    srcs = [
+        "__init__.py",
+        "constants.py",
+        "models.py",
+        "utils.py",
+    ],
     imports = ["../.."],
     visibility = ["//visibility:public"],
 )

--- a/crisp/shared/constants.py
+++ b/crisp/shared/constants.py
@@ -1,0 +1,16 @@
+"""Constants used across the critical path analysis modules."""
+
+# Base URL of the Jaeger UI that trace links point at. Defaults to the
+# upstream Jaeger all-in-one default (port 16686) so
+# ``docker run jaegertracing/all-in-one`` works out of the box. Override
+# this with your deployment's URL — see crisp/configuration.py once that
+# lands for a config-driven approach. The trailing slash matters:
+# call sites concatenate directly as f"{JAEGER_UI_URL}{traceId}?...".
+JAEGER_UI_URL = "http://localhost:16686/trace/"
+
+# HTML / FontAwesome class appended to sortable table headers in rendered
+# reports.
+SORTABLE_COL_CLASS = ' <i class="fas fa-sort"></i>'
+
+# Metric field name referenced by several CSV/output generators.
+TOTAL_TIME = "totalTime"

--- a/crisp/shared/models.py
+++ b/crisp/shared/models.py
@@ -1,0 +1,182 @@
+"""Shared data models used across critical path analysis modules.
+
+This module contains core data structures that are shared between
+multiple modules to avoid circular dependencies.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+
+class MetricVals:
+    """Container for metric values with inclusive and exclusive times.
+
+    Tracks inclusive time, exclusive time, frequency, and example span IDs
+    for the worst-case inclusive and exclusive measurements.
+    """
+
+    def __init__(self, inc, excl, freq, sid, exemplars: list[tuple[str, str]] | None = None):
+        self.inc = inc
+        self.excl = excl
+        self.freq = freq
+        self.incExVal, self.incEx = inc, sid
+        self.exclExVal, self.exclEx = excl, sid
+        self.exemplars: list[tuple[str, str]] = exemplars if exemplars is not None else []
+
+    def __str__(self) -> str:
+        return f"self.inc={self.inc}, self.excl={self.excl}, self.freq={self.freq}, self.incEx={self.incEx}, self.exclEx={self.exclEx}"
+
+    # Adds the values of metrics ignoring the sid.
+    def __add__(self, other):
+        result = MetricVals(0, 0, 0, -1)
+        result += self
+        result += other
+        return result
+
+    # Adds the values of metrics ignoring the sid.
+    def __iadd__(self, metric):
+        self.inc += metric.inc
+        self.excl += metric.excl
+        self.freq += metric.freq
+        if metric.incExVal > self.incExVal:
+            self.incEx = metric.incEx
+            self.incExVal = metric.incExVal
+        if metric.exclExVal > self.exclExVal:
+            self.exclEx = metric.exclEx
+            self.exclExVal = metric.exclExVal
+        return self
+
+    # Divides each metric value by val. Ignores the sids.
+    def __floordiv__(self, val):
+        result = MetricVals(0, 0, 0, -1)
+        result.inc = self.inc
+        result.excl = self.excl
+        result.freq = self.freq
+        result //= val
+        return result
+
+    # Divides each metric value by val. Ignores the sids.
+    def __ifloordiv__(self, val):
+        self.inc //= val
+        self.excl //= val
+        self.freq //= val
+        return self
+
+
+class CallPathProfile:
+    """Profile containing metrics for multiple call paths.
+
+    Aggregates metric values across multiple call paths, tracking
+    the total count of profiles merged and example trace IDs.
+    """
+
+    def __init__(self, kv: dict[str, Any], count: int, traceId):
+        self.profile = kv
+        self.count = count
+        self.traceId = traceId
+
+    def Get(self):
+        return self.profile
+
+    # Returns the profile metrics divided by the count. Ignores SID.
+    def GetNormalized(self):
+        if self.count == 0:
+            raise Exception("GetNormalized called with zero count.")  # noqa: TRY002
+        result = {}
+        for k, v in self.profile.items():
+            result[k] = v // self.count
+        return result
+
+    # Divides profile metrics by the count. Ignores SID.
+    def Normalize(self):
+        if self.count == 0:
+            raise Exception("Normalize called with zero count.")  # noqa: TRY002
+        for k in self.profile:
+            self.profile[k] = self.profile[k] // self.count
+
+    # Divides the specified field of the metrics in profiles by the count.
+    def NormalizeField(self, field):
+        if self.count == 0:
+            raise Exception("NormalizeField called with zero count.")  # noqa: TRY002
+        for k in self.profile:
+            v = getattr(self.profile[k], field) // self.count
+            setattr(self.profile[k], field, v)
+
+    # Updates (via addition) or inserts a new callpath metric without changing the count.
+    def Upsert(self, path, metric):
+        if path in self.profile:
+            self.profile[path] += metric
+        else:
+            self.profile[path] = copy.copy(metric)
+
+    # Makes the field zero if it is negative.
+    def Sanitize(self, field, debug_on):
+        for k, v in self.profile.items():
+            if hasattr(v, field):
+                if getattr(v, field) < 0:
+                    # NOTE: self.filename is not set by __init__; this debug
+                    # branch mirrors the internal source verbatim and would
+                    # AttributeError if reached with debug_on=True. Fixing
+                    # is out of scope for this port; tracked for a follow-up.
+                    debug_on and logging.debug(
+                        f"In {self.filename} zero out time entry for key {k} field {field}",
+                    )
+                    setattr(self.profile[k], field, 0)
+
+    # Merges two call path profiles returning the summation. The SIDs are not propagated.
+    def __add__(self, other):
+        result = CallPathProfile({}, 0, -1)
+        result += self
+        result += other
+        return result
+
+    # Merges two call path profiles returning the summation. The SIDs are not propagated.
+    def __iadd__(self, other):
+        for call_path, metric in other.profile.items():
+            self.Upsert(call_path, metric)
+        self.count += other.count
+        return self
+
+    def __repr__(self):
+        return str(self.profile)
+
+
+class LatencyData:
+    """Data structure for storing latency measurements and hypothetical scenarios."""
+
+    def __init__(
+        self,
+        traceID,
+        latency,
+        hypoLatency,
+        hypoLatencyOptimistic,
+        hypoLatencyPessimistic,
+    ):
+        self.traceID = traceID
+        self.latency = latency
+        self.hypoLatency = hypoLatency
+        self.hypoLatencyOptimistic = hypoLatencyOptimistic
+        self.hypoLatencyPessimistic = hypoLatencyPessimistic
+
+    def __str__(self):
+        return f"({self.traceID},{self.latency}.{self.hypoLatency})"
+
+    def __add__(self, other):
+        latency = self.latency + other.latency
+        hypo = self.hypoLatency + other.hypoLatency
+        opt = self.hypoLatencyOptimistic + other.hypoLatencyOptimistic
+        pes = self.hypoLatencyPessimistic + other.hypoLatencyPessimistic
+        return LatencyData("", latency, hypo, opt, pes)
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def average(self, count):
+        self.traceID = ""
+        self.latency = self.latency / count
+        self.hypoLatency = self.hypoLatency / count
+        self.hypoLatencyOptimistic = self.hypoLatencyOptimistic / count
+        self.hypoLatencyPessimistic = self.hypoLatencyPessimistic / count

--- a/crisp/shared/utils.py
+++ b/crisp/shared/utils.py
@@ -1,0 +1,23 @@
+"""Shared utility functions used across critical path analysis modules.
+
+This module contains simple utility functions that are used by multiple
+modules to avoid code duplication and circular dependencies.
+"""
+
+
+def getLeafNodeFromCallPath(path: str) -> str:
+    """Extract the leaf node from a call path string.
+
+    Args:
+        path: Call path string with nodes separated by '->'
+
+    Returns:
+        The last node in the path
+
+    Examples:
+        >>> getLeafNodeFromCallPath("service1->service2->service3")
+        'service3'
+        >>> getLeafNodeFromCallPath("single_node")
+        'single_node'
+    """
+    return path.rsplit("->", 1)[-1]

--- a/tests/shared/test_constants.py
+++ b/tests/shared/test_constants.py
@@ -1,0 +1,37 @@
+"""Tests for shared constants to ensure coverage."""
+
+import unittest
+
+from crisp.shared.constants import (
+    JAEGER_UI_URL,
+    SORTABLE_COL_CLASS,
+    TOTAL_TIME,
+)
+
+
+class TestConstants(unittest.TestCase):
+    """Test constants are properly defined."""
+
+    def test_jaeger_ui_url(self):
+        """JAEGER_UI_URL is an http(s) URL and does not leak an internal host."""
+        self.assertIsInstance(JAEGER_UI_URL, str)
+        # Accept either scheme so the default can change (e.g. local Jaeger
+        # at http://localhost:16686/ or a user-configured https endpoint)
+        # without having to update this assertion.
+        self.assertRegex(JAEGER_UI_URL, r"^https?://")
+        # Guard against accidentally re-introducing an Uber-internal host.
+        self.assertNotIn("uberinternal", JAEGER_UI_URL)
+
+    def test_sortable_col_class(self):
+        """Test SORTABLE_COL_CLASS constant."""
+        self.assertIsInstance(SORTABLE_COL_CLASS, str)
+        self.assertIn("fas fa-sort", SORTABLE_COL_CLASS)
+
+    def test_total_time(self):
+        """Test TOTAL_TIME constant."""
+        self.assertEqual(TOTAL_TIME, "totalTime")
+        self.assertIsInstance(TOTAL_TIME, str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/shared/test_models.py
+++ b/tests/shared/test_models.py
@@ -1,0 +1,117 @@
+# ruff: noqa: I001
+"""Tests for shared data models.
+
+This module contains unit tests for MetricVals, CallPathProfile, and LatencyData classes.
+"""
+
+from unittest import TestCase
+
+from crisp.shared.models import (
+    MetricVals,
+    CallPathProfile,
+    LatencyData,
+)
+
+
+class TestMetricVals(TestCase):
+    def test_addition(self):
+        metric1 = MetricVals(1, 2, 3, 100)
+        metric2 = MetricVals(4, 5, 6, 200)
+        result = metric1 + metric2
+        self.assertEqual(result.inc, 5)
+        self.assertEqual(result.excl, 7)
+        self.assertEqual(result.freq, 9)
+
+    def test_in_place_addition(self):
+        metric = MetricVals(1, 2, 3, 100)
+        metric += MetricVals(4, 5, 6, 200)
+        self.assertEqual(metric.inc, 5)
+        self.assertEqual(metric.excl, 7)
+        self.assertEqual(metric.freq, 9)
+
+    def test_floordiv(self):
+        metric = MetricVals(10, 20, 30, 100)
+        result = metric // 2
+        self.assertEqual(result.inc, 5)
+        self.assertEqual(result.excl, 10)
+        self.assertEqual(result.freq, 15)
+
+    def test_in_place_floordiv(self):
+        metric = MetricVals(10, 20, 30, 100)
+        metric //= 2
+        self.assertEqual(metric.inc, 5)
+        self.assertEqual(metric.excl, 10)
+        self.assertEqual(metric.freq, 15)
+
+
+class TestCallPathProfile(TestCase):
+    def setUp(self):
+        self.metric1 = MetricVals(1, 2, 3, 100)
+        self.metric2 = MetricVals(4, 5, 6, 200)
+        self.profile1 = CallPathProfile({"path1": self.metric1}, 2, 1)
+        self.profile2 = CallPathProfile({"path2": self.metric2}, 3, 2)
+
+    def test_get_normalized(self):
+        result = self.profile1.GetNormalized()
+        self.assertEqual(result["path1"].inc, 0)
+        self.assertEqual(result["path1"].excl, 1)
+        self.assertEqual(result["path1"].freq, 1)
+
+    def test_normalize(self):
+        self.profile1.Normalize()
+        self.assertEqual(self.profile1.profile["path1"].inc, 0)
+        self.assertEqual(self.profile1.profile["path1"].excl, 1)
+        self.assertEqual(self.profile1.profile["path1"].freq, 1)
+
+    def test_normalize_field(self):
+        self.profile1.NormalizeField("inc")
+        self.assertEqual(self.profile1.profile["path1"].inc, 0)
+
+    def test_upsert_existing(self):
+        self.profile1.Upsert("path1", MetricVals(1, 1, 1, 300))
+        self.assertEqual(self.profile1.profile["path1"].inc, 2)
+        self.assertEqual(self.profile1.profile["path1"].excl, 3)
+        self.assertEqual(self.profile1.profile["path1"].freq, 4)
+
+    def test_upsert_new(self):
+        self.profile1.Upsert("path3", MetricVals(1, 1, 1, 300))
+        self.assertEqual(self.profile1.profile["path3"].inc, 1)
+        self.assertEqual(self.profile1.profile["path3"].excl, 1)
+        self.assertEqual(self.profile1.profile["path3"].freq, 1)
+
+    def test_add_profiles(self):
+        result = self.profile1 + self.profile2
+        self.assertIn("path1", result.profile)
+        self.assertIn("path2", result.profile)
+        self.assertEqual(result.count, 5)
+
+    def test_in_place_add_profiles(self):
+        self.profile1 += self.profile2
+        self.assertIn("path1", self.profile1.profile)
+        self.assertIn("path2", self.profile1.profile)
+        self.assertEqual(self.profile1.count, 5)
+
+
+class TestLatencyData(TestCase):
+    def test_addition_and_average(self):
+        """Test LatencyData addition using sum() and average() method."""
+        d1 = LatencyData("1", 100, 10, 1, 2)
+        d2 = LatencyData("2", 100, 20, 3, 4)
+        d3 = LatencyData("3", 100, 30, 5, 6)
+
+        process_traces = sum(
+            [d1, d2, d3],
+            start=LatencyData("", 0, 0, 0, 0),
+        )
+
+        self.assertEqual(process_traces.latency, 300)
+        self.assertEqual(process_traces.hypoLatency, 60)
+        self.assertEqual(process_traces.hypoLatencyOptimistic, 9)
+        self.assertEqual(process_traces.hypoLatencyPessimistic, 12)
+
+        process_traces.average(3)
+
+        self.assertEqual(process_traces.latency, 100)
+        self.assertEqual(process_traces.hypoLatency, 20)
+        self.assertEqual(process_traces.hypoLatencyOptimistic, 3)
+        self.assertEqual(process_traces.hypoLatencyPessimistic, 4)

--- a/tests/shared/test_utils.py
+++ b/tests/shared/test_utils.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from crisp.shared.utils import getLeafNodeFromCallPath
+
+
+class TestGetLeafNodeFromCallPath(TestCase):
+    def test_regular_path(self):
+        path = "node1->node2->node3"
+        result = getLeafNodeFromCallPath(path)
+        self.assertEqual(result, "node3")
+
+    def test_single_node_path(self):
+        path = "singleNode"
+        result = getLeafNodeFromCallPath(path)
+        self.assertEqual(result, "singleNode")
+
+    def test_empty_string(self):
+        path = ""
+        result = getLeafNodeFromCallPath(path)
+        self.assertEqual(result, "")


### PR DESCRIPTION
PR 4 of the critical_path -> crisp port. Adds the layer-2 (crisp/shared) package: small, dependency-free primitives that higher-level modules (metrics, output, core) will build on.

New source (3 files, ~210 lines):
  - crisp/shared/constants.py  JAEGER_UI_URL, SORTABLE_COL_CLASS, TOTAL_TIME.
  - crisp/shared/utils.py      getLeafNodeFromCallPath().
  - crisp/shared/models.py     MetricVals, CallPathProfile,
                                LatencyData.

New tests (3 files + __init__, ~175 lines, 18 new cases):
  - tests/shared/test_constants.py
  - tests/shared/test_utils.py
  - tests/shared/test_models.py

Deliberate changes vs. internal source:
  * JAEGER_UI_URL: the internal default pointed at jaeger-phx3.uberinternal.com (leaks an Uber-internal host). Changed to http://localhost:16686/trace/ — the upstream Jaeger all-in-one default, so the out-of-the-box docker image works, and a config-driven override will land with PR 7b. A new assertNotIn("uberinternal", ...) guard protects against accidental regressions.
  * test_constants: loosened the scheme assertion from startswith("https://") to a regex ^https?:// so the default can change between http and https without test churn.
  * models.py CallPathProfile.__init__: kv: dict[str, any] ->
    dict[str, Any]. The lowercase "any" was builtins.any (a function), not a type — a latent annotation bug from the internal source.

Known latent issue preserved verbatim: CallPathProfile.Sanitize() references self.filename which __init__ never assigns. Would AttributeError if the debug_on branch fires. A NOTE comment makes this explicit; a fix is deferred to a later PR to keep this one diff-minimal.

Build / wiring:
  - crisp/shared/BUILD.bazel srcs extended with the three new files. No deps changes needed: //crisp:pkg (from PR 2) already aggregates //crisp/shared:shared, and //:pytest already depends on //crisp:pkg (from PR 3), so the new tests are picked up automatically.

Verification: - bazel test //:pytest --cache_test_results=no PASSES.
    Before PR 4 src: 3 collection errors in tests/shared/.
    After PR 4 src:  107 passed, 3 subtests passed.
  - grep for uber|phx3|jaeger-crisp|wayfare|galileo|mp-proxy| ctf- under crisp/shared/ returns zero hits; under tests/shared/ only the intentional assertNotIn guard.