### PR TITLE
feat(crisp/shared): extend with 10 constants + 6 metrics data types

### DIFF
--- a/crisp/LAYERS.md
+++ b/crisp/LAYERS.md
@@ -33,3 +33,44 @@ so that every call site migrates with a single-line import change rather
 than a rename sweep. Renaming to `snake_case` is a cross-cutting concern
 that deserves its own dedicated PR once the port has stabilized — please
 don't do it as a drive-by in an unrelated change.
+
+## Legacy terminology preserved verbatim
+
+Some attribute names and user-facing strings still reference the internal
+framework they came from (most notably `Metrics.isCtfTest` and the display
+string "CTF test traces"). These are preserved verbatim for the same
+reason the `camelCase` names are: renaming them cascades through every
+caller in every unported PR. A generic rename (e.g. `isCtfTest` →
+`isTestTrace`) will happen in the same post-stabilization sweep that
+handles `camelCase` → `snake_case`. The underlying classification logic
+was already generalized in the `crisp.utils.span_utils` port (see the
+configurable `TEST_TRACE_OP_PREFIXES` / `TEST_TRACE_SERVICES` lists), so
+no behavior is Uber-specific even though the attribute name still is.
+
+## Layer-crossing test dependencies — handling rule
+
+Many tests in the internal codebase were written before this layering
+existed, so they freely import types from what we now call deeper layers.
+When porting, apply this decision in order:
+
+1. **Audit the test's actually-used types.** If a test imports a heavy
+   class but only reads a handful of attributes, the class may be a thin
+   data container that does not genuinely need the deep dependencies its
+   module imports at the top. If it can be relocated to a shallower
+   layer *verbatim* (body unchanged, file home changed), **promote it**
+   during the port — see `crisp.shared.models` for examples of types
+   lifted from internal `critical_path/models.py`.
+2. **If the type genuinely needs a deeper dependency** (e.g. it imports
+   `common`, does I/O, or pulls in graph machinery), **defer the test**
+   to the PR that completes its deepest dependency. Note the deferral in
+   the source PR's commit message and, if the deferral spans multiple
+   PRs, add an entry to the "Deferred tests" list below.
+3. **Never** modify test bodies to work around the problem — no
+   lightweight stand-ins, no mocks substituted for real types, no
+   subset-test-selection. Either (1) or (2). Modifying test bodies
+   silently weakens verification and breaks the verbatim-port rule.
+
+### Deferred tests
+
+| Test file (internal) | Deferred until PR | Reason                |
+| -------------------- | ----------------- | --------------------- |

--- a/crisp/shared/constants.py
+++ b/crisp/shared/constants.py
@@ -14,3 +14,34 @@ SORTABLE_COL_CLASS = ' <i class="fas fa-sort"></i>'
 
 # Metric field name referenced by several CSV/output generators.
 TOTAL_TIME = "totalTime"
+
+# Sentinel values used by QuantizedMetrics.__init__ to compute the
+# min/max depth of a histogram via running min/max against these
+# intentionally-extreme seeds.
+DEFAULT_MIN_DEPTH = 1000000000
+DEFAULT_MAX_DEPTH = -1
+
+# Percentiles (as fractions in [0, 1]) used by QuantizedMetrics and
+# related distribution summaries.
+PERCENTILE_50 = 0.5
+PERCENTILE_90 = 0.9
+PERCENTILE_95 = 0.95
+PERCENTILE_99 = 0.99
+
+# Zero-initializers for the three error-count categories tracked by
+# ErrCountsData.
+DEFAULT_SELF_ERRORS = 0
+DEFAULT_PROPAGATED_ERRORS = 0
+DEFAULT_STOPPED_ERRORS = 0
+
+
+class SpanKindValues:
+    """Numeric values for span kinds.
+
+    Referenced by the SpanKind Enum in crisp.shared.models and by
+    higher layers that emit span-kind-based classifications.
+    """
+
+    CLIENT = 0
+    SERVER = 1
+    UNKNOWN = 2

--- a/crisp/shared/models.py
+++ b/crisp/shared/models.py
@@ -8,7 +8,22 @@ from __future__ import annotations
 
 import copy
 import logging
+from enum import Enum
 from typing import Any
+
+from crisp.shared.constants import (
+    DEFAULT_MAX_DEPTH,
+    DEFAULT_MIN_DEPTH,
+    DEFAULT_PROPAGATED_ERRORS,
+    DEFAULT_SELF_ERRORS,
+    DEFAULT_STOPPED_ERRORS,
+    PERCENTILE_50,
+    PERCENTILE_90,
+    PERCENTILE_95,
+    PERCENTILE_99,
+    SpanKindValues,
+)
+from crisp.utils.dict_utils import getCPSize
 
 
 class MetricVals:
@@ -180,3 +195,269 @@ class LatencyData:
         self.hypoLatency = self.hypoLatency / count
         self.hypoLatencyOptimistic = self.hypoLatencyOptimistic / count
         self.hypoLatencyPessimistic = self.hypoLatencyPessimistic / count
+
+
+class QuantizedMetrics:
+    headers: tuple[str, ...] = (
+        "items",
+        "p0",
+        "p100",
+        "avg",
+        "p50",
+        "p90",
+        "p95",
+        "p99",
+    )
+
+    def __init__(self, histo: dict[int, int]):
+        self.p100 = None
+        self.p0 = None
+        self.items = None
+        self.avg = None
+        self.p50 = None
+        self.p90 = None
+        self.p95 = None
+        self.p99 = None
+        self.isValid = False
+        if len(histo) == 0:
+            return
+
+        all = []
+        maxDepth = DEFAULT_MAX_DEPTH
+        minDepth = DEFAULT_MIN_DEPTH
+        sum = 0
+        items = 0
+        for k, v in histo.items():
+            all.extend([k] * v)
+            items += v
+            sum += k * v
+            minDepth = min(minDepth, k)
+            maxDepth = max(maxDepth, k)
+
+        avg = sum / items
+        p50 = all[int(len(all) * PERCENTILE_50)]
+        p90 = all[int(len(all) * PERCENTILE_90)]
+        p95 = all[int(len(all) * PERCENTILE_95)]
+        p99 = all[int(len(all) * PERCENTILE_99)]
+
+        self.p100 = maxDepth
+        self.p0 = minDepth
+        self.items = items
+        self.avg = avg
+        self.p50 = p50
+        self.p90 = p90
+        self.p95 = p95
+        self.p99 = p99
+        self.isValid = True
+
+    def getRow(self):
+        if not self.isValid:
+            return None
+        return [getattr(self, x) for x in QuantizedMetrics.headers]
+
+
+class ErrCountsData:
+    def __init__(
+        self,
+        selfErrors=DEFAULT_SELF_ERRORS,
+        propagatedErrors=DEFAULT_PROPAGATED_ERRORS,
+        stoppedErrors=DEFAULT_STOPPED_ERRORS,
+    ):
+        self.selfErrors = selfErrors
+        self.propagatedErrors = propagatedErrors
+        self.stoppedErrors = stoppedErrors
+
+    def __str__(self):
+        return f"{self.selfErrors},{self.propagatedErrors},{self.stoppedErrors}"
+
+    def __add__(self, other):
+        return ErrCountsData(
+            self.selfErrors + other.selfErrors,
+            self.propagatedErrors + other.propagatedErrors,
+            self.stoppedErrors + other.stoppedErrors,
+        )
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def toArray(self):
+        return [self.selfErrors, self.propagatedErrors, self.stoppedErrors]
+
+
+class SavingData:
+    def __init__(self, timeSaved, latency, opCount):
+        self.timeSaved = timeSaved
+        self.latency = latency
+        self.opCount = opCount
+
+    def __add__(self, other):
+        return SavingData(
+            self.timeSaved + other.timeSaved,
+            self.latency + other.latency,
+            self.opCount + other.opCount,
+        )
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+
+class SpanKind(Enum):
+    CLIENT = SpanKindValues.CLIENT
+    SERVER = SpanKindValues.SERVER
+    UNKNOWN = SpanKindValues.UNKNOWN
+
+
+# The full error critical path metrics
+class ErrorCPMetrics:
+    """
+    ErrorCPMetric represents the following measurements as dictionaries
+    1. errCPCallpathTimeExclusive: the error call-path profile with exclusive callpath times
+        computed based on the full error critical path
+    2. errCPErrCounts: the error call-path profile with error counts computed based on the
+        full error critical path
+    3. savingPotential: a map [opName]: exclusive timeSaved spent in op
+    4. numCPErrors: the number of errored out nodes on the critical path
+    5. numRelatedToCPErrors: the number of errored out nodes not on the
+        critical path but connected to the critical path via a chain of failed calls
+    """
+
+    def __init__(
+        self,
+        errCPCallpathTimeExclusive,
+        errCPErrCounts,
+        savingPotential,
+        numCPErrors,
+        numRelatedToCPErrors,
+    ):
+        self.errCPCallpathTimeExclusive = errCPCallpathTimeExclusive
+        self.errCPErrCounts = errCPErrCounts
+        self.errCPSize = getCPSize(errCPCallpathTimeExclusive)
+        self.savingPotential = savingPotential
+        self.numCPErrors = numCPErrors
+        self.numRelatedToCPErrors = numRelatedToCPErrors
+
+
+# whole program error metrics
+class ErrorMetrics:
+    """
+    ErrorMetrics contains various metrics on errors for the whole program
+    1. numAllErrors: the number of errored spans
+    2. errCounts: a map from opCallpath to error counts
+        ["opCallpath": <selfErrors, propagatedErrors, stoppedErrors>]
+    3. errCallChainCounts: a map from opCallPath to error call-chain counts
+        ["opCallpath": integer count of errored out callcahin]
+    4. selfErrDepthList: a list of self error depth
+    5. stoppedErrDepthList: a list of stopped error depth
+    6. depthMap: a map from depth (key) to ErrCountsData
+        [depth: <selfErrors, propagatedErrors, stoppedErrors>]
+    7. propLengthMap: a map from propagation length to count of self errors
+        [propLength: integer counts of self errors with that propLength]
+    8. resiliencyMap: a map from canonicalOpName to ErrCountsData
+        ["canonicalOpName": <selfErrors, propagatedErrors, stoppedErrors>]
+        though we only update the propagated and stopped errors for this map
+    9. maxErrDepthPropToRoot: the max depth of self error propagated to root
+        this value is -1 if the root did not error
+    10. propToRootHistoQuantized: selferrors propagated to root, captured as a QuantizedError
+    11. notPropToRootHistoQuantized: selferrors not propagated to root, captured as a QuantizedError
+    12. propToRooOnCPtHistoQuantized: selferrors propagated to root on critical path, captured as a QuantizedError
+    13. notPropToRooOnCPtHistoQuantized: selferrors not propagated to root on critical path, captured as a QuantizedError
+    14. supressHistoQuantized:  supressed errors, captured as a QuantizedError
+    15. supressOnCPHistoQuantized: supressed errors on critical path, captured as a QuantizedError
+    """
+
+    def __init__(
+        self,
+        numAllErrors,
+        errCounts,
+        errCallChainCounts,
+        selfErrDepthList,
+        stoppedErrDepthList,
+        errDepthMap,
+        errPropLengthMap,
+        resiliencyMap,
+        maxErrDepthPropToRoot,
+        propToRootHistoQuantized,
+        notPropToRootHistoQuantized,
+        propToRootOnCPHistoQuantized,
+        notPropToRootOnCPHistoQuantized,
+        supressHistoQuantized,
+        supressOnCPHistoQuantized,
+    ):
+        self.numAllErrors = numAllErrors
+        self.errCounts = errCounts
+        self.errCallChainCounts = errCallChainCounts
+        self.selfErrDepthList = selfErrDepthList
+        self.stoppedErrDepthList = stoppedErrDepthList
+        self.errDepthMap = errDepthMap
+        self.errPropLengthMap = errPropLengthMap
+        self.resiliencyMap = resiliencyMap
+        self.maxErrDepthPropToRoot = maxErrDepthPropToRoot
+        self.propToRootHistoQuantized = propToRootHistoQuantized
+        self.notPropToRootHistoQuantized = notPropToRootHistoQuantized
+        self.propToRootOnCPHistoQuantized = propToRootOnCPHistoQuantized
+        self.notPropToRootOnCPHistoQuantized = notPropToRootOnCPHistoQuantized
+        self.supressHistoQuantized = supressHistoQuantized
+        self.supressOnCPHistoQuantized = supressOnCPHistoQuantized
+
+
+class Metrics:
+    def __init__(
+        self,
+        traceID,
+        traceSz,
+        CPMetrics,
+        errCPMetrics,
+        errMetrics,
+        totalWork,
+        timeSavedOnWork,
+        latency,
+        timeSavedOnCPPessimistic,
+        timeSavedOnCPOptimistic,
+        timeSavedOnCPAllSeries,
+        rootSpanID,
+        descendants,
+        depth,
+        numNodesOnCP,
+        rootReturnError,
+        propToRootErrCCT,
+        isCtfTest,
+        numProxyRoots,
+        tags,
+        cycles,
+        crossRegionCalls,
+        projectedCPMetrics=None,
+        projectedLatency=None,
+        isIncomplete=False,
+        isSubtreeIncomplete=False,
+    ):
+        self.traceID = traceID
+        self.CPMetrics = CPMetrics
+        self.errCPMetrics = errCPMetrics
+        self.errMetrics = errMetrics
+        self.fileSz = traceSz
+        self.propToRootErrCCT = propToRootErrCCT
+
+        if CPMetrics:
+            self.cpSize = getCPSize(CPMetrics.profile)
+
+        self.totalWork = totalWork
+        self.timeSavedOnWork = timeSavedOnWork
+        self.latency = latency
+        self.timeSavedOnCPPessimistic = timeSavedOnCPPessimistic
+        self.timeSavedOnCPOptimistic = timeSavedOnCPOptimistic
+        self.timeSavedOnCPAllSeries = timeSavedOnCPAllSeries
+        self.rootSpanID = rootSpanID
+        self.numNodes = descendants
+        self.depth = depth
+        self.numNodesOnCP = numNodesOnCP
+
+        self.rootReturnError = rootReturnError
+        self.isCtfTest = isCtfTest
+        self.numProxyRoots = numProxyRoots
+        self.tags = tags
+        self.cycles = cycles
+        self.crossRegionCalls = crossRegionCalls
+        self.projectedCPMetrics = projectedCPMetrics
+        self.projectedLatency = projectedLatency
+        self.isIncomplete = isIncomplete
+        self.isSubtreeIncomplete = isSubtreeIncomplete

--- a/tests/shared/test_constants.py
+++ b/tests/shared/test_constants.py
@@ -3,9 +3,19 @@
 import unittest
 
 from crisp.shared.constants import (
+    DEFAULT_MAX_DEPTH,
+    DEFAULT_MIN_DEPTH,
+    DEFAULT_PROPAGATED_ERRORS,
+    DEFAULT_SELF_ERRORS,
+    DEFAULT_STOPPED_ERRORS,
     JAEGER_UI_URL,
+    PERCENTILE_50,
+    PERCENTILE_90,
+    PERCENTILE_95,
+    PERCENTILE_99,
     SORTABLE_COL_CLASS,
     TOTAL_TIME,
+    SpanKindValues,
 )
 
 
@@ -31,6 +41,76 @@ class TestConstants(unittest.TestCase):
         """Test TOTAL_TIME constant."""
         self.assertEqual(TOTAL_TIME, "totalTime")
         self.assertIsInstance(TOTAL_TIME, str)
+
+
+class TestDepthSentinels(unittest.TestCase):
+    """Test the depth-sentinel constants used by QuantizedMetrics."""
+
+    def test_min_depth_is_large_positive_int(self):
+        # DEFAULT_MIN_DEPTH is seeded into a running min(), so any real
+        # observed depth should beat it. Any sufficiently large int works;
+        # we pin the specific internal value to catch accidental edits.
+        self.assertIsInstance(DEFAULT_MIN_DEPTH, int)
+        self.assertEqual(DEFAULT_MIN_DEPTH, 1_000_000_000)
+
+    def test_max_depth_is_minus_one(self):
+        # DEFAULT_MAX_DEPTH is seeded into a running max(), so any real
+        # observed depth (>= 0) should beat it.
+        self.assertIsInstance(DEFAULT_MAX_DEPTH, int)
+        self.assertEqual(DEFAULT_MAX_DEPTH, -1)
+
+    def test_min_beats_max_when_no_data(self):
+        # Property check: with no data points, the "min" sentinel stays
+        # larger than the "max" sentinel, which callers rely on to detect
+        # the empty-histogram case.
+        self.assertGreater(DEFAULT_MIN_DEPTH, DEFAULT_MAX_DEPTH)
+
+
+class TestPercentiles(unittest.TestCase):
+    """Test percentile constants are fractions in [0, 1]."""
+
+    def test_values(self):
+        self.assertEqual(PERCENTILE_50, 0.5)
+        self.assertEqual(PERCENTILE_90, 0.9)
+        self.assertEqual(PERCENTILE_95, 0.95)
+        self.assertEqual(PERCENTILE_99, 0.99)
+
+    def test_all_in_unit_interval(self):
+        for p in (PERCENTILE_50, PERCENTILE_90, PERCENTILE_95, PERCENTILE_99):
+            self.assertGreaterEqual(p, 0.0)
+            self.assertLessEqual(p, 1.0)
+
+    def test_monotonic(self):
+        # Guard against a swap or typo in a future edit.
+        self.assertLess(PERCENTILE_50, PERCENTILE_90)
+        self.assertLess(PERCENTILE_90, PERCENTILE_95)
+        self.assertLess(PERCENTILE_95, PERCENTILE_99)
+
+
+class TestDefaultErrorCounts(unittest.TestCase):
+    """Test error-count zero-initializers."""
+
+    def test_all_zero(self):
+        self.assertEqual(DEFAULT_SELF_ERRORS, 0)
+        self.assertEqual(DEFAULT_PROPAGATED_ERRORS, 0)
+        self.assertEqual(DEFAULT_STOPPED_ERRORS, 0)
+
+
+class TestSpanKindValues(unittest.TestCase):
+    """Test the raw numeric span-kind values."""
+
+    def test_values(self):
+        self.assertEqual(SpanKindValues.CLIENT, 0)
+        self.assertEqual(SpanKindValues.SERVER, 1)
+        self.assertEqual(SpanKindValues.UNKNOWN, 2)
+
+    def test_distinct(self):
+        values = {
+            SpanKindValues.CLIENT,
+            SpanKindValues.SERVER,
+            SpanKindValues.UNKNOWN,
+        }
+        self.assertEqual(len(values), 3)
 
 
 if __name__ == "__main__":

--- a/tests/shared/test_models.py
+++ b/tests/shared/test_models.py
@@ -1,16 +1,28 @@
 # ruff: noqa: I001
 """Tests for shared data models.
 
-This module contains unit tests for MetricVals, CallPathProfile, and LatencyData classes.
+This module contains unit tests for MetricVals, CallPathProfile, and
+LatencyData, plus the metrics data types relocated from internal
+critical_path/models.py (QuantizedMetrics, ErrCountsData, SavingData,
+SpanKind, ErrorCPMetrics, ErrorMetrics, Metrics).
 """
 
 from unittest import TestCase
 
+from crisp.shared.constants import SpanKindValues
 from crisp.shared.models import (
-    MetricVals,
     CallPathProfile,
+    ErrCountsData,
+    ErrorCPMetrics,
+    ErrorMetrics,
     LatencyData,
+    Metrics,
+    MetricVals,
+    QuantizedMetrics,
+    SavingData,
+    SpanKind,
 )
+from crisp.utils.dict_utils import getCPSize
 
 
 class TestMetricVals(TestCase):
@@ -115,3 +127,275 @@ class TestLatencyData(TestCase):
         self.assertEqual(process_traces.hypoLatency, 20)
         self.assertEqual(process_traces.hypoLatencyOptimistic, 3)
         self.assertEqual(process_traces.hypoLatencyPessimistic, 4)
+
+
+class TestQuantizedMetrics(TestCase):
+    def test_empty_histo(self):
+        qm = QuantizedMetrics({})
+        self.assertFalse(qm.isValid)
+        for field in ("p0", "p100", "items", "avg", "p50", "p90", "p95", "p99"):
+            self.assertIsNone(getattr(qm, field))
+        self.assertIsNone(qm.getRow())
+
+    def test_single_value_histo(self):
+        qm = QuantizedMetrics({5: 1})
+        self.assertTrue(qm.isValid)
+        self.assertEqual(qm.items, 1)
+        self.assertEqual(qm.p0, 5)
+        self.assertEqual(qm.p100, 5)
+        self.assertEqual(qm.avg, 5.0)
+        self.assertEqual(qm.p50, 5)
+        self.assertEqual(qm.p90, 5)
+        self.assertEqual(qm.p95, 5)
+        self.assertEqual(qm.p99, 5)
+
+    def test_typical_histo(self):
+        # histo keys 1..5 each with count 1 -> expanded list [1,2,3,4,5],
+        # items=5, sum=15, avg=3. Percentiles use int(len*frac) indexing.
+        # int(5*0.5)=2 -> all[2]=3; int(5*0.9)=4 -> all[4]=5; 0.95 & 0.99
+        # also round to index 4 -> 5.
+        qm = QuantizedMetrics({1: 1, 2: 1, 3: 1, 4: 1, 5: 1})
+        self.assertTrue(qm.isValid)
+        self.assertEqual(qm.items, 5)
+        self.assertEqual(qm.avg, 3.0)
+        self.assertEqual(qm.p0, 1)
+        self.assertEqual(qm.p100, 5)
+        self.assertEqual(qm.p50, 3)
+        self.assertEqual(qm.p90, 5)
+        self.assertEqual(qm.p95, 5)
+        self.assertEqual(qm.p99, 5)
+
+    def test_histo_with_repetition(self):
+        # {10: 3} -> expanded list [10, 10, 10]. items=3, avg=10. All
+        # percentile indices resolve to 10.
+        qm = QuantizedMetrics({10: 3})
+        self.assertTrue(qm.isValid)
+        self.assertEqual(qm.items, 3)
+        self.assertEqual(qm.avg, 10.0)
+        self.assertEqual(qm.p0, 10)
+        self.assertEqual(qm.p100, 10)
+        self.assertEqual(qm.p50, 10)
+
+    def test_get_row_valid(self):
+        qm = QuantizedMetrics({5: 1})
+        row = qm.getRow()
+        self.assertEqual(
+            row,
+            [qm.items, qm.p0, qm.p100, qm.avg, qm.p50, qm.p90, qm.p95, qm.p99],
+        )
+        self.assertEqual(len(row), len(QuantizedMetrics.headers))
+
+
+class TestErrCountsData(TestCase):
+    def test_defaults(self):
+        e = ErrCountsData()
+        self.assertEqual(e.selfErrors, 0)
+        self.assertEqual(e.propagatedErrors, 0)
+        self.assertEqual(e.stoppedErrors, 0)
+
+    def test_explicit_values(self):
+        e = ErrCountsData(1, 2, 3)
+        self.assertEqual(e.selfErrors, 1)
+        self.assertEqual(e.propagatedErrors, 2)
+        self.assertEqual(e.stoppedErrors, 3)
+
+    def test_str(self):
+        self.assertEqual(str(ErrCountsData(1, 2, 3)), "1,2,3")
+
+    def test_add(self):
+        a = ErrCountsData(1, 2, 3)
+        b = ErrCountsData(4, 5, 6)
+        c = a + b
+        self.assertEqual((c.selfErrors, c.propagatedErrors, c.stoppedErrors), (5, 7, 9))
+        # operands are not mutated
+        self.assertEqual(a.selfErrors, 1)
+        self.assertEqual(b.selfErrors, 4)
+
+    def test_sum_with_explicit_start(self):
+        # __radd__ delegates to __add__, which indexes .selfErrors on the
+        # right-hand operand — so bare sum() (which seeds start=0, an
+        # int) fails. Pass an ErrCountsData start explicitly, matching
+        # the pattern used in TestLatencyData and in the internal tests.
+        total = sum(
+            [ErrCountsData(1, 1, 1), ErrCountsData(2, 2, 2)],
+            start=ErrCountsData(),
+        )
+        self.assertEqual(
+            (total.selfErrors, total.propagatedErrors, total.stoppedErrors),
+            (3, 3, 3),
+        )
+
+    def test_to_array(self):
+        self.assertEqual(ErrCountsData(1, 2, 3).toArray(), [1, 2, 3])
+
+
+class TestSavingData(TestCase):
+    def test_constructor_stores_fields(self):
+        s = SavingData(10, 100, 2)
+        self.assertEqual(s.timeSaved, 10)
+        self.assertEqual(s.latency, 100)
+        self.assertEqual(s.opCount, 2)
+
+    def test_add(self):
+        result = SavingData(1, 2, 3) + SavingData(10, 20, 30)
+        self.assertEqual((result.timeSaved, result.latency, result.opCount), (11, 22, 33))
+
+    def test_sum_with_explicit_start(self):
+        # See TestErrCountsData.test_sum_with_explicit_start for why a
+        # start value is required.
+        total = sum(
+            [SavingData(1, 1, 1), SavingData(2, 2, 2), SavingData(3, 3, 3)],
+            start=SavingData(0, 0, 0),
+        )
+        self.assertEqual((total.timeSaved, total.latency, total.opCount), (6, 6, 6))
+
+
+class TestSpanKind(TestCase):
+    def test_values_match_numeric_constants(self):
+        self.assertEqual(SpanKind.CLIENT.value, SpanKindValues.CLIENT)
+        self.assertEqual(SpanKind.SERVER.value, SpanKindValues.SERVER)
+        self.assertEqual(SpanKind.UNKNOWN.value, SpanKindValues.UNKNOWN)
+
+    def test_three_distinct_members(self):
+        self.assertEqual(len(set(SpanKind)), 3)
+
+    def test_membership(self):
+        self.assertIn(SpanKind.CLIENT, SpanKind)
+        self.assertIn(SpanKind.SERVER, SpanKind)
+        self.assertIn(SpanKind.UNKNOWN, SpanKind)
+
+
+class TestErrorCPMetrics(TestCase):
+    def test_constructor_stores_fields(self):
+        errCPCallpathTime = {"a->b": 5, "c": 10}
+        errCPErrCounts = {"a->b": ErrCountsData(1, 0, 0)}
+        savingPotential = {"a": 3}
+        m = ErrorCPMetrics(errCPCallpathTime, errCPErrCounts, savingPotential, 2, 1)
+        self.assertIs(m.errCPCallpathTimeExclusive, errCPCallpathTime)
+        self.assertIs(m.errCPErrCounts, errCPErrCounts)
+        self.assertIs(m.savingPotential, savingPotential)
+        self.assertEqual(m.numCPErrors, 2)
+        self.assertEqual(m.numRelatedToCPErrors, 1)
+
+    def test_err_cp_size_matches_get_cp_size(self):
+        # errCPSize is derived at construction time via getCPSize; the
+        # value should equal getCPSize applied to the same dict.
+        errCPCallpathTime = {"a->b->c": 5, "d->e": 42}
+        m = ErrorCPMetrics(errCPCallpathTime, {}, {}, 0, 0)
+        self.assertEqual(m.errCPSize, getCPSize(errCPCallpathTime))
+
+    def test_err_cp_size_empty(self):
+        m = ErrorCPMetrics({}, {}, {}, 0, 0)
+        self.assertEqual(m.errCPSize, 0)
+
+
+class TestErrorMetrics(TestCase):
+    def test_constructor_stores_all_fields(self):
+        # Dense constructor, but every field needs to be preserved; we
+        # sample-check each with a distinct sentinel value so a future
+        # assignment swap inside __init__ is caught.
+        m = ErrorMetrics(
+            numAllErrors=7,
+            errCounts={"a": ErrCountsData(1, 2, 3)},
+            errCallChainCounts={"a": 4},
+            selfErrDepthList=[1, 2],
+            stoppedErrDepthList=[3],
+            errDepthMap={1: ErrCountsData(1, 0, 0)},
+            errPropLengthMap={2: 5},
+            resiliencyMap={"op1": ErrCountsData(0, 1, 2)},
+            maxErrDepthPropToRoot=-1,
+            propToRootHistoQuantized=QuantizedMetrics({}),
+            notPropToRootHistoQuantized=QuantizedMetrics({}),
+            propToRootOnCPHistoQuantized=QuantizedMetrics({}),
+            notPropToRootOnCPHistoQuantized=QuantizedMetrics({}),
+            supressHistoQuantized=QuantizedMetrics({}),
+            supressOnCPHistoQuantized=QuantizedMetrics({}),
+        )
+        self.assertEqual(m.numAllErrors, 7)
+        self.assertEqual(m.errCounts["a"].selfErrors, 1)
+        self.assertEqual(m.errCallChainCounts["a"], 4)
+        self.assertEqual(m.selfErrDepthList, [1, 2])
+        self.assertEqual(m.stoppedErrDepthList, [3])
+        self.assertEqual(m.errDepthMap[1].selfErrors, 1)
+        self.assertEqual(m.errPropLengthMap[2], 5)
+        self.assertEqual(m.resiliencyMap["op1"].propagatedErrors, 1)
+        self.assertEqual(m.maxErrDepthPropToRoot, -1)
+        # The six *Quantized fields are all stored verbatim.
+        for field in (
+            "propToRootHistoQuantized",
+            "notPropToRootHistoQuantized",
+            "propToRootOnCPHistoQuantized",
+            "notPropToRootOnCPHistoQuantized",
+            "supressHistoQuantized",
+            "supressOnCPHistoQuantized",
+        ):
+            self.assertIsInstance(getattr(m, field), QuantizedMetrics)
+
+
+class TestMetrics(TestCase):
+    def _build(self, CPMetrics):
+        return Metrics(
+            traceID="trace-1",
+            traceSz=123,
+            CPMetrics=CPMetrics,
+            errCPMetrics=None,
+            errMetrics=None,
+            totalWork=1000,
+            timeSavedOnWork=50,
+            latency=500,
+            timeSavedOnCPPessimistic=10,
+            timeSavedOnCPOptimistic=20,
+            timeSavedOnCPAllSeries=15,
+            rootSpanID="root-1",
+            descendants=8,
+            depth=4,
+            numNodesOnCP=3,
+            rootReturnError=False,
+            propToRootErrCCT={},
+            isCtfTest=False,
+            numProxyRoots=0,
+            tags=[],
+            cycles=0,
+            crossRegionCalls=0,
+        )
+
+    def test_constructor_stores_all_fields(self):
+        profile = CallPathProfile({"a->b": MetricVals(1, 2, 3, 100)}, 2, "trace-1")
+        m = self._build(CPMetrics=profile)
+        self.assertEqual(m.traceID, "trace-1")
+        self.assertEqual(m.fileSz, 123)  # renamed from traceSz by __init__
+        self.assertIs(m.CPMetrics, profile)
+        self.assertEqual(m.totalWork, 1000)
+        self.assertEqual(m.timeSavedOnWork, 50)
+        self.assertEqual(m.latency, 500)
+        self.assertEqual(m.timeSavedOnCPPessimistic, 10)
+        self.assertEqual(m.timeSavedOnCPOptimistic, 20)
+        self.assertEqual(m.timeSavedOnCPAllSeries, 15)
+        self.assertEqual(m.rootSpanID, "root-1")
+        self.assertEqual(m.numNodes, 8)  # renamed from descendants by __init__
+        self.assertEqual(m.depth, 4)
+        self.assertEqual(m.numNodesOnCP, 3)
+        self.assertFalse(m.rootReturnError)
+        self.assertFalse(m.isCtfTest)
+        self.assertEqual(m.numProxyRoots, 0)
+        self.assertEqual(m.tags, [])
+        self.assertEqual(m.cycles, 0)
+        self.assertEqual(m.crossRegionCalls, 0)
+        # Defaults
+        self.assertIsNone(m.projectedCPMetrics)
+        self.assertIsNone(m.projectedLatency)
+        self.assertFalse(m.isIncomplete)
+        self.assertFalse(m.isSubtreeIncomplete)
+
+    def test_cp_size_computed_when_cpmetrics_truthy(self):
+        profile = CallPathProfile({"a->b->c": MetricVals(1, 2, 3, 100)}, 1, "trace-1")
+        m = self._build(CPMetrics=profile)
+        self.assertEqual(m.cpSize, getCPSize(profile.profile))
+
+    def test_cp_size_skipped_when_cpmetrics_none(self):
+        # The internal __init__ guards `if CPMetrics:` before computing
+        # cpSize, so a falsy CPMetrics leaves the attribute unset. This
+        # is existing behavior we preserve verbatim; callers that need a
+        # uniform attribute should add their own default.
+        m = self._build(CPMetrics=None)
+        self.assertFalse(hasattr(m, "cpSize"))


### PR DESCRIPTION
## Summary

Promotes thin metrics data types out of internal `critical_path/models.py` into the `crisp/shared` layer so later PRs (metrics, output) can import them without reaching into the as-yet-unported core layer. No behavior changes — all class/constant bodies are copied **verbatim**; imports are rewritten to `crisp.shared.*` / `crisp.utils.*`.

This PR is inserted between PR 4 (shared skeleton) and PR 5 (metrics) after an audit of `test_aggregators.py` showed it needed these types at layer 2, not layer 5.

## What's in `crisp/shared/`

**`constants.py` (+31 lines)**

| Constant | Purpose |
|---|---|
| `DEFAULT_MIN_DEPTH`, `DEFAULT_MAX_DEPTH` | Sentinels for running min/max over `QuantizedMetrics` histograms |
| `PERCENTILE_50/90/95/99` | Percentile fractions |
| `DEFAULT_SELF_ERRORS`, `DEFAULT_PROPAGATED_ERRORS`, `DEFAULT_STOPPED_ERRORS` | Zero-initializers for error counters |
| `SpanKindValues` | Raw numeric kind constants (0=CLIENT, 1=SERVER, 2=UNKNOWN) |

**`models.py` (+281 lines)**

| Class | Role |
|---|---|
| `QuantizedMetrics` | Histogram → p0/p50/p90/p95/p99/p100 + avg, with empty-histogram handling |
| `ErrCountsData` | `(selfErrors, propagatedErrors, stoppedErrors)` triple, supports `+` |
| `SavingData` | `(timeSaved, latency, opCount)` accumulator, supports `+` |
| `SpanKind` (`Enum`) | `CLIENT` / `SERVER` / `UNKNOWN` wrapper over `SpanKindValues` |
| `ErrorCPMetrics` | Per-trace error critical-path summary (calls `getCPSize`) |
| `ErrorMetrics` | Aggregate error metrics (15 fields) |
| `Metrics` | Top-level per-trace metrics container |

## Tests

Internal had **zero dedicated coverage** for any of these, so per the "zero coverage → write new tests" rule in `LAYERS.md`, we add focused tests rather than defer them.

**`tests/shared/test_constants.py` (+54 lines)** — depth sentinels, percentile values + ordering, default error counts, `SpanKindValues` shape.

**`tests/shared/test_models.py` (+284 lines)** — one focused class per new type. Notable coverage:

- `QuantizedMetrics`: empty / single-value / `1..5` / repeated-key histos; `getRow()` shape matches `headers`
- `ErrCountsData` / `SavingData`: constructors, `__add__`, `sum(..., start=...)`
- `ErrorCPMetrics`: `errCPSize == getCPSize(dict)` — tests wiring, not implementation
- `ErrorMetrics`: every constructor field preserved (guards against assignment swaps in `__init__`)
- `Metrics`: field storage including the `traceSz`→`fileSz` / `descendants`→`numNodes` renames that happen inside `__init__`, and the `cpSize` conditional

**Test count:** 107 → 140 passing (`bazel test //:pytest`).

## Verbatim-preservation quirks locked in by tests (not fixed here)

Porting rule is to not modify behavior, but these are worth calling out so future readers don't waste time:

1. `ErrCountsData.__radd__` / `SavingData.__radd__` call `self.__add__(other)`, which indexes `.selfErrors` on `other`. So bare `sum([...])` (seeds `int 0`) crashes; callers must pass `start=ErrCountsData()` / `start=SavingData(0, 0, 0)`. Tests follow the same pattern as the existing `LatencyData` test.
2. `Metrics.__init__` only sets `self.cpSize` when `CPMetrics` is truthy. `test_cp_size_skipped_when_cpmetrics_none` asserts `not hasattr(m, "cpSize")` — locking in current behavior. Callers that need a uniform attribute must add their own default.

## Policy updates in `crisp/LAYERS.md` (+41 lines)

- **"Legacy terminology preserved verbatim"** — records that `isCtfTest` and "CTF test traces" are kept as-is pending a future rename sweep. Keeps this PR's diff minimal.
- **"Layer-crossing test dependencies — handling rule"** — codifies the 3-step decision surfaced by this PR:
    1. Audit the type's real dependencies; if thin, **promote to the shallowest layer that satisfies them** (this PR's approach).
    2. If genuinely deep, **defer the test** to the PR that completes the deepest dependency.
    3. **Never modify test bodies** (no mocks / stubs / subset selection) to paper over the issue.
  Includes an empty "Deferred tests" tracking table for case (2).

## Stacking

- Base: `main` (post-PR 4 merge)
- Branch: `port/pr-04b-shared-metrics-types`
- Unblocks: PR 5a (`crisp/metrics/aggregators` + verbatim `test_aggregators.py`)

## Test plan

- [x] `bazel test //:pytest` → 140 passed, 3 subtests passed
- [x] Leak grep over `tests/shared/` (`uber|phx3|uberinternal|jaeger-crisp|wayfare|galileo|mp-proxy|ctf-`) — only hit is the intentional `assertNotIn("uberinternal", JAEGER_UI_URL)` regression guard
- [x] Linter clean on both new test files
- [x] No new files in `crisp/shared/` — extensions only; BUILD unchanged