### PR TITLE
port(crisp): add common.py — constants, Config, and pipeline helpers (PR 8a)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -33,6 +33,7 @@ py_test(
     deps = [
         ":crisp_lib",
         "//crisp:cli",
+        "//crisp:common",
         "//crisp:configuration",
         "//crisp:pkg",
         "@pypi//pytest",
@@ -53,5 +54,12 @@ py_test(
     srcs = ["tests/test_cli.py"],
     data = ["services.yaml"],
     deps = ["//crisp:cli"],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_common",
+    srcs = ["tests/test_common.py"],
+    deps = ["//crisp:common"],
     imports = ["."],
 )

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -29,3 +29,13 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [":configuration"],
 )
+
+py_library(
+    name = "common",
+    srcs = ["common.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crisp/shared:shared",
+        "@pypi//python_dateutil",
+    ],
+)

--- a/crisp/LAYERS.md
+++ b/crisp/LAYERS.md
@@ -76,3 +76,9 @@ When porting, apply this decision in order:
 | -------------------------------------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
 | `output/tests/test_csv_generators.py::TestGenCyclesCSVFile.*` (×2)   | PR 8a             | `@patch("...common.Config")` decorator; patch-target module `crisp.common` does not exist yet.        |
 | `output/tests/test_csv_generators.py::TestGenSummaryCSVFile.*` (×2)  | PR 8a             | Same as above. Helper `getDummyMetric` (uses `crisp.shared.models.Metrics`) returns with these tests. |
+| `tests/test_common.py::TbutilTestCase::test_downloadFromTerrablob`    | PR 8b             | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TbutilTestCase::test_uploadToTerrablob`        | PR 8b             | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TbutilTestCase::test_constructPathAndUploadToTerrablob` | PR 8b    | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TestGetTBClient.*` (×3)                        | PR 8b             | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TestDirExistsOnTB.*`                           | PR 8b             | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TestBlobExistsOnTB.*`                          | PR 8b             | TBClient not yet ported.                                                                              |

--- a/crisp/common.py
+++ b/crisp/common.py
@@ -1,0 +1,285 @@
+# ruff: noqa: I001
+import argparse
+import datetime
+import logging
+import multiprocessing as mp
+import os
+import re
+import time
+import traceback
+import typing
+from collections.abc import Callable
+
+import dateutil.tz
+
+from crisp.shared.constants import TAG_NAME, TAG_VALUE, TAG_SEARCH_DEPTH
+
+
+DEFAULT_TAGS = []
+TAG_YAML_VERSION = "1.0"
+TAG_KEYS = [TAG_NAME, TAG_VALUE, TAG_SEARCH_DEPTH]
+DEFAULT_TAG_SEARCH_DEPTH = 1
+DEFAULT_TAG = {
+    TAG_NAME: "*",
+    TAG_VALUE: "*",
+    TAG_SEARCH_DEPTH: DEFAULT_TAG_SEARCH_DEPTH,
+}
+DISK_CHECK_FREQUENCY = 1000
+MAX_DOWNLOAD_RETRY = 2
+MAX_TRACE_PER_QUERY = 1000
+
+# generated csv file names
+SUMMARY_CSV = "summary.csv"
+HYPO_LATENCY_CSV = "hypoLatency.csv"
+TRACE_STATS_CSV = "traceStats.csv"
+ERROR_DEPTH_CSV = "errDepth.csv"
+PERCENT_ERROR_DEPTH_CSV = "percentErrDepth.csv"
+SELF_ERROR_DEPTH_TO_NUM_TRACES_CSV = "selfErrDepthToNumTraces.csv"
+PERCENT_SELF_ERROR_DEPTH_TO_NUM_TRACES_CSV = "percentSelfErrDepthToNumTraces.csv"
+MAX_ERROR_DEPTH_PROP_TO_ROOT_TO_NUM_TRACES_CSV = "maxErrDepthPropToRootToNumTraces.csv"
+PERCENT_MAX_ERROR_DEPTH_PROP_TO_ROOT_TO_NUM_TRACES_CSV = (
+    "percentMaxErrDepthPropToRootToNumTraces.csv"
+)
+ERROR_PROP_LENGTH_CSV = "errPropLength.csv"
+RESILIENCY_CSV = "resiliency.csv"
+PERCENT_ERROR_CSV = "percentError.csv"
+SAVING_POTENTIAL_CSV = "savingPotential.csv"
+PER_TRACE_ERR_INFO_CSV = "perTraceErrInfo.csv"
+CYCLES_CSV = "cycles.csv"
+CROSS_REGION_CALLS_CSV = "crossRegionCalls.csv"
+
+# various header names used in generated CSV files
+PRORP_TO_ROOT = "PropToRoot"
+NOT_PRORP_TO_ROOT = "NotPropToRoot"
+PRORP_TO_ROOT_ON_CP = "PropToRootOnCP"
+NOT_PRORP_TO_ROOT_ON_CP = "NotPropToRootOnCP"
+SUPRESSED_ERR = "SupressedErr"
+SUPRESSED_ERR_ON_CP = "SupressedErrOnCP"
+METRIC_COL = "metric"
+ROOT_HAS_ERR_COL = "hasRootErr"
+HAS_ROOT_ERR = "1"
+NO_ROOT_ERR = "0"
+TRACE_COL = "trace"
+TRACE_TYPE_COL = "traceType"
+WORK_COL = "work"
+WORK_SAVED_COL = "workSaved"
+PERCENT_WORK_SAVED_COL = "%workSaved"
+LATENCY_COL = "latency"
+TIME_SAVED_ON_CP_COL = "timeSavedOnCP"
+PERCENT_LATENCY_SAVED_COL = "%latencySaved"
+NUM_CP_ERRORS_COL = "#CPErrors"
+PERCENT_CP_ERRORS_COL = "%CPErrors"
+NUM_CONNECTED_TO_CP_ERRORS_COL = "#connectedToCPErrors"
+PERCENT_CONNECTED_TO_CP_ERRORS_COL = "%connectToCPErrors"
+NUM_ERRORS_COL = "#errors"
+PERCENT_ERRORS_COL = "%errors"
+NUM_NODES_ON_CP_COL = "#nodesOnCP"
+NUM_NODES_COL = "#nodes"
+MAX_DEPTH_COL = "maxDepth"
+NUM_SELF_ERRORS_COL = "#selfErrors"
+MAX_ERR_DEPTH_PROP_TO_ROOT_COL = "maxErrDepthPropagatedToRoot"
+PERCENT_MAX_ERR_DEPTH_PROP_TO_ROOT_COL = "%maxErrDepthPropagatedToRoot"
+MIN_DEPTH_NON_ROOT_SELF_ERRORS_COL = "minDepthNonRootSelfErrors"
+MAX_DEPTH_NON_ROOT_SELF_ERRORS_COL = "maxDepthNonRootSelfErrors"
+P50_DEPTH_NON_ROOT_SELF_ERRORS_COL = "p50DepthNonRootSelfErrors"
+P90_DEPTH_NON_ROOT_SELF_ERRORS_COL = "p90DepthNonRootSelfErrors"
+P95_DEPTH_NON_ROOT_SELF_ERRORS_COL = "p95DepthNonRootSelfErrors"
+P99_DEPTH_NON_ROOT_SELF_ERRORS_COL = "p99DepthNonRootSelfErrors"
+MIN_PERCENT_DEPTH_NON_ROOT_SELF_ERRORS_COL = "min%DepthNonRootSelfErrors"
+P50_PERCENT_DEPTH_NON_ROOT_SELF_ERRORS_COL = "p50%DepthNonRootSelfErrors"
+P90_PERCENT_DEPTH_NON_ROOT_SELF_ERRORS_COL = "p90%DepthNonRootSelfErrors"
+P95_PERCENT_DEPTH_NON_ROOT_SELF_ERRORS_COL = "p95%DepthNonRootSelfErrors"
+P99_PERCENT_DEPTH_NON_ROOT_SELF_ERRORS_COL = "p99%DepthNonRootSelfErrors"
+MAX_PERCENT_DEPTH_NON_ROOT_SELF_ERRORS_COL = "max%DepthNonRootSelfErrors"
+
+DEPTH_COL = "depth"
+PERCENT_DEPTH_COL = "%depth"
+PROPAGATION_LENGTH_COL = "propagationLength"
+NUM_PROPAGATED_ERRORS_COL = "#propagatedErrors"
+NUM_STOPPED_ERRORS_COL = "#stoppedErrors"
+OP_NAME_COL = "opName"
+RESILIENCY_COL = "resiliency"
+NUM_TRACES_COL = "#traces"
+NUM_TRACES_FOR_MIN_COL = "#tracesForMin"
+NUM_TRACES_FOR_MAX_COL = "#tracesForMax"
+NUM_TRACES_FOR_P50_COL = "#tracesForP50"
+NUM_TRACES_FOR_P90_COL = "#tracesForP90"
+NUM_TRACES_FOR_P95_COL = "#tracesForP95"
+NUM_TRACES_FOR_P99_COL = "#tracesForP99"
+NUM_TRACES_FOR_CP_ERRORS_COL = "#tracesForCPErrors"
+NUM_TRACES_FOR_CONNECTED_TO_CP_ERRORS_COL = "#tracesForConnectedToCPErrors"
+POTENTIAL_SAVING_COL = "potentialSaving"
+NUM_OP_COL = "#ops"
+PERCENTILE_COL = "percentile"
+# TODO: UPDATE ME
+LATENCY_REDUCTION_COL = "latency_reduction"
+
+NON_TEST_TRACES_STATS_TAG = "statsAcrossNonTestTraces"
+ROOT_ERROR_TRACES_STATS_TAG = "statsAcrossRootErrTraces"
+NON_ROOT_ERROR_TRACES_STATS_TAG = "statsAcrossNonRootErrTraces"
+
+
+class Config:
+    def __init__(
+        self,
+        operationName: str = "",
+        serviceName: str = "",
+        tags: list = DEFAULT_TAGS,
+        output: str = "traces",
+        numTrace: int = 1000,
+        ioParallelism: int = 1,
+        computeParallelism: int = 1,
+        lookbackDays: int = 1,
+        startTimestamp: typing.Optional[int] = None,
+        endTimestamp: typing.Optional[int] = None,
+        ignoreLastNMinutes: int = 10,
+        timeoutSec: int = 60,
+        useMidnightTime: bool = False,
+        rootTrace: bool = False,
+        anonymize: bool = False,
+        inputDir: str = "traces",
+        filterProxy: bool = False,
+        file: typing.Optional[argparse.FileType] = None,
+        topN: int = 5,
+        numHMTrace: int = 100,
+        numOperation: int = 100,
+        tracesDir: str = "traces",
+        downloadRetry: int = 10,
+        diskFreeWaitTime: int = 60,
+        diskRequirement: int = 5,
+        doRanges: bool = False,
+        endpointDiskGBLimit: int = 500,
+        dryRun: bool = False,
+        exclusionSet: typing.Optional[set] = None,
+        qps: int = 500,
+        numShards: int = 1,
+        shardId: int = 0,
+        errorAnalysis: bool = False,
+        deltaMicroSec: int = 0,
+        deltaTargetService: typing.Optional[str] = None,
+        deltaTargetOperation: typing.Optional[str] = None,
+        lightMode: bool = False,
+        mergeAllRoots: bool = True,
+        maxExemplars: int = 3,
+    ):
+        self.operationName = operationName
+        self.serviceName = serviceName
+        self.tags = tags
+        self.output = output
+        self.numTrace = numTrace
+        self.ioParallelism = ioParallelism
+        self.computeParallelism = computeParallelism
+        self.lookbackDays = lookbackDays
+        self.ignoreLastNMinutes = ignoreLastNMinutes
+        self.timeoutSec = timeoutSec
+        self.useMidnightTime = useMidnightTime
+        self.rootTrace = rootTrace
+        self.anonymize = anonymize
+        self.inputDir = inputDir
+        self.filterProxy = filterProxy
+        self.file = file
+        self.topN = topN
+        self.numHMTrace = numHMTrace
+        self.numOperation = numOperation
+        self.jaegerTraceFiles = []
+        self.tracesDir = tracesDir
+        self.filesToUpload = None
+        self.traceIDs = []
+        self.downloadRetry = downloadRetry
+        self.failed = False
+        self.failedLog = []
+        self.diskFreeWaitTime = diskFreeWaitTime
+        self.diskRequirement = diskRequirement
+        self.doRanges = doRanges
+        self.endpointDiskGBLimit = endpointDiskGBLimit
+        self.dryRun = dryRun
+        self.exclusionSet = exclusionSet if exclusionSet else set()
+        self.qps = qps
+        self.numShards = numShards
+        self.shardId = shardId
+        self.callsPerWorker = max(
+            1,
+            int(self.qps / (self.ioParallelism * self.numShards)),
+        )
+        self.errorAnalysis = errorAnalysis
+        self.lightMode = lightMode
+        self.mergeAllRoots = mergeAllRoots
+        self.maxExemplars = maxExemplars
+        # Compute the start and end UTC times for trace query.
+        initialTimeStamp = getMidnightTimeStamp() if self.useMidnightTime else time.time() * 1000 * 1000
+        self.startTimestamp = int(initialTimeStamp - (self.lookbackDays * 24 * 60 * 60) * 1000 * 1000) if not startTimestamp else startTimestamp
+        self.endTimestamp = int(initialTimeStamp - (self.ignoreLastNMinutes * 60) * 1000 * 1000) if not endTimestamp else endTimestamp
+        self.deltaMicroSec = deltaMicroSec
+        self.deltaTargetService = deltaTargetService
+        self.deltaTargetOperation = deltaTargetOperation
+
+    @property
+    def projectionEnabled(self) -> bool:
+        return self.deltaTargetService is not None and self.deltaTargetOperation is not None
+
+    def getOutputDir(self):
+        if self.file:
+            return os.path.dirname(self.file.name)
+        return self.tracesDir
+
+
+class PipelinePhase:
+    def __init__(
+        self,
+        name: str,
+        func: Callable[[Config, mp.Queue], None],
+        blocking: bool,
+    ):
+        self.name = name
+        self.func = func
+        self.blocking = blocking
+
+
+def templateHandler(
+    message: str,
+    realHandler: Callable[[Config], None],
+    preStart: Callable[[Config], None],
+    postFinish: Callable[[Config], None],
+    c: Config,
+    resultQ: mp.Queue,
+) -> Config:
+    logging.info(f"{message} for {c.serviceName}::{c.operationName}")
+    try:
+        if not c.failed:
+            if preStart:
+                preStart(c)
+            realHandler(c)
+            if postFinish:
+                postFinish(c)
+        else:
+            logging.info(f"Skipping {message} for {c.serviceName}::{c.operationName}")
+    except Exception as ex:
+        exceptionStr = "".join(traceback.TracebackException.from_exception(ex).format())
+        logging.warning(exceptionStr)
+        c.failedLog.append(exceptionStr)
+        c.failedLog.append(f"{message} failed for {c.serviceName}::{c.operationName}")
+        c.failed = True
+    if resultQ:
+        resultQ.put(c)
+        resultQ.close()
+
+    logging.info(f"Finished {message} for {c.serviceName}::{c.operationName}")
+    return c
+
+
+def replaceNonAlphaNumericWithUnderscore(str):
+    return re.sub("[^a-zA-Z0-9_]+", "_", str)
+
+
+def getMidnightTimeStamp():
+    midnight = (
+        datetime.datetime.now(dateutil.tz.gettz("UTC"))
+        .replace(hour=0, minute=0, second=0, microsecond=0)
+        .astimezone(dateutil.tz.tzutc())
+    )
+    return midnight.timestamp() * 1000 * 1000
+
+
+# Helper function to convert signed int to hex string
+def intToHexString(value):
+    return value.to_bytes(8, byteorder='big', signed=True).hex()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,24 +1,17 @@
 import time
-import os
-import sys
 from unittest import TestCase, mock
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-import common as common
+import crisp.common as common
 
 
 class CommonTestCase(TestCase):
     def test_templateHandler(self):
         def realHandler(c):
             pass
-
         def preStart(c):
             pass
-
         def postFinish(c):
             pass
-
         c = common.Config()
         resultQ = mock.MagicMock()
         common.templateHandler("message", realHandler, preStart, postFinish, c, resultQ)
@@ -26,216 +19,127 @@ class CommonTestCase(TestCase):
         resultQ.close.assert_called_once()
 
 
-# Test cases for MetricVals class
-class TestMetricVals(TestCase):
-    def test_addition(self):
-        metric1 = common.MetricVals(1, 2, 3, 100)
-        metric2 = common.MetricVals(4, 5, 6, 200)
-        result = metric1 + metric2
-        self.assertEqual(result.inc, 5)
-        self.assertEqual(result.excl, 7)
-        self.assertEqual(result.freq, 9)
-
-    def test_in_place_addition(self):
-        metric = common.MetricVals(1, 2, 3, 100)
-        metric += common.MetricVals(4, 5, 6, 200)
-        self.assertEqual(metric.inc, 5)
-        self.assertEqual(metric.excl, 7)
-        self.assertEqual(metric.freq, 9)
-
-    def test_floordiv(self):
-        metric = common.MetricVals(10, 20, 30, 100)
-        result = metric // 2
-        self.assertEqual(result.inc, 5)
-        self.assertEqual(result.excl, 10)
-        self.assertEqual(result.freq, 15)
-
-    def test_in_place_floordiv(self):
-        metric = common.MetricVals(10, 20, 30, 100)
-        metric //= 2
-        self.assertEqual(metric.inc, 5)
-        self.assertEqual(metric.excl, 10)
-        self.assertEqual(metric.freq, 15)
-
-
-# Test cases for CallPathProfile class
-class TestCallPathProfile(TestCase):
-    def setUp(self):
-        self.metric1 = common.MetricVals(1, 2, 3, 100)
-        self.metric2 = common.MetricVals(4, 5, 6, 200)
-        self.profile1 = common.CallPathProfile({"path1": self.metric1}, 2, 1)
-        self.profile2 = common.CallPathProfile({"path2": self.metric2}, 3, 2)
-
-    def test_get_normalized(self):
-        result = self.profile1.GetNormalized()
-        self.assertEqual(result["path1"].inc, 0)
-        self.assertEqual(result["path1"].excl, 1)
-        self.assertEqual(result["path1"].freq, 1)
-
-    def test_normalize(self):
-        self.profile1.Normalize()
-        self.assertEqual(self.profile1.profile["path1"].inc, 0)
-        self.assertEqual(self.profile1.profile["path1"].excl, 1)
-        self.assertEqual(self.profile1.profile["path1"].freq, 1)
-
-    def test_normalize_field(self):
-        self.profile1.NormalizeField("inc")
-        self.assertEqual(self.profile1.profile["path1"].inc, 0)
-
-    def test_upsert_existing(self):
-        self.profile1.Upsert("path1", common.MetricVals(1, 1, 1, 300))
-        self.assertEqual(self.profile1.profile["path1"].inc, 2)
-        self.assertEqual(self.profile1.profile["path1"].excl, 3)
-        self.assertEqual(self.profile1.profile["path1"].freq, 4)
-
-    def test_upsert_new(self):
-        self.profile1.Upsert("path3", common.MetricVals(1, 1, 1, 300))
-        self.assertEqual(self.profile1.profile["path3"].inc, 1)
-        self.assertEqual(self.profile1.profile["path3"].excl, 1)
-        self.assertEqual(self.profile1.profile["path3"].freq, 1)
-
-    def test_add_profiles(self):
-        result = self.profile1 + self.profile2
-        self.assertIn("path1", result.profile)
-        self.assertIn("path2", result.profile)
-        self.assertEqual(result.count, 5)
-
-    def test_in_place_add_profiles(self):
-        self.profile1 += self.profile2
-        self.assertIn("path1", self.profile1.profile)
-        self.assertIn("path2", self.profile1.profile)
-        self.assertEqual(self.profile1.count, 5)
-
-
-class TestGetLeafNodeFromCallPath(TestCase):
-    def test_regular_path(self):
-        path = "node1->node2->node3"
-        result = common.getLeafNodeFromCallPath(path)
-        self.assertEqual(result, "node3")
-
-    def test_single_node_path(self):
-        path = "singleNode"
-        result = common.getLeafNodeFromCallPath(path)
-        self.assertEqual(result, "singleNode")
-
-    def test_empty_string(self):
-        path = ""
-        result = common.getLeafNodeFromCallPath(path)
-        self.assertEqual(result, "")
-
-
 class TbutilTestCase(TestCase):
     def test_replaceNonAlphaNumericWithUnderscore(self):
-        res = common.replaceNonAlphaNumericWithUnderscore("Service::OperationName")
-        self.assertEqual(res, "Service_OperationName")
-        res = common.replaceNonAlphaNumericWithUnderscore("api-group1-service")
-        self.assertEqual(res, "api_group1_service")
-        res = common.replaceNonAlphaNumericWithUnderscore(
-            "/users/:userID/v1/action",
-        )
-        self.assertEqual(res, "_users_userID_v1_action")
-        res = common.replaceNonAlphaNumericWithUnderscore(
-            "presentation.handler.process-task",
-        )
-        self.assertEqual(res, "presentation_handler_process_task")
-
-    def test_downloadFromTerrablob(self):
-        with mock.patch("common.TBClient") as tb_client_mock:
-            tb_client_obj = tb_client_mock.return_value
-            tb_client_obj.download_file_from_tb.return_value = "temp/folder/file.csv"
-            res = common.downloadFromTerrablob("remote_file.csv", "temp/folder/file.csv")
-            self.assertEqual(res, "temp/folder/file.csv")
-            tb_client_obj.download_file_from_tb.assert_called_once_with(
-                tb_file_path="remote_file.csv",
-                local_file_path="temp/folder/file.csv",
-            )
-
-    @mock.patch("common.TBClient")
-    def test_uploadToTerrablob(self, tb_client_mock):
-        tb_client_obj = tb_client_mock.return_value
-        tb_client_obj.upload_file_to_tb.return_value = "/example/path/data/2023_01_01/file.csv"
-
-        res = common.uploadToTerrablob(
-            "local/folder/file.csv",
-            "/example/path/data/2023_01_01",
-        )
-
-        self.assertEqual(res, "/example/path/data/2023_01_01/file.csv")
-        tb_client_obj.upload_file_to_tb.assert_called_once_with(
-            tb_file_path="/example/path/data/2023_01_01/file.csv",
-            local_file_path="local/folder/file.csv",
-        )
-
-    @mock.patch("common.TBClient")
-    def test_constructPathAndUploadToTerrablob(self, tb_client_mock):
-        tb_client_obj = tb_client_mock.return_value
-        tb_client_obj.upload_file_to_tb.side_effect = [
-            "/example/path/data/service/Service_renderMetrics/2023_01_01/file.csv",
-            "/example/path/data/service/Service_renderMetrics/latest/file.csv",
-            "/example/alternative_path/data/service/Service_renderMetrics/2023_01_01/file.csv",
-        ]
-
-        tbPath, latestTbPath = common.constructPathAndUploadToTerrablob(
-            "/example/path/data",
-            "service",
-            "Service::renderMetrics",
-            "local/folder/file.csv",
-            "2023_01_01",
-            publishAsLatest=True,
-        )
-
-        self.assertEqual(tbPath, "/example/path/data/service/Service_renderMetrics/2023_01_01/file.csv")
-        self.assertEqual(latestTbPath, "/example/path/data/service/Service_renderMetrics/latest/file.csv")
-
-        tbPath, latestTbPath = common.constructPathAndUploadToTerrablob(
-            "/example/alternative_path/data",
-            "service",
-            "Service::renderMetrics",
-            "local/folder/file.csv",
-            "2023_01_01",
-            publishAsLatest=False,
-        )
-        self.assertEqual(tbPath, "/example/alternative_path/data/service/Service_renderMetrics/2023_01_01/file.csv")
-        self.assertIsNone(latestTbPath)
+        res = common.replaceNonAlphaNumericWithUnderscore("Bloc::renderTemplate")
+        assert res == "Bloc_renderTemplate"
+        res = common.replaceNonAlphaNumericWithUnderscore("my-service-group1")
+        assert res == "my_service_group1"
+        res = common.replaceNonAlphaNumericWithUnderscore("/api/:resourceId/v2/action")
+        assert res == "_api_resourceId_v2_action"
+        res = common.replaceNonAlphaNumericWithUnderscore("my-service.my-operation")
+        assert res == "my_service_my_operation"
 
 
 class GetMidnightTimestampTestCase(TestCase):
     def test_getMidnightTimeStamp(self):
         assert time.time() * 1000 * 1000 >= common.getMidnightTimeStamp()
 
-class TestIntToHexString(TestCase):
 
+class TestIntToHexString(TestCase):
     def test_positive_value(self):
-        # Test a positive integer
-        value = 1234567890
-        expected_hex = '00000000499602d2'  # Expected hex string for the positive value
-        result = common.intToHexString(value)
-        self.assertEqual(result, expected_hex)
+        result = common.intToHexString(1234567890)
+        self.assertEqual(result, '00000000499602d2')
 
     def test_negative_value(self):
-        # Test a negative integer
-        value = -1234567890
-        expected_hex = 'ffffffffb669fd2e'  # Expected hex string for the negative value
-        result = common.intToHexString(value)
-        self.assertEqual(result, expected_hex)
+        result = common.intToHexString(-1234567890)
+        self.assertEqual(result, 'ffffffffb669fd2e')
 
     def test_zero_value(self):
-        # Test zero
-        value = 0
-        expected_hex = '0000000000000000'  # Expected hex string for zero
-        result = common.intToHexString(value)
-        self.assertEqual(result, expected_hex)
+        result = common.intToHexString(0)
+        self.assertEqual(result, '0000000000000000')
 
     def test_max_positive_value(self):
-        # Test the maximum positive 64-bit signed integer
-        value = 9223372036854775807
-        expected_hex = '7fffffffffffffff'  # Expected hex string for the maximum positive value
-        result = common.intToHexString(value)
-        self.assertEqual(result, expected_hex)
+        result = common.intToHexString(9223372036854775807)
+        self.assertEqual(result, '7fffffffffffffff')
 
     def test_max_negative_value(self):
-        # Test the maximum negative 64-bit signed integer
-        value = -9223372036854775808
-        expected_hex = '8000000000000000'  # Expected hex string for the maximum negative value
-        result = common.intToHexString(value)
-        self.assertEqual(result, expected_hex)
+        result = common.intToHexString(-9223372036854775808)
+        self.assertEqual(result, '8000000000000000')
+
+
+class TestConfig(TestCase):
+    def test_default_field_values(self):
+        c = common.Config()
+        self.assertEqual(c.operationName, "")
+        self.assertEqual(c.serviceName, "")
+        self.assertEqual(c.numTrace, 1000)
+        self.assertEqual(c.ioParallelism, 1)
+        self.assertEqual(c.computeParallelism, 1)
+        self.assertEqual(c.lookbackDays, 1)
+        self.assertEqual(c.topN, 5)
+        self.assertEqual(c.numHMTrace, 100)
+        self.assertEqual(c.numOperation, 100)
+        self.assertEqual(c.diskRequirement, 5)
+        self.assertFalse(c.doRanges)
+        self.assertFalse(c.dryRun)
+        self.assertTrue(c.mergeAllRoots)
+        self.assertEqual(c.maxExemplars, 3)
+
+    def test_callsPerWorker_default(self):
+        c = common.Config()
+        # max(1, int(500 / (1 * 1))) == 500
+        self.assertEqual(c.callsPerWorker, 500)
+
+    def test_callsPerWorker_custom(self):
+        c = common.Config(qps=100, ioParallelism=2, numShards=5)
+        # max(1, int(100 / (2 * 5))) == max(1, 10) == 10
+        self.assertEqual(c.callsPerWorker, 10)
+
+    def test_projectionEnabled_false_when_none(self):
+        c = common.Config()
+        self.assertFalse(c.projectionEnabled)
+
+    def test_projectionEnabled_false_when_only_service(self):
+        c = common.Config(deltaTargetService="svc")
+        self.assertFalse(c.projectionEnabled)
+
+    def test_projectionEnabled_true_when_both_set(self):
+        c = common.Config(deltaTargetService="svc", deltaTargetOperation="op")
+        self.assertTrue(c.projectionEnabled)
+
+    def test_getOutputDir_returns_tracesDir_when_file_none(self):
+        c = common.Config(tracesDir="my_traces")
+        self.assertEqual(c.getOutputDir(), "my_traces")
+
+    def test_getOutputDir_returns_dirname_when_file_set(self):
+        fake_file = mock.MagicMock()
+        fake_file.name = "/some/dir/traces.json"
+        c = common.Config(file=fake_file)
+        self.assertEqual(c.getOutputDir(), "/some/dir")
+
+    def test_timestamps_auto_computed(self):
+        c = common.Config()
+        self.assertIsInstance(c.startTimestamp, int)
+        self.assertIsInstance(c.endTimestamp, int)
+        self.assertGreater(c.startTimestamp, 0)
+        self.assertGreater(c.endTimestamp, 0)
+
+    def test_timestamps_explicit(self):
+        c = common.Config(startTimestamp=1000, endTimestamp=2000)
+        self.assertEqual(c.startTimestamp, 1000)
+        self.assertEqual(c.endTimestamp, 2000)
+
+    def test_removed_fields_not_present(self):
+        c = common.Config()
+        self.assertFalse(hasattr(c, 'useUSSO'))
+        self.assertFalse(hasattr(c, 'uploadToTB'))
+        self.assertFalse(hasattr(c, 'uploadToCrispRiTB'))
+        self.assertFalse(hasattr(c, 'uploadTar'))
+        self.assertFalse(hasattr(c, 'noOverwriteUpload'))
+        self.assertFalse(hasattr(c, 'ignoreCtfTests'))
+        self.assertFalse(hasattr(c, 'enableM3Metrics'))
+        self.assertFalse(hasattr(c, 'jobTag'))
+        self.assertFalse(hasattr(c, 'useParquet'))
+        self.assertFalse(hasattr(c, 'jaegerOfflineToken'))
+        self.assertFalse(hasattr(c, 'terrablobOfflineToken'))
+        self.assertFalse(hasattr(c, 'serviceMode'))
+        self.assertFalse(hasattr(c, 'zone'))
+
+    def test_unconditional_instance_vars(self):
+        c = common.Config()
+        self.assertEqual(c.jaegerTraceFiles, [])
+        self.assertIsNone(c.filesToUpload)
+        self.assertEqual(c.traceIDs, [])
+        self.assertFalse(c.failed)
+        self.assertEqual(c.failedLog, [])


### PR DESCRIPTION
## Summary

Ports the OSS-safe subset of internal `common.py` (686 lines) into
`crisp/common.py` (~285 lines). All Uber-internal infrastructure dependencies
(TerraBlob, M3, USSO) are excluded; the TB helper functions and M3 emit
functions are deferred to PR 8b.

### What's included

**Constants** — verbatim from internal:
- Algorithm constants: `DEFAULT_TAGS`, `TAG_YAML_VERSION`, `DEFAULT_TAG`,
  `DISK_CHECK_FREQUENCY`, `MAX_DOWNLOAD_RETRY`, `MAX_TRACE_PER_QUERY`
- All CSV output filename constants (`SUMMARY_CSV` … `CROSS_REGION_CALLS_CSV`)
- All CSV column-header constants (`METRIC_COL` … `LATENCY_REDUCTION_COL`)
- Trace-stats tag strings (`NON_TEST_TRACES_STATS_TAG`, etc.)
- `TAG_NAME` / `TAG_VALUE` / `TAG_SEARCH_DEPTH` imported from
  `crisp.shared.constants` (promoted in PR 7a)

**Constants excluded** (internal infra only):
- `PARQUET_FILE_NAME` — internal Parquet storage
- `CRISP_LOCAL_NAME/PORT/CI_AGENT`, `APPLICATION_IDENTIFIER/ENVIRONMENT`,
  `BASE_SERVICE_TB_PATH`, TB folder constants — TerraBlob deployment config
- `AUTOFLUSH_INTERVAL_MS`, all `M3_*` constants and histogram bucket
  definitions, `M3Singleton` — M3 metrics system

**`Config` class** — ported with 13 internal params removed:

| Removed param | Reason |
|---|---|
| `useUSSO` | USSO (Uber SSO) |
| `uploadToTB` / `uploadToCrispRiTB` | TerraBlob |
| `uploadTar` / `noOverwriteUpload` | Depended on TerraBlob flags |
| `ignoreCtfTests` | CTF (internal canary test framework) |
| `enableM3Metrics` / `jobTag` | M3 metrics system |
| `useParquet` | Internal Parquet storage |
| `jaegerOfflineToken` / `terrablobOfflineToken` | Internal auth tokens |
| `serviceMode` | Internal service-mode deployment flag |
| `zone` | Internal routing zone |

Default values for `operationName` and `serviceName` changed from hardcoded
internal Uber service identifiers to `""`.

**`PipelinePhase`** — verbatim.

**Functions included** (verbatim):
- `templateHandler`, `replaceNonAlphaNumericWithUnderscore`,
  `getMidnightTimeStamp`, `intToHexString`

**Functions excluded** (deferred to PR 8b):
- `serviceOperationToTBPath`, `getTBClient`, `dirExistsOnTB`,
  `blobExistsOnTB`, `downloadFromTerrablob`, `uploadToTerrablob`,
  `constructPathAndUploadToTerrablob`, `getM3Client`, `emitDurationMetric`,
  `emitNonTransitiveMetrics`, `emitTransitiveMetric`, `getServiceOperationTags`

### Tests (`tests/test_common.py`)

4 test classes ported verbatim (import path changed only):
- `CommonTestCase::test_templateHandler`
- `TbutilTestCase::test_replaceNonAlphaNumericWithUnderscore`
- `GetMidnightTimestampTestCase::test_getMidnightTimeStamp`
- `TestIntToHexString` (5 tests)

New `TestConfig` class (13 tests, internal had zero Config coverage):
defaults, `callsPerWorker` computation, `projectionEnabled` property,
`getOutputDir`, timestamp auto-compute, removed-field assertions.

6 TB-dependent test classes deferred to PR 8b and recorded in `crisp/LAYERS.md`.

## Test plan

- [x] `bazel test //...` — all targets pass (including new `test_common`)
- [x] `grep -rn "uber\." crisp/common.py tests/test_common.py` — empty
