### PR TITLE
feat(crisp/output): port formatters + verbatim test_formatters

### DIFF
--- a/crisp/output/BUILD.bazel
+++ b/crisp/output/BUILD.bazel
@@ -2,7 +2,14 @@ load("@rules_python//python:py_library.bzl", "py_library")
 
 py_library(
     name = "output",
-    srcs = ["__init__.py"],
+    srcs = [
+        "__init__.py",
+        "formatters.py",
+    ],
     imports = ["../.."],
     visibility = ["//visibility:public"],
+    deps = [
+        "//crisp/shared:shared",
+        "@pypi//pandas",
+    ],
 )

--- a/crisp/output/formatters.py
+++ b/crisp/output/formatters.py
@@ -1,0 +1,83 @@
+"""DataFrame and HTML formatting utilities for critical path analysis."""
+
+import logging
+
+from crisp.shared.constants import (
+    JAEGER_UI_URL,
+    SORTABLE_COL_CLASS,
+    TOTAL_TIME,
+)
+
+
+def makeClickable(url, name):
+    """Create an HTML link with target="_blank"."""
+    return f'<a href="{url}" rel="noopener noreferrer" target="_blank">{name}</a>'
+
+
+def sortableColHeader(name):
+    """Add sortable icon to column header."""
+    return name + SORTABLE_COL_CLASS
+
+
+def addHyperLinkToTrace(df, tracespanIDmap):
+    """Make each trace column header navigatable to Jaeger UI."""
+    hyperLinkHT = {}
+    for k, v in tracespanIDmap.items():
+        hyperLinkHT[k] = makeClickable(f"{JAEGER_UI_URL}{k}?uiFind={v}", "#")
+    df.rename(columns=hyperLinkHT, inplace=True)
+    return df
+
+
+def renameSortableIcon(df, columns):
+    """Use fas fa-sort script to make columns sortable."""
+    sortableRenameHT = {}
+    for col in columns:
+        sortableRenameHT[col] = sortableColHeader(col)
+
+    df.rename(columns=sortableRenameHT, inplace=True)
+    return df
+
+
+def insertOccurenceCol(df, jaegerTraceFiles, nonZeros):
+    """Insert one column that counts the number of times the operation is seen on the critical path."""
+    occurenceColHeader = f"occurence ({len(jaegerTraceFiles)})"
+    # Initialize with 0 (not "") so the column gets numeric dtype; the loop
+    # below assigns ints, and pandas >=2.x rejects int assignment into a
+    # str-inferred column. End state is unchanged (every cell is overwritten).
+    df.insert(0, occurenceColHeader, 0)
+    for i in range(len(df)):
+        df.at[df.index[i], f"occurence ({len(jaegerTraceFiles)})"] = int(nonZeros[i])
+    return df, occurenceColHeader
+
+
+def reindexDescending(df, prefixColumns, traceIDIndex):
+    """Sort rows by the descending sum of values in traceIDIndex columns."""
+    df_sorted_by_row = df.reindex(
+        df[traceIDIndex].sum(axis=1).sort_values(ascending=False).index,
+    )
+
+    logging.info("reindexDescending df.loc start")
+    # Sort traceIDIndex columns by descending values in the TOTAL_TIME row
+    traceIDSorted = (
+        df.loc[TOTAL_TIME, traceIDIndex]
+        .sort_values(ascending=False)
+        .index.tolist()
+    )
+
+    # Combine the sorted columns with prefixColumns and reindex the DataFrame
+    return df_sorted_by_row.reindex(columns=prefixColumns + traceIDSorted)
+
+
+def setCellFormating(df, percentiles, occurenceColHeader):
+    """Set cell formatting precision for different column types."""
+    precisionHT = {}
+    for i in df.columns.values:
+        # All columns except percentiles with % sign will be in scientific.
+        precisionHT[i] = "{:.2e}"
+
+    for p in percentiles:
+        precisionHT[sortableColHeader(p.percentageWithAvgPrefix())] = "{:.2f}"
+
+    # occurence column will be in decimal
+    precisionHT[sortableColHeader(occurenceColHeader)] = "{:5d}"
+    return precisionHT

--- a/tests/output/test_formatters.py
+++ b/tests/output/test_formatters.py
@@ -1,0 +1,110 @@
+"""Tests for formatter functions."""
+
+import unittest
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from crisp.output.formatters import (
+    JAEGER_UI_URL,
+    SORTABLE_COL_CLASS,
+    TOTAL_TIME,
+    addHyperLinkToTrace,
+    insertOccurenceCol,
+    makeClickable,
+    reindexDescending,
+    renameSortableIcon,
+    setCellFormating,
+    sortableColHeader,
+)
+
+
+class TestFormatters(unittest.TestCase):
+
+    def test_makeClickable(self):
+        url = "http://example.com"
+        name = "Example"
+        result = makeClickable(url, name)
+        expected = '<a href="http://example.com" rel="noopener noreferrer" target="_blank">Example</a>'
+        self.assertEqual(result, expected)
+
+    def test_sortableColHeader(self):
+        result = sortableColHeader("col1")
+        expected = "col1" + SORTABLE_COL_CLASS
+        self.assertEqual(result, expected)
+
+    def test_addHyperLinkToTrace(self):
+        df = pd.DataFrame({'trace1': [1, 2], 'trace2': [3, 4]})
+        tracespanIDmap = {'trace1': 'span1', 'trace2': 'span2'}
+
+        result_df = addHyperLinkToTrace(df, tracespanIDmap)
+
+        expected_cols = [
+            f'<a href="{JAEGER_UI_URL}trace1?uiFind=span1" rel="noopener noreferrer" target="_blank">#</a>',
+            f'<a href="{JAEGER_UI_URL}trace2?uiFind=span2" rel="noopener noreferrer" target="_blank">#</a>'
+        ]
+        self.assertEqual(list(result_df.columns), expected_cols)
+
+    def test_renameSortableIcon(self):
+        df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        columns = ['col1', 'col2']
+
+        result_df = renameSortableIcon(df, columns)
+
+        expected_cols = [
+            'col1' + SORTABLE_COL_CLASS,
+            'col2' + SORTABLE_COL_CLASS
+        ]
+        self.assertEqual(list(result_df.columns), expected_cols)
+
+    def test_insertOccurenceCol(self):
+        df = pd.DataFrame({'op1': [1, 2], 'op2': [3, 4]})
+        jaegerTraceFiles = ['file1.json', 'file2.json', 'file3.json']
+        nonZeros = pd.Series([10, 20])
+
+        result_df, occurenceColHeader = insertOccurenceCol(df, jaegerTraceFiles, nonZeros)
+
+        expected_header = "occurence (3)"
+        self.assertEqual(occurenceColHeader, expected_header)
+        self.assertEqual(result_df.columns[0], expected_header)
+        self.assertEqual(result_df.iloc[0, 0], 10)
+        self.assertEqual(result_df.iloc[1, 0], 20)
+
+    def test_reindexDescending(self):
+        # Create test dataframe with TOTAL_TIME row
+        df = pd.DataFrame({
+            'trace1': [10, 5, 15],  # sum = 30
+            'trace2': [8, 3, 12],   # sum = 23
+            'trace3': [12, 7, 20]   # sum = 39
+        }, index=['op1', 'op2', TOTAL_TIME])
+
+        prefixColumns = ['prefix1']
+        traceIDIndex = ['trace1', 'trace2', 'trace3']
+
+        result_df = reindexDescending(df, prefixColumns, traceIDIndex)
+
+        # Should be sorted by TOTAL_TIME row values: trace3 (20), trace1 (15), trace2 (12)
+        expected_cols = ['prefix1', 'trace3', 'trace1', 'trace2']
+        self.assertEqual(list(result_df.columns), expected_cols)
+
+    def test_setCellFormating(self):
+        df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+
+        # Mock percentiles with required methods
+        percentiles = [
+            MagicMock(percentageWithAvgPrefix=MagicMock(return_value="P50%"))
+        ]
+        occurenceColHeader = "occurence (100)"
+
+        result = setCellFormating(df, percentiles, occurenceColHeader)
+
+        # Check that it returns a dictionary with formatting
+        self.assertIsInstance(result, dict)
+        self.assertIn(sortableColHeader("P50%"), result)
+        self.assertEqual(result[sortableColHeader("P50%")], "{:.2f}")
+        self.assertIn(sortableColHeader(occurenceColHeader), result)
+        self.assertEqual(result[sortableColHeader(occurenceColHeader)], "{:5d}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

First module in the output layer. Verbatim port + **one minimal source fix** required for pandas 3.x dtype enforcement.

## Changes

| File | Lines | What |
|---|---|---|
| `crisp/output/formatters.py` | +84 | Verbatim port + 1-line pandas 3.x fix (see below) |
| `tests/output/test_formatters.py` | +110 | Verbatim port; 1 import block rewritten |
| `tests/output/__init__.py` | 0 | Package marker |
| `crisp/output/BUILD.bazel` | +7/-1 | Add `formatters.py` to srcs + explicit `//crisp/shared` + `@pypi//pandas` deps |

Seven public functions ported under their original names: `makeClickable`, `sortableColHeader`, `addHyperLinkToTrace`, `renameSortableIcon`, `insertOccurenceCol`, `reindexDescending`, `setCellFormating`.

## One non-verbatim source fix worth reviewing

In `insertOccurenceCol`, internal initializes the new column with `""` then immediately overwrites every cell with `int(nonZeros[i])` in the loop. On pandas ≥2.x the `""` infers `str` dtype, and int assignment into a str column raises `TypeError`.

```diff
-    df.insert(0, occurenceColHeader, "")
+    # Initialize with 0 (not "") so the column gets numeric dtype; the loop
+    # below assigns ints, and pandas >=2.x rejects int assignment into a
+    # str-inferred column. End state is unchanged (every cell is overwritten).
+    df.insert(0, occurenceColHeader, 0)
```

End state identical to internal (every cell is overwritten in the loop). Without this fix, `test_insertOccurenceCol` fails on pandas 3.0.2 (the version in `requirements_lock.txt`); with it, the test passes **unchanged** — no test-body modifications.

## Test rewrites (one block only)

Only the import block changed: `from uber.tooling…output.formatters` → `from crisp.output.formatters`. Test bodies, assertions, fixtures all byte-for-byte. Dropped the `# ruff: noqa: I001` header.

Note: the test imports `JAEGER_UI_URL` / `SORTABLE_COL_CLASS` / `TOTAL_TIME` **through `crisp.output.formatters`** (not directly from `crisp.shared.constants`) — preserved verbatim from internal, which intentionally re-exports these constants at module load.

## BUILD tightening

Added `//crisp/shared:shared` and `@pypi//pandas` as explicit deps of the `output` library. Mirrors the metrics layer's tightening from PR 5b.

## Stack

- Base: `main` (post-PR-5b at `3dbbc23`)
- Unblocks: PR 6b (`csv_generators`)

## Test plan

- [x] `bazel test //:pytest` → **170 passed** (was 163 on `main`; +7)
- [x] Leak grep clean (`uber|phx3|uberinternal|jaeger-crisp|wayfare|galileo|mp-proxy|ctf-`)
- [x] Lints clean