### PR TITLE
port(crisp): add path helper and service-operation tags to common.py (PR 8b)

### DIFF
--- a/crisp/LAYERS.md
+++ b/crisp/LAYERS.md
@@ -76,9 +76,9 @@ When porting, apply this decision in order:
 | -------------------------------------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
 | `output/tests/test_csv_generators.py::TestGenCyclesCSVFile.*` (×2)   | PR 8a             | `@patch("...common.Config")` decorator; patch-target module `crisp.common` does not exist yet.        |
 | `output/tests/test_csv_generators.py::TestGenSummaryCSVFile.*` (×2)  | PR 8a             | Same as above. Helper `getDummyMetric` (uses `crisp.shared.models.Metrics`) returns with these tests. |
-| `tests/test_common.py::TbutilTestCase::test_downloadFromTerrablob`    | PR 8b             | TBClient not yet ported.                                                                              |
-| `tests/test_common.py::TbutilTestCase::test_uploadToTerrablob`        | PR 8b             | TBClient not yet ported.                                                                              |
-| `tests/test_common.py::TbutilTestCase::test_constructPathAndUploadToTerrablob` | PR 8b    | TBClient not yet ported.                                                                              |
-| `tests/test_common.py::TestGetTBClient.*` (×3)                        | PR 8b             | TBClient not yet ported.                                                                              |
-| `tests/test_common.py::TestDirExistsOnTB.*`                           | PR 8b             | TBClient not yet ported.                                                                              |
-| `tests/test_common.py::TestBlobExistsOnTB.*`                          | PR 8b             | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TbutilTestCase::test_downloadFromTerrablob`    | PR 11             | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TbutilTestCase::test_uploadToTerrablob`        | PR 11             | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TbutilTestCase::test_constructPathAndUploadToTerrablob` | PR 11    | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TestGetTBClient.*` (×3)                        | PR 11             | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TestDirExistsOnTB.*`                           | PR 11             | TBClient not yet ported.                                                                              |
+| `tests/test_common.py::TestBlobExistsOnTB.*`                          | PR 11             | TBClient not yet ported.                                                                              |

--- a/crisp/common.py
+++ b/crisp/common.py
@@ -283,3 +283,23 @@ def getMidnightTimeStamp():
 # Helper function to convert signed int to hex string
 def intToHexString(value):
     return value.to_bytes(8, byteorder='big', signed=True).hex()
+
+
+def serviceOperationToTBPath(service, operation, blobPath, suffix):
+    return os.path.join(
+        blobPath,
+        replaceNonAlphaNumericWithUnderscore(service),
+        replaceNonAlphaNumericWithUnderscore(operation),
+        suffix,
+    )
+
+
+SERVICE_TAG_NAME = "service_name"
+OPERATION_TAG_NAME = "operation_name"
+
+
+def getServiceOperationTags(config: "Config") -> dict[str, str]:
+    return {
+        SERVICE_TAG_NAME: replaceNonAlphaNumericWithUnderscore(config.serviceName),
+        OPERATION_TAG_NAME: replaceNonAlphaNumericWithUnderscore(config.operationName),
+    }

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -143,3 +143,31 @@ class TestConfig(TestCase):
         self.assertEqual(c.traceIDs, [])
         self.assertFalse(c.failed)
         self.assertEqual(c.failedLog, [])
+
+
+class TestServiceOperationToTBPath(TestCase):
+    def test_basic(self):
+        result = common.serviceOperationToTBPath(
+            "my-service", "MyService::doThing", "/output", "2024_01_01"
+        )
+        self.assertEqual(result, "/output/my_service/MyService_doThing/2024_01_01")
+
+    def test_latest_suffix(self):
+        result = common.serviceOperationToTBPath(
+            "my-service", "MyService::doThing", "/output", "latest"
+        )
+        self.assertEqual(result, "/output/my_service/MyService_doThing/latest")
+
+
+class TestGetServiceOperationTags(TestCase):
+    def test_returns_correct_keys(self):
+        c = common.Config(serviceName="my-service", operationName="MyService::doThing")
+        tags = common.getServiceOperationTags(c)
+        self.assertEqual(tags[common.SERVICE_TAG_NAME], "my_service")
+        self.assertEqual(tags[common.OPERATION_TAG_NAME], "MyService_doThing")
+
+    def test_default_config(self):
+        c = common.Config()
+        tags = common.getServiceOperationTags(c)
+        self.assertIn(common.SERVICE_TAG_NAME, tags)
+        self.assertIn(common.OPERATION_TAG_NAME, tags)


### PR DESCRIPTION
## Summary

Adds the two remaining OSS-safe helpers from internal `common.py` that were
deferred from PR 8a, and updates the deferred-tests table in `LAYERS.md`.

### Changes

**`crisp/common.py`** — three additions:
- `SERVICE_TAG_NAME = "service_name"` and `OPERATION_TAG_NAME = "operation_name"`
  constants (replacing the internal `M3_SERVICE_TAG_NAME` / `M3_OPERATION_TAG_NAME`
  names that were tied to the M3 metrics system)
- `serviceOperationToTBPath(service, operation, blobPath, suffix)` — builds a
  filesystem path by sanitising service and operation names with
  `replaceNonAlphaNumericWithUnderscore`; no TerraBlob dependency, just `os.path.join`
- `getServiceOperationTags(config)` — returns `{SERVICE_TAG_NAME: ...,
  OPERATION_TAG_NAME: ...}` using the same sanitiser; useful to any caller that
  needs a stable string key for a service/operation pair

**What's still excluded** (no change from PR 8a):
- All TB functions (`getTBClient`, `downloadFromTerrablob`, etc.) — deferred to
  PR 11 when `crisp.tb_client` is ported
- All M3 emit functions (`emitDurationMetric`, `emitNonTransitiveMetrics`,
  `emitTransitiveMetric`, `getM3Client`) — dropped entirely (internal-only)

**`tests/test_common.py`** — two new test classes:
- `TestServiceOperationToTBPath` (2 tests): basic path construction and
  `"latest"` suffix
- `TestGetServiceOperationTags` (2 tests): correct keys/values, default Config

**`crisp/LAYERS.md`** — deferred TB test target updated from "PR 8b" → "PR 11"
for all 6 TBClient-dependent test classes.

## Test plan

- [x] `bazel test //...` — all 4 targets pass
- [x] `grep -rn "uber\." crisp/common.py tests/test_common.py` — empty
