### PR TITLE
port(crisp): add configuration.py and cli.py (PR 7b)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,12 +29,29 @@ py_test(
     size = "small",
     srcs = ["pytest_runner.py"],
     main = "pytest_runner.py",
-    data = glob(["tests/**"]) + ["pyproject.toml"],
+    data = glob(["tests/**"]) + ["pyproject.toml", "services.yaml"],
     deps = [
         ":crisp_lib",
+        "//crisp:cli",
+        "//crisp:configuration",
         "//crisp:pkg",
         "@pypi//pytest",
     ],
     env = {"MPLBACKEND": "Agg"},
+    imports = ["."],
+)
+
+py_test(
+    name = "test_configuration",
+    srcs = ["tests/test_configuration.py"],
+    deps = ["//crisp:configuration"],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_cli",
+    srcs = ["tests/test_cli.py"],
+    data = ["services.yaml"],
+    deps = ["//crisp:cli"],
     imports = ["."],
 )

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -15,3 +15,17 @@ py_library(
         "//crisp/utils:utils",
     ],
 )
+
+py_library(
+    name = "configuration",
+    srcs = ["configuration.py"],
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+py_library(
+    name = "cli",
+    srcs = ["cli.py"],
+    visibility = ["//visibility:public"],
+    deps = [":configuration"],
+)

--- a/crisp/cli.py
+++ b/crisp/cli.py
@@ -1,0 +1,207 @@
+# ruff: noqa: I001
+import argparse
+from dataclasses import dataclass
+from typing import Optional
+from collections.abc import Sequence
+
+
+@dataclass(frozen=True)
+class MainArgs:
+    services_file: str
+    numTrace: int
+    ioParallelism: int
+    computeParallelism: int
+    shardId: int
+    numShards: int
+    diskRequirement: int
+    endpointDiskGBLimit: int
+    useMP: bool
+    useMidnightTime: bool
+    ignoreLastNMinutes: int
+    filterProxy: bool
+    mergeAllRoots: bool
+    doRanges: bool
+    qps: int
+    errorAnalysis: bool
+    startTimestamp: Optional[int]
+    endTimestamp: Optional[int]
+    maxExemplars: int
+
+
+def _build_main_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--services-file",
+        "-s",
+        dest="services_file",
+        type=argparse.FileType("r"),
+        required=True,
+        help="A YAML file with a list of service and operation names.",
+    )
+    parser.add_argument(
+        "--numTrace",
+        action="store",
+        help="number of traces to download",
+        default=1000,
+        type=int,
+    )
+    parser.add_argument(
+        "--ioParallelism",
+        action="store",
+        help="Number of concurrent python processes.",
+        default=1,
+        type=int,
+    )
+    parser.add_argument(
+        "--computeParallelism",
+        action="store",
+        help="Number of concurrent python processes.",
+        default=1,
+        type=int,
+    )
+    parser.add_argument(
+        "--shardId",
+        action="store",
+        help="The shards id of this shard.",
+        default=0,
+        type=int,
+    )
+    parser.add_argument(
+        "--numShards",
+        action="store",
+        help="Number of shards that the yaml is chunked into.",
+        default=1,
+        type=int,
+    )
+    parser.add_argument(
+        "--diskRequirement",
+        action="store",
+        help="disk requirement to run CRISP in Gigabyte.",
+        default=5,
+        type=int,
+    )
+    parser.add_argument(
+        "--endpointDiskGBLimit",
+        action="store",
+        help="upperbound for individual endpoint disk usage in Gigabyte.",
+        default=500,
+        type=int,
+    )
+    parser.add_argument(
+        "--useMP",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Use multiprocessing based pipeline",
+    )
+    parser.add_argument(
+        "--useMidnightTime",
+        dest="useMidnightTime",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Use the start time as the midnight today UTC.",
+    )
+    parser.add_argument(
+        "--ignoreLastNMinutes",
+        action="store",
+        help="Number of last N minutes to ignore for trace collection.",
+        default=10,
+        type=int,
+    )
+    parser.add_argument(
+        "--filterProxy",
+        dest="filterProxy",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Remove proxy nodes from the output",
+    )
+    parser.add_argument(
+        "--mergeAllRoots",
+        dest="mergeAllRoots",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        required=False,
+        help="Merge metrics from every matching root span instead of analyzing only the first match (default=true).",
+    )
+    parser.add_argument(
+        "--doRanges",
+        dest="doRanges",
+        action="store_true",
+        help="Compute flamegraphs for every 20 percentiles (default=false)",
+        default=False,
+        required=False,
+    )
+    parser.add_argument(
+        "--qps",
+        dest="qps",
+        action="store",
+        help="QPS for the trace fetching (default=500)",
+        default=500,
+        type=int,
+    )
+    parser.add_argument(
+        "--errorAnalysis",
+        dest="errorAnalysis",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Run error analysis",
+    )
+    parser.add_argument(
+        "--startTimestamp",
+        dest="startTimestamp",
+        action="store",
+        default=None,
+        required=False,
+        help="Start timestamp for trace collection in UTC format",
+        type=int,
+    )
+    parser.add_argument(
+        "--endTimestamp",
+        dest="endTimestamp",
+        action="store",
+        default=None,
+        required=False,
+        help="End timestamp for trace collection in UTC format",
+        type=int,
+    )
+    parser.add_argument(
+        "--maxExemplars",
+        dest="maxExemplars",
+        action="store",
+        default=3,
+        required=False,
+        help="Maximum number of exemplars (trace/span pairs) to keep per call path in protobuf output (default=3).",
+        type=int,
+    )
+    return parser
+
+
+def parse_main_args(argv: Optional[Sequence[str]] = None) -> MainArgs:
+    parser = _build_main_parser()
+    namespace = parser.parse_args(argv)
+    services_handle = namespace.services_file
+    services_path = services_handle.name
+    services_handle.close()
+    return MainArgs(
+        services_file=services_path,
+        numTrace=namespace.numTrace,
+        ioParallelism=namespace.ioParallelism,
+        computeParallelism=namespace.computeParallelism,
+        shardId=namespace.shardId,
+        numShards=namespace.numShards,
+        diskRequirement=namespace.diskRequirement,
+        endpointDiskGBLimit=namespace.endpointDiskGBLimit,
+        useMP=namespace.useMP,
+        useMidnightTime=namespace.useMidnightTime,
+        ignoreLastNMinutes=namespace.ignoreLastNMinutes,
+        filterProxy=namespace.filterProxy,
+        mergeAllRoots=namespace.mergeAllRoots,
+        doRanges=namespace.doRanges,
+        qps=namespace.qps,
+        errorAnalysis=namespace.errorAnalysis,
+        startTimestamp=namespace.startTimestamp,
+        endTimestamp=namespace.endTimestamp,
+        maxExemplars=namespace.maxExemplars,
+    )

--- a/crisp/configuration.py
+++ b/crisp/configuration.py
@@ -1,0 +1,152 @@
+"""Configuration settings for critical path analysis.
+
+This module contains configurable parameters and settings that control
+the behavior of the critical path analysis algorithms.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class AnalysisConfig:
+    """Configuration class for critical path analysis parameters.
+
+    This class contains all the configurable settings that affect
+    how the critical path analysis algorithms behave.
+    """
+
+    # Overlap and timing tolerances
+    overlap_allowance_fraction: float = 0.01
+    """How much spans can overlap as a fraction of the total execution time of their common parent."""
+
+    server_lengthening_factor: float = 1.01
+    """How much a server span can be greater than its client span."""
+
+    # Algorithm control flags
+    enable_optimistic_time_saved: bool = False
+    """Enable optimistic time saved calculations (kept for reference, not used)."""
+
+    enable_pessimistic_time_saved: bool = False
+    """Enable pessimistic time saved calculations (kept for reference, not used)."""
+
+    # Processing limits and defaults
+    max_concurrent_downloads: int = 5
+    """Maximum number of concurrent trace downloads allowed."""
+
+    default_compute_parallelism: int = 16
+    """Default number of parallel compute operations."""
+
+    default_io_parallelism: int = 4
+    """Default number of parallel I/O operations."""
+
+    # Retry configuration
+    max_retry_attempts: int = 3
+    """Maximum number of retry attempts for failed operations."""
+
+    retry_min_wait_seconds: int = 1
+    """Minimum wait time between retries in seconds."""
+
+    retry_max_wait_seconds: int = 10
+    """Maximum wait time between retries in seconds."""
+
+    retry_jitter_max_seconds: int = 2
+    """Maximum jitter to add to retry wait times in seconds."""
+
+
+# Global configuration instance
+_config: Optional[AnalysisConfig] = None
+
+
+def get_config() -> AnalysisConfig:
+    """Get the global analysis configuration instance.
+
+    Returns:
+        AnalysisConfig: The current configuration instance.
+    """
+    global _config
+    if _config is None:
+        _config = AnalysisConfig()
+    return _config
+
+
+def set_config(config: AnalysisConfig) -> None:
+    """Set the global analysis configuration instance.
+
+    Args:
+        config: The new configuration to use.
+    """
+    global _config
+    _config = config
+
+
+def reset_config() -> None:
+    """Reset the configuration to default values."""
+    global _config
+    _config = AnalysisConfig()
+
+
+class ConfigBuilder:
+    """Builder class for creating custom analysis configurations."""
+
+    def __init__(self) -> None:
+        self._config = AnalysisConfig()
+
+    def overlap_allowance(self, fraction: float) -> 'ConfigBuilder':
+        """Set the overlap allowance fraction."""
+        self._config.overlap_allowance_fraction = fraction
+        return self
+
+    def server_lengthening(self, factor: float) -> 'ConfigBuilder':
+        """Set the server lengthening factor."""
+        self._config.server_lengthening_factor = factor
+        return self
+
+    def enable_optimistic(self, enabled: bool = True) -> 'ConfigBuilder':
+        """Enable or disable optimistic time saved calculations."""
+        self._config.enable_optimistic_time_saved = enabled
+        return self
+
+    def enable_pessimistic(self, enabled: bool = True) -> 'ConfigBuilder':
+        """Enable or disable pessimistic time saved calculations."""
+        self._config.enable_pessimistic_time_saved = enabled
+        return self
+
+    def parallelism(self, compute: int, io: int) -> 'ConfigBuilder':
+        """Set compute and I/O parallelism levels."""
+        self._config.default_compute_parallelism = compute
+        self._config.default_io_parallelism = io
+        return self
+
+    def retry_config(self, max_attempts: int, min_wait: int, max_wait: int, jitter: int) -> 'ConfigBuilder':
+        """Set retry configuration parameters."""
+        self._config.max_retry_attempts = max_attempts
+        self._config.retry_min_wait_seconds = min_wait
+        self._config.retry_max_wait_seconds = max_wait
+        self._config.retry_jitter_max_seconds = jitter
+        return self
+
+    def build(self) -> AnalysisConfig:
+        """Build and return the configuration."""
+        return self._config
+
+
+# Convenience functions for commonly used config values
+def get_overlap_allowance() -> float:
+    """Get the current overlap allowance fraction."""
+    return get_config().overlap_allowance_fraction
+
+
+def get_server_lengthening_factor() -> float:
+    """Get the current server lengthening factor."""
+    return get_config().server_lengthening_factor
+
+
+def is_optimistic_enabled() -> bool:
+    """Check if optimistic time saved calculations are enabled."""
+    return get_config().enable_optimistic_time_saved
+
+
+def is_pessimistic_enabled() -> bool:
+    """Check if pessimistic time saved calculations are enabled."""
+    return get_config().enable_pessimistic_time_saved

--- a/services.yaml
+++ b/services.yaml
@@ -1,0 +1,2 @@
+example-service:
+  - "ExampleService::doSomething"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import crisp.cli as cli
+
+
+def _get_services_file() -> str:
+    return str(Path(__file__).resolve().parents[1] / "services.yaml")
+
+
+def test_parse_main_args_defaults():
+    services_path = _get_services_file()
+    args = cli.parse_main_args(["--services-file", services_path])
+    assert args.services_file == services_path
+    assert args.numTrace == 1000
+    assert args.ioParallelism == 1
+    assert args.computeParallelism == 1
+    assert args.shardId == 0
+    assert args.numShards == 1
+    assert args.diskRequirement == 5
+    assert args.endpointDiskGBLimit == 500
+    assert args.useMP is False
+    assert args.useMidnightTime is False
+    assert args.ignoreLastNMinutes == 10
+    assert args.filterProxy is False
+    assert args.mergeAllRoots is True
+    assert args.doRanges is False
+    assert args.qps == 500
+    assert args.errorAnalysis is False
+    assert args.startTimestamp is None
+    assert args.endTimestamp is None
+    assert args.maxExemplars == 3
+
+
+def test_parse_main_args_overrides():
+    services_path = _get_services_file()
+    argv = [
+        "--services-file",
+        services_path,
+        "--numTrace",
+        "123",
+        "--ioParallelism",
+        "4",
+        "--computeParallelism",
+        "5",
+        "--shardId",
+        "2",
+        "--numShards",
+        "3",
+        "--diskRequirement",
+        "7",
+        "--endpointDiskGBLimit",
+        "9",
+        "--useMP",
+        "--useMidnightTime",
+        "--ignoreLastNMinutes",
+        "11",
+        "--filterProxy",
+        "--no-mergeAllRoots",
+        "--doRanges",
+        "--qps",
+        "321",
+        "--errorAnalysis",
+        "--startTimestamp",
+        "1",
+        "--endTimestamp",
+        "2",
+        "--maxExemplars",
+        "5",
+    ]
+
+    args = cli.parse_main_args(argv)
+
+    assert args.numTrace == 123
+    assert args.ioParallelism == 4
+    assert args.computeParallelism == 5
+    assert args.shardId == 2
+    assert args.numShards == 3
+    assert args.diskRequirement == 7
+    assert args.endpointDiskGBLimit == 9
+    assert args.useMP is True
+    assert args.useMidnightTime is True
+    assert args.ignoreLastNMinutes == 11
+    assert args.filterProxy is True
+    assert args.mergeAllRoots is False
+    assert args.doRanges is True
+    assert args.qps == 321
+    assert args.errorAnalysis is True
+    assert args.startTimestamp == 1
+    assert args.endTimestamp == 2
+    assert args.maxExemplars == 5

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,190 @@
+import unittest
+
+from crisp.configuration import (
+    AnalysisConfig,
+    ConfigBuilder,
+    get_config,
+    get_overlap_allowance,
+    get_server_lengthening_factor,
+    is_optimistic_enabled,
+    is_pessimistic_enabled,
+    reset_config,
+    set_config,
+)
+
+
+class TestAnalysisConfigDefaults(unittest.TestCase):
+    def setUp(self):
+        reset_config()
+
+    def tearDown(self):
+        reset_config()
+
+    def test_overlap_allowance_fraction_default(self):
+        cfg = AnalysisConfig()
+        self.assertAlmostEqual(cfg.overlap_allowance_fraction, 0.01)
+
+    def test_server_lengthening_factor_default(self):
+        cfg = AnalysisConfig()
+        self.assertAlmostEqual(cfg.server_lengthening_factor, 1.01)
+
+    def test_enable_optimistic_time_saved_default(self):
+        cfg = AnalysisConfig()
+        self.assertFalse(cfg.enable_optimistic_time_saved)
+
+    def test_enable_pessimistic_time_saved_default(self):
+        cfg = AnalysisConfig()
+        self.assertFalse(cfg.enable_pessimistic_time_saved)
+
+    def test_max_concurrent_downloads_default(self):
+        cfg = AnalysisConfig()
+        self.assertEqual(cfg.max_concurrent_downloads, 5)
+
+    def test_default_compute_parallelism_default(self):
+        cfg = AnalysisConfig()
+        self.assertEqual(cfg.default_compute_parallelism, 16)
+
+    def test_default_io_parallelism_default(self):
+        cfg = AnalysisConfig()
+        self.assertEqual(cfg.default_io_parallelism, 4)
+
+    def test_max_retry_attempts_default(self):
+        cfg = AnalysisConfig()
+        self.assertEqual(cfg.max_retry_attempts, 3)
+
+    def test_retry_min_wait_seconds_default(self):
+        cfg = AnalysisConfig()
+        self.assertEqual(cfg.retry_min_wait_seconds, 1)
+
+    def test_retry_max_wait_seconds_default(self):
+        cfg = AnalysisConfig()
+        self.assertEqual(cfg.retry_max_wait_seconds, 10)
+
+    def test_retry_jitter_max_seconds_default(self):
+        cfg = AnalysisConfig()
+        self.assertEqual(cfg.retry_jitter_max_seconds, 2)
+
+
+class TestGlobalConfigSingleton(unittest.TestCase):
+    def setUp(self):
+        reset_config()
+
+    def tearDown(self):
+        reset_config()
+
+    def test_get_config_returns_instance(self):
+        cfg = get_config()
+        self.assertIsInstance(cfg, AnalysisConfig)
+
+    def test_get_config_returns_same_object(self):
+        self.assertIs(get_config(), get_config())
+
+    def test_set_config_replaces_singleton(self):
+        new_cfg = AnalysisConfig(overlap_allowance_fraction=0.05)
+        set_config(new_cfg)
+        self.assertIs(get_config(), new_cfg)
+        self.assertAlmostEqual(get_config().overlap_allowance_fraction, 0.05)
+
+    def test_reset_config_restores_defaults(self):
+        set_config(AnalysisConfig(overlap_allowance_fraction=0.99))
+        reset_config()
+        self.assertAlmostEqual(get_config().overlap_allowance_fraction, 0.01)
+
+    def test_reset_config_creates_new_object(self):
+        original = get_config()
+        reset_config()
+        self.assertIsNot(get_config(), original)
+
+
+class TestConfigBuilder(unittest.TestCase):
+    def setUp(self):
+        reset_config()
+
+    def tearDown(self):
+        reset_config()
+
+    def test_build_returns_analysis_config(self):
+        cfg = ConfigBuilder().build()
+        self.assertIsInstance(cfg, AnalysisConfig)
+
+    def test_overlap_allowance(self):
+        cfg = ConfigBuilder().overlap_allowance(0.05).build()
+        self.assertAlmostEqual(cfg.overlap_allowance_fraction, 0.05)
+
+    def test_server_lengthening(self):
+        cfg = ConfigBuilder().server_lengthening(1.10).build()
+        self.assertAlmostEqual(cfg.server_lengthening_factor, 1.10)
+
+    def test_enable_optimistic(self):
+        cfg = ConfigBuilder().enable_optimistic().build()
+        self.assertTrue(cfg.enable_optimistic_time_saved)
+
+    def test_enable_optimistic_false(self):
+        cfg = ConfigBuilder().enable_optimistic(False).build()
+        self.assertFalse(cfg.enable_optimistic_time_saved)
+
+    def test_enable_pessimistic(self):
+        cfg = ConfigBuilder().enable_pessimistic().build()
+        self.assertTrue(cfg.enable_pessimistic_time_saved)
+
+    def test_parallelism(self):
+        cfg = ConfigBuilder().parallelism(compute=8, io=2).build()
+        self.assertEqual(cfg.default_compute_parallelism, 8)
+        self.assertEqual(cfg.default_io_parallelism, 2)
+
+    def test_retry_config(self):
+        cfg = ConfigBuilder().retry_config(max_attempts=5, min_wait=2, max_wait=20, jitter=3).build()
+        self.assertEqual(cfg.max_retry_attempts, 5)
+        self.assertEqual(cfg.retry_min_wait_seconds, 2)
+        self.assertEqual(cfg.retry_max_wait_seconds, 20)
+        self.assertEqual(cfg.retry_jitter_max_seconds, 3)
+
+    def test_chaining(self):
+        cfg = (
+            ConfigBuilder()
+            .overlap_allowance(0.02)
+            .server_lengthening(1.05)
+            .enable_optimistic()
+            .parallelism(4, 1)
+            .build()
+        )
+        self.assertAlmostEqual(cfg.overlap_allowance_fraction, 0.02)
+        self.assertAlmostEqual(cfg.server_lengthening_factor, 1.05)
+        self.assertTrue(cfg.enable_optimistic_time_saved)
+        self.assertEqual(cfg.default_compute_parallelism, 4)
+
+
+class TestConvenienceFunctions(unittest.TestCase):
+    def setUp(self):
+        reset_config()
+
+    def tearDown(self):
+        reset_config()
+
+    def test_get_overlap_allowance_default(self):
+        self.assertAlmostEqual(get_overlap_allowance(), 0.01)
+
+    def test_get_overlap_allowance_after_set(self):
+        set_config(AnalysisConfig(overlap_allowance_fraction=0.07))
+        self.assertAlmostEqual(get_overlap_allowance(), 0.07)
+
+    def test_get_server_lengthening_factor_default(self):
+        self.assertAlmostEqual(get_server_lengthening_factor(), 1.01)
+
+    def test_get_server_lengthening_factor_after_set(self):
+        set_config(AnalysisConfig(server_lengthening_factor=1.20))
+        self.assertAlmostEqual(get_server_lengthening_factor(), 1.20)
+
+    def test_is_optimistic_enabled_default(self):
+        self.assertFalse(is_optimistic_enabled())
+
+    def test_is_optimistic_enabled_after_set(self):
+        set_config(AnalysisConfig(enable_optimistic_time_saved=True))
+        self.assertTrue(is_optimistic_enabled())
+
+    def test_is_pessimistic_enabled_default(self):
+        self.assertFalse(is_pessimistic_enabled())
+
+    def test_is_pessimistic_enabled_after_set(self):
+        set_config(AnalysisConfig(enable_pessimistic_time_saved=True))
+        self.assertTrue(is_pessimistic_enabled())


### PR DESCRIPTION
## Summary

- Ports `configuration.py` (152 lines): `AnalysisConfig` dataclass, global
  `get_config`/`set_config`/`reset_config` helpers, `ConfigBuilder` fluent API,
  and four convenience accessor functions. No imports outside stdlib.

- Ports `cli.py` with internal-only flags removed: `MainArgs` frozen dataclass,
  `_build_main_parser()`, and `parse_main_args()`. Nine flags present in the
  internal version are excluded because they depend on Uber-internal
  infrastructure that does not exist in OSS:

  | Removed flag | Reason |
  |---|---|
  | `--uploadToTB` / `--uploadToCrispRiTB` | TerraBlob (internal blob storage) |
  | `--uploadTar` / `--noOverwriteUpload` | Depended on TerraBlob flags |
  | `--useUSSO` | Uber Single Sign-On |
  | `--emitM3Metrics` / `--jobTag` | M3 (internal metrics system) |
  | `--ignoreCtfTests` | CTF (internal canary test framework) |
  | `--useParquet` | Routes to internal Parquet storage infrastructure |

- Adds `tests/test_configuration.py` (28 tests): internal had zero coverage;
  covers defaults, singleton lifecycle, `ConfigBuilder` fluent API, and all
  four convenience accessors with global-state isolation via
  `setUp`/`tearDown`.

- Ports `tests/test_cli.py` (2 tests): `test_parse_main_args_defaults` and
  `test_parse_main_args_overrides` ported verbatim minus assertions for the
  removed flags; only change is the import path (`uber.tooling...cli` →
  `crisp.cli`).

- Adds `services.yaml` minimal fixture (2 lines) at repo root, required by
  the CLI test's `--services-file` argument.

- Updates `crisp/BUILD.bazel` and root `BUILD.bazel` with `py_library` /
  `py_test` targets (with correct `visibility` and deps on the monolithic
  `pytest` target).

## Test plan

- [x] `bazel test //...` — all 3 targets pass (`pytest`, `test_cli`, `test_configuration`)
- [x] `grep -r "uber\." crisp/cli.py crisp/configuration.py` — empty
