### PR TITLE
feat(crisp/metrics): port percentile_calculator + verbatim test_percentile_calculator

### DIFF
--- a/crisp/metrics/BUILD.bazel
+++ b/crisp/metrics/BUILD.bazel
@@ -5,7 +5,12 @@ py_library(
     srcs = [
         "__init__.py",
         "aggregators.py",
+        "percentile_calculator.py",
     ],
     imports = ["../.."],
     visibility = ["//visibility:public"],
+    deps = [
+        "//crisp/shared:shared",
+        "@pypi//pandas",
+    ],
 )

--- a/crisp/metrics/percentile_calculator.py
+++ b/crisp/metrics/percentile_calculator.py
@@ -1,0 +1,197 @@
+"""Percentile calculation functions for critical path metrics.
+
+This module contains functions for calculating percentiles and creating
+DataFrames with percentile information for trace analysis.
+"""
+
+import logging
+
+import pandas as pd
+
+from crisp.shared.constants import TOTAL_TIME
+from crisp.shared.models import LatencyData
+from crisp.shared.utils import getLeafNodeFromCallPath
+
+
+def processMetricChunk(chunk, field):
+    """Process a chunk of metrics and create a DataFrame with operation times.
+
+    Args:
+        chunk: List of Metrics objects to process
+        field: Field name to extract from metrics (e.g., 'inc', 'excl')
+
+    Returns:
+        DataFrame with traceID as index and operations as columns
+    """
+    data = []
+    index = []  # To store traceID for each row
+    for m in chunk:
+        d = {TOTAL_TIME: m.latency}
+        for k, v in m.CPMetrics.profile.items():
+            leaf = getLeafNodeFromCallPath(k)
+            if leaf in d:
+                d[leaf] += getattr(v, field)
+            else:
+                d[leaf] = getattr(v, field)
+        data.append(d)
+        index.append(m.traceID)  # Append traceID to the index list
+
+    # Create DataFrame from the data and set traceID as the index
+    dfChunk = pd.DataFrame(data, index=index).fillna(0)
+    return dfChunk
+
+
+def insertInDF(metrics, field):
+    """Create a DataFrame from metrics by processing in chunks.
+
+    Args:
+        metrics: List of Metrics objects
+        field: Field name to extract from metrics (e.g., 'inc', 'excl')
+
+    Returns:
+        DataFrame with all metrics processed and concatenated
+    """
+    # Process metrics in chunks
+    chunkSize = 10000
+    chunks = [metrics[i : i + chunkSize] for i in range(0, len(metrics), chunkSize)]
+    # Process each chunk and concatenate the results
+    dfs = [processMetricChunk(chunk, field) for chunk in chunks]
+
+    if len(dfs) > 0:
+        return pd.concat(dfs)
+    return pd.DataFrame()
+
+
+def addPercentileColumns(df, percentiles):
+    """Add percentile columns to a DataFrame.
+
+    Takes a DataFrame with operations and traces, calculates percentiles
+    based on total time, and adds percentile columns.
+
+    Args:
+        df: DataFrame with traceID as index and operations as columns
+        percentiles: List of Percentile objects
+
+    Returns:
+        Transposed DataFrame with percentile columns added
+    """
+    # Here a data frame looks like this:
+    # traceId       Op1     Op2     Op3 totalTime
+    #   687216      99      1       30    130
+    #   287382      89      2       20    111
+    #   79827       90      3       40    133
+
+    columnsToAdd = {}
+    for p in percentiles:
+        columnsToAdd[p.percentileWithMaxPrefix()] = []
+        columnsToAdd[p.percentageWithAvgPrefix()] = []
+
+    dfByTotalTime = df.sort_values(by=[TOTAL_TIME])
+    numRows = len(df.index)
+    for p in percentiles:
+        # Denominator is the sum of all values till the given percentile.
+        # For example, P50 of 1000 traces will add the total time of
+        # all traces from 0th to 499th.
+        endRow = int(numRows * p.percentile)
+        denominator = dfByTotalTime[TOTAL_TIME][:endRow].sum()
+        for i in dfByTotalTime:
+            # Numerator is the sum of all values seen for the given operation sorted by the total time.
+            # For example, P50 of 1000 traces will add the the ith operation present in the 0th-499th
+            # traces sorted by the total time.
+            numerator = dfByTotalTime[i][:endRow].sum()
+            worstCase = dfByTotalTime[i][:endRow].max()
+            p.pVal[i] = worstCase
+            p.pPct[i] = (numerator / denominator) if denominator != 0 else 0
+            columnsToAdd[p.percentileWithMaxPrefix()].append(p.pVal[i])
+            columnsToAdd[p.percentageWithAvgPrefix()].append(p.pPct[i])
+
+    df = df.transpose()
+
+    # Here a data frame looks like this:
+    #      687216 287382 79827
+    # op1   ?      ?       ?
+    # op2   ?      ?       ?
+    # op3   ?      ?       ?
+
+    for i, p in enumerate(percentiles):
+        df.insert(
+            i,
+            p.percentileWithMaxPrefix(),
+            columnsToAdd[p.percentileWithMaxPrefix()],
+        )
+
+    for i, p in enumerate(percentiles):
+        df.insert(
+            len(percentiles) + i,
+            p.percentageWithAvgPrefix(),
+            columnsToAdd[p.percentageWithAvgPrefix()],
+        )
+
+    # Here a data frame looks like this:
+    #       p50 P95 P99  P50% P95% P99%  687216 287382 79827
+    # op1    ?    ?   ?   ?    ?    ?     ?      ?       ?
+    # op2    ?    ?   ?   ?    ?    ?     ?      ?       ?
+    # op3    ?    ?   ?   ?    ?    ?     ?      ?       ?
+
+    return df
+
+
+def insertInclusivePercentileInfoDF(df, percentilesInclusive, inclusiveDF):
+    """Insert inclusive percentile columns into a DataFrame.
+
+    Args:
+        df: DataFrame to insert columns into
+        percentilesInclusive: List of Percentile objects for inclusive metrics
+        inclusiveDF: DataFrame containing inclusive percentile data
+
+    Returns:
+        DataFrame with inclusive percentile columns inserted
+    """
+    # Insert percentileStr columns.
+    for idx, p in enumerate(percentilesInclusive):
+        df.insert(
+            idx,
+            p.percentileWithMaxPrefix(),
+            inclusiveDF[p.percentileWithMaxPrefix()],
+        )
+
+    # Insert percentileWithPercentSign columns.
+    for idx, p in enumerate(percentilesInclusive):
+        df.insert(
+            len(percentilesInclusive) + idx,
+            p.percentageWithAvgPrefix(),
+            inclusiveDF[p.percentageWithAvgPrefix()],
+        )
+    return df
+
+
+def genLatencyPercentile(latencyHypo, percentiles, sortBy, tailLatency):
+    """Generate latency percentile statistics.
+
+    Args:
+        latencyHypo: List of LatencyData objects
+        percentiles: List of percentile values (e.g., [1, 5, 10, 50, 90, 95, 99, 100])
+        sortBy: Function to use for sorting (e.g., lambda x: x.latency)
+        tailLatency: If True, calculate tail latency (top percentile), otherwise head latency
+
+    Returns:
+        List of tuples (percentile, count, averaged_latency_data)
+    """
+    latencyPercentile = []
+    latencySorted = sorted(latencyHypo, key=sortBy, reverse=False)
+    for p in percentiles:
+        limit = round(len(latencySorted) * p / 100)
+        if limit == 0:
+            logging.info("not enough samples for top " + str(p) + " % time saved")
+            continue
+        if tailLatency:
+            start = len(latencySorted) - limit
+            sortedList = latencySorted[start:]
+        else:
+            sortedList = latencySorted[:limit]
+        assert len(sortedList) == limit
+        latency = sum(sortedList, LatencyData("", 0, 0, 0, 0))
+        latency.average(limit)
+        latencyPercentile.append((p, limit, latency))
+
+    return latencyPercentile

--- a/tests/metrics/test_percentile_calculator.py
+++ b/tests/metrics/test_percentile_calculator.py
@@ -1,0 +1,142 @@
+"""Tests for percentile calculation functions.
+
+This module contains unit tests for the percentile calculation functions
+used in critical path analysis.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from crisp.metrics.percentile_calculator import (
+    addPercentileColumns,
+    genLatencyPercentile,
+    insertInDF,
+    insertInclusivePercentileInfoDF,
+    processMetricChunk,
+)
+from crisp.shared.models import LatencyData
+
+
+class TestPercentileCalculator(unittest.TestCase):
+    """Tests for percentile calculation functions."""
+
+    def test_processMetricChunk(self):
+        """Test processing a metric chunk into a DataFrame."""
+        chunk = [
+            MagicMock(traceID="trace1", latency=100, CPMetrics=MagicMock(profile={"op1": MagicMock(time=30)})),
+            MagicMock(traceID="trace2", latency=200, CPMetrics=MagicMock(profile={"op1": MagicMock(time=40)}))
+        ]
+        with patch("crisp.shared.constants.TOTAL_TIME", "totalTime"):
+            df = processMetricChunk(chunk, "time")
+            expected_df = pd.DataFrame(
+                {"totalTime": [100, 200], "op1": [30, 40]},
+                index=["trace1", "trace2"]
+            )
+            pd.testing.assert_frame_equal(df, expected_df)
+
+    def test_insertInDF(self):
+        """Test inserting chunks of metrics into a DataFrame."""
+        metrics = [
+            MagicMock(traceID="trace1", latency=100, CPMetrics=MagicMock(profile={"op1": MagicMock(time=30)})),
+            MagicMock(traceID="trace2", latency=200, CPMetrics=MagicMock(profile={"op1": MagicMock(time=40)})),
+            MagicMock(traceID="trace3", latency=300, CPMetrics=MagicMock(profile={"op1": MagicMock(time=50)})),
+        ]
+        with patch("crisp.metrics.percentile_calculator.processMetricChunk") as mock_processMetricChunk:
+            mock_processMetricChunk.side_effect = lambda chunk, _: pd.DataFrame(
+                [{"totalTime": metric.latency, "op1": metric.CPMetrics.profile["op1"].time} for metric in chunk],
+                index=[metric.traceID for metric in chunk]
+            )
+            df = insertInDF(metrics, "time")
+            self.assertEqual(df.shape[0], 3)
+
+    def test_addPercentileColumns(self):
+        """Test adding percentile columns to a DataFrame."""
+        df = pd.DataFrame({"op1": [10, 20, 30], "totalTime": [10, 20, 30]})
+        percentiles = [
+            MagicMock(
+                percentile=0.5,
+                percentileWithMaxPrefix=MagicMock(return_value="P50"),
+                percentageWithAvgPrefix=MagicMock(return_value="P50%"),
+            )
+        ]
+        with patch("crisp.shared.constants.TOTAL_TIME", "totalTime"):
+            df_result = addPercentileColumns(df, percentiles)
+            self.assertIn("P50", df_result.columns)
+
+    def test_insertInclusivePercentileInfoDF(self):
+        """Test inserting inclusive percentile info from one DataFrame to another."""
+        df = pd.DataFrame(columns=["op1", "op2"])
+        inclusiveDF = pd.DataFrame({
+            "P50": [10, 20],
+            "P90": [30, 40],
+            "P50%": [0.5, 0.6],
+            "P90%": [0.7, 0.8]
+        }, index=["op1", "op2"])
+
+        percentilesInclusive = [
+            MagicMock(percentileWithMaxPrefix=MagicMock(return_value="P50"), percentageWithAvgPrefix=MagicMock(return_value="P50%")),
+            MagicMock(percentileWithMaxPrefix=MagicMock(return_value="P90"), percentageWithAvgPrefix=MagicMock(return_value="P90%"))
+        ]
+
+        df_result = insertInclusivePercentileInfoDF(df, percentilesInclusive, inclusiveDF)
+
+        # Check that columns have been inserted correctly
+        expected_columns = ["P50", "P90", "P50%", "P90%", "op1", "op2"]
+        self.assertEqual(df_result.columns.tolist(), expected_columns)
+        self.assertEqual(df_result["P50"].tolist(), [10, 20])
+        self.assertEqual(df_result["P90%"].tolist(), [0.7, 0.8])
+
+    def compare_latency_data_lists(self, list1, list2):
+        """Helper function to compare lists of (percentile, limit, LatencyData) tuples."""
+        self.assertEqual(len(list1), len(list2), "Lists have different lengths")
+        for (p1, limit1, latency1), (p2, limit2, latency2) in zip(list1, list2):
+            self.assertEqual(p1, p2, "Percentiles differ")
+            self.assertEqual(limit1, limit2, "Limits differ")
+            # Compare each attribute in LatencyData
+            self.assertEqual(latency1.traceID, latency2.traceID, "Trace IDs differ")
+            self.assertAlmostEqual(latency1.latency, latency2.latency, places=2, msg="Latencies differ")
+            self.assertAlmostEqual(latency1.hypoLatency, latency2.hypoLatency, places=2, msg="Hypothetical latencies differ")
+            self.assertAlmostEqual(latency1.hypoLatencyOptimistic, latency2.hypoLatencyOptimistic,
+                                   places=2, msg="Optimistic hypothetical latencies differ")
+            self.assertAlmostEqual(latency1.hypoLatencyPessimistic, latency2.hypoLatencyPessimistic,
+                                   places=2, msg="Pessimistic hypothetical latencies differ")
+
+    def test_genLatencyPercentile(self):
+        """Test the genLatencyPercentile function with sample data."""
+        # Create sample LatencyData objects
+        latencyHypo = [
+            LatencyData("trace1", 100, 80, 70, 90),
+            LatencyData("trace2", 200, 180, 170, 190),
+            LatencyData("trace3", 300, 280, 270, 290),
+            LatencyData("trace4", 400, 380, 370, 390),
+            LatencyData("trace5", 500, 480, 470, 490),
+        ]
+        percentiles = [20, 40, 60, 80, 100]
+
+        # Test sorting by latency, tailLatency=False
+        result = genLatencyPercentile(latencyHypo, percentiles, lambda x: x.latency, tailLatency=False)
+        expected = []
+        for p in percentiles:
+            limit = round(len(latencyHypo) * p / 100)
+            selected = latencyHypo[:limit]
+            avg_latency = sum(selected, LatencyData("", 0, 0, 0, 0))
+            avg_latency.average(limit)
+            expected.append((p, limit, avg_latency))
+        self.compare_latency_data_lists(result, expected)
+
+        # Test sorting by hypoLatency, tailLatency=True
+        result = genLatencyPercentile(latencyHypo, percentiles, lambda x: x.hypoLatency, tailLatency=True)
+        expected = []
+        latencySorted = sorted(latencyHypo, key=lambda x: x.hypoLatency)
+        for p in percentiles:
+            limit = round(len(latencyHypo) * p / 100)
+            if limit == 0:
+                continue
+            start = len(latencySorted) - limit
+            selected = latencySorted[start:]
+            avg_latency = sum(selected, LatencyData("", 0, 0, 0, 0))
+            avg_latency.average(limit)
+            expected.append((p, limit, avg_latency))
+        self.compare_latency_data_lists(result, expected)


### PR DESCRIPTION
## Summary

Second module in the metrics layer. Verbatim port: rewrite imports + `patch()` paths, keep code/test bodies unchanged.

## Changes

| File | Lines | What |
|---|---|---|
| `crisp/metrics/percentile_calculator.py` | +198 | Verbatim. 3 imports rewritten to `crisp.shared.{constants,models,utils}` |
| `tests/metrics/test_percentile_calculator.py` | +144 | Verbatim. 2 imports + 3 `unittest.mock.patch()` target strings rewritten |
| `crisp/metrics/BUILD.bazel` | +5/-1 | Added `percentile_calculator.py` to srcs **and** explicit deps `//crisp/shared:shared` + `@pypi//pandas` |

Five public functions ported under their original names per LAYERS.md naming policy: `processMetricChunk`, `insertInDF`, `addPercentileColumns`, `insertInclusivePercentileInfoDF`, `genLatencyPercentile`.

## Two non-byte-for-byte test details

1. **Three `patch()` target strings rewritten** alongside imports — `unittest.mock.patch(...)` takes module paths as strings, so they need the same `critical_path.*` → `crisp.*` rewrite (no body change).
2. **Dropped `# ruff: noqa: I001`** header — same as PR 5a, dead noise once the import paths collapse to a clean order.

## BUILD tightening (minor scope)

Added `//crisp/shared:shared` and `@pypi//pandas` as explicit `deps` of the `metrics` library. Previously they only resolved transitively via the `//crisp:pkg` meta-target, which means the metrics library was technically under-declared from PR 5a. This PR fixes that for both `aggregators` (PR 5a's leftover) and the new `percentile_calculator`. No behavior change.

## Stack

- Base: `main` (post-PR-5a at `02e5b73`)
- Unblocks: PR 6a (`crisp/output/formatters`)

## Test plan

- [x] `bazel test //:pytest` → **163 passed** (was 158 on `main`; +5)
- [x] Leak grep clean (`uber|phx3|uberinternal|jaeger-crisp|wayfare|galileo|mp-proxy|ctf-`)
- [x] Lints clean
