### PR TITLE
port(crisp): add graph.py — standalone functions and graph-build phase (PR 9b)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,7 @@ py_test(
         "//crisp:common",
         "//crisp:configuration",
         "//crisp:constants",
+        "//crisp:graph",
         "//crisp:pkg",
         "@pypi//pytest",
     ],
@@ -62,5 +63,12 @@ py_test(
     name = "test_common",
     srcs = ["tests/test_common.py"],
     deps = ["//crisp:common"],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_graph",
+    srcs = ["tests/test_graph.py"],
+    deps = ["//crisp:graph"],
     imports = ["."],
 )

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -46,3 +46,17 @@ py_library(
         "@pypi//python_dateutil",
     ],
 )
+
+py_library(
+    name = "graph",
+    srcs = ["graph.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":common",
+        ":configuration",
+        ":constants",
+        ":pkg",
+        "//crisp/shared:shared",
+        "//crisp/utils:utils",
+    ],
+)

--- a/crisp/LAYERS.md
+++ b/crisp/LAYERS.md
@@ -82,3 +82,17 @@ When porting, apply this decision in order:
 | `tests/test_common.py::TestGetTBClient.*` (×3)                        | PR 11             | TBClient not yet ported.                                                                              |
 | `tests/test_common.py::TestDirExistsOnTB.*`                           | PR 11             | TBClient not yet ported.                                                                              |
 | `tests/test_common.py::TestBlobExistsOnTB.*`                          | PR 11             | TBClient not yet ported.                                                                              |
+| `tests/test_graph.py::GraphTestCase::test_findCriticalPath`            | PR 9c             | `findCriticalPath` not yet ported.                                                                    |
+| `tests/test_graph.py::GraphTestCase::test_findErrorsOnCriticalPath`    | PR 9c             | `findErrorsOnCriticalPath` not yet ported.                                                            |
+| `tests/test_graph.py::GraphTestCase::test_computeTimeSaved`            | PR 9c             | `computeTimeSaved` not yet ported.                                                                    |
+| `tests/test_graph.py::GraphTestCase::test_rootReturnError`             | PR 9c             | `findErrorsOnCriticalPath` not yet ported.                                                            |
+| `tests/test_graph.py::GraphTestCase::test_metrics1`                    | PR 9c             | `findCriticalPath`, `accumeCPMetrics`, `accumeErrorCPMetrics` not yet ported.                        |
+| `tests/test_graph.py::GraphTestCase::test_metrics2`                    | PR 9c             | Same as above.                                                                                        |
+| `tests/test_graph.py::GraphTestCase::test_timeskewMetrics`             | PR 9c             | Same as above.                                                                                        |
+| `tests/test_graph.py::GraphTestCase::test_overlapedSerialCalls`        | PR 9c             | `findCriticalPath`, `accumeCPMetrics` not yet ported.                                                 |
+| `tests/test_graph.py::GraphTestCase::test_exclusion`                   | PR 9c             | `findCriticalPath` not yet ported.                                                                    |
+| `tests/test_graph.py::GraphTestCase::test_computeErrDepthHisto`        | PR 9d             | `computeErrDepthHisto`, `computeSupressErrDepthHisto` not yet ported.                                 |
+| `tests/test_graph.py::GraphTestCase::test_getOutboundCount_*` (×5)     | PR 9d             | `getOutboundCount` not yet ported.                                                                    |
+| `tests/test_graph.py::GraphTestCase::test_getAllOutboundCounts`         | PR 9d             | `getAllOutboundCounts` not yet ported.                                                                 |
+| `tests/test_graph.py::GraphTestCase::test_getCycles`                   | PR 9d             | `getCycles` not yet ported.                                                                           |
+| `tests/test_graph.py::TestCrossRegionDetection.*` (×5)                 | PR 9d             | `getCrossRegionCalls` not yet ported.                                                                 |

--- a/crisp/graph.py
+++ b/crisp/graph.py
@@ -1,0 +1,963 @@
+# ruff: noqa: I001
+import heapq
+import logging
+import os
+from typing import Callable
+
+import crisp.common as common
+from crisp.shared.models import (
+    MetricVals,
+    CallPathProfile,
+    QuantizedMetrics,
+    ErrCountsData,
+    SavingData,
+    SpanKind,
+    ErrorCPMetrics,
+    ErrorMetrics,
+    Metrics,
+)
+from crisp.shared.utils import getLeafNodeFromCallPath
+from crisp.models import (
+    PBlock, GraphNode, GetRemainingTags,
+)
+from crisp.constants import (
+    SPANS, SPAN_ID, REFERENCES, START_TIME, SPAN_KIND, PEER_SERVICE,
+    DURATION, OPERATION_NAME, PROCESS_ID, REF_TYPE, CHILD_OF,
+    TAGS, LOGS, FIELDS, PROCESSES, HOSTNAME, TESTING, OP_TIME_EXCLUSIVE,
+    TOTAL_WORK, TIME_SAVED_ON_WORK, TIME_SAVED_ON_CP, ERR_CP_CALLPATH_EXCLUSIVE,
+    ERR_CP_ERR_COUNTS, SERVER, CLIENT, PARQUET_PROCESS, PARQUET_SERVICE_NAME,
+    PARQUET_OPERATION_NAME, PARQUET_HOSTNAME, PARQUET_START_TIME, PARQUET_DURATION,
+    PARQUET_SPAN_SET, PARQUET_KIND, PARQUET_SPAN_ID, PARQUET_PARENT_SPAN_ID,
+    PARQUET_SPANS, PARQUET_TAGS, PARQUET_ERROR, PARQUET_RPC_STATUS_CODE,
+    PARQUET_RPC_SYSTEM, PARQUET_ERROR_MESSAGE, SYNTHETIC_ERR_CP_ROOT, SYNTHETIC_FULL_ERR_NON_CP_ROOT, Colors,
+    DEFAULT_MAX_DEPTH
+)
+from crisp.configuration import (
+    get_overlap_allowance, get_server_lengthening_factor, is_optimistic_enabled,
+    is_pessimistic_enabled
+)
+from crisp.utils.dict_utils import (
+    accumulateInDict, getCPSize
+)
+
+# Re-export for backward compatibility
+__all__ = ['Graph', 'accumulateInDict', 'bcolors', 'getCPSize']
+from crisp.utils.span_utils import (
+    isProxyNode, isErrPropNode, isTestTraceByServiceName, isTestTraceByOpName
+)
+
+
+# bcolors class moved to constants.py - use Colors instead
+bcolors = Colors
+
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)-8s %(message)s",
+    level=logging.INFO,
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+debug_on = logging.getLogger(__name__).isEnabledFor(logging.DEBUG)
+
+def isAcceptableParentChildDuration(parent, me):
+    if me.duration > get_server_lengthening_factor() * parent.duration:
+        return False
+    return True
+
+
+# detects server1 -> [^server] -> server2, where middleone has one and only one child (server2)
+def isFuzzyClientServerCall(parent, me):
+    if me.spanKind != SpanKind.SERVER:
+        return False
+    if parent.spanKind == SpanKind.SERVER:
+        return False
+    if len(parent.children) != 1:
+        return False
+    grandParent = parent.parent
+    if not grandParent or (grandParent.spanKind != SpanKind.SERVER):
+        return False
+    return isAcceptableParentChildDuration(parent, me)
+
+
+# detects client1 -> server2, where client1 has one and only one child (server2)
+def isCleanClientServerCall(parent, me):
+    if me.spanKind != SpanKind.SERVER:
+        return False
+    if parent.spanKind != SpanKind.CLIENT:
+        return False
+    if len(parent.children) != 1:
+        return False
+    return isAcceptableParentChildDuration(parent, me)
+
+
+# Detects if parent and child are running on different hosts.
+def onDifferentHosts(hostDict, parent, me):
+    parentHost = hostDict[parent.pid] if parent.pid in hostDict else None
+    meHost = hostDict[me.pid] if me.pid in hostDict else None
+    if not parentHost or not meHost:
+        return False
+    if parentHost == meHost:
+        return False
+    if len(parent.children) != 1:
+        return False
+    return isAcceptableParentChildDuration(parent, me)
+
+
+# adjust duration to be no longer than the parent. This helps us not get -ve numbers.
+def adjustChildDuration(parent, me):
+    if me.duration > parent.duration:
+        me.duration = parent.duration
+
+
+# Checks if "parent" is a client(ish) and "me" is server.
+def isClientServerCall(hostDict, parent, me, adjustChild=True):
+    if (
+        isCleanClientServerCall(parent, me)
+        or isFuzzyClientServerCall(parent, me)
+        or onDifferentHosts(hostDict, parent, me)
+    ):
+        if isAcceptableParentChildDuration(parent, me):
+            adjustChild and adjustChildDuration(parent, me)
+            return True
+    return False
+
+
+def get_split_child_trace_ids(trace_data: dict) -> list[dict]:
+    """
+    Identify child trace IDs from split point markers in a parent trace.
+
+    When Jaeger splits large traces due to size limits, it creates spans with
+    special tags (internal.splittrace.traceID / spanID) that indicate the child
+    trace ID. This scans all spans for those markers.
+
+    Args:
+        trace_data: Jaeger trace JSON data
+
+    Returns:
+        List of dicts, each containing child_trace_id and metadata
+    """
+    split_children = []
+    seen_child_ids = set()
+
+    try:
+        for item in trace_data.get("data", []):
+            for span in item.get(SPANS, []):
+                child_trace_id = None
+                child_span_id = None
+
+                for tag in span.get(TAGS, []):
+                    tag_key = tag.get("key", "")
+                    if tag_key == "internal.splittrace.traceID":
+                        child_trace_id = tag.get("value")
+                    elif tag_key == "internal.splittrace.spanID":
+                        child_span_id = tag.get("value")
+
+                if child_trace_id and child_trace_id not in seen_child_ids:
+                    seen_child_ids.add(child_trace_id)
+                    split_children.append({
+                        'child_trace_id': child_trace_id,
+                        'child_span_id': child_span_id,
+                        'split_point_span_id': span.get(SPAN_ID),
+                        'split_point_operation': span.get(OPERATION_NAME, ""),
+                    })
+    except Exception as e:
+        logging.warning(f"Failed to parse split trace markers from trace data: {e}")
+
+    return split_children
+
+
+def extract_root_span_metadata(trace_data: dict) -> tuple[str, str]:
+    """
+    Extract the actual service name and operation name from trace root span.
+
+    This function parses Jaeger trace data to find the root span (span without parent references)
+    and extracts the service name and operation name from it. This is useful for creating
+    Graph instances with the correct serviceName and operationName parameters when those are not available in the config.
+
+    Args:
+        trace_data: Parsed JSON trace data from Jaeger containing 'data' field with
+                   processes and spans information
+
+    Returns:
+        Tuple of (service_name, operation_name) extracted from the root span.
+        Falls back to ("", "") if extraction fails.
+    """
+    try:
+        # Parse process names from trace data (similar to Graph.parseNode)
+        process_names = {}
+        for item in trace_data.get("data", []):
+            for process_id, process_info in item.get(PROCESSES, {}).items():
+                process_names[process_id] = process_info.get("serviceName", "")
+
+        # Find potential root spans (spans without parent references)
+        potential_roots = []
+        for item in trace_data.get("data", []):
+            for span in item.get(SPANS, []):
+                has_parent = False
+                for ref in span.get(REFERENCES, []):
+                    if ref.get(REF_TYPE) == CHILD_OF:
+                        has_parent = True
+                        break
+
+                if not has_parent:
+                    potential_roots.append(span)
+
+        # Use the first root span found
+        if potential_roots:
+            root_span = potential_roots[0]
+            process_id = root_span.get(PROCESS_ID)
+            service_name = process_names.get(process_id, "")
+            operation_name = root_span.get(OPERATION_NAME, "")
+            return service_name, operation_name
+
+    except Exception as e:
+        logging.warning(f"Failed to extract root span metadata from trace: {e}")
+
+    # Fallback to defaults
+    return "", ""
+
+class Graph:
+    """
+    Graph represents a Jaeger trace composed of spans (represented by GraphNodes).
+    It is the central data structure on which we compute the critical path.
+    Each Graph is built from some Jaeger JSON file represented by its filename.
+    A well-formed Jaeger trace should have one and only one rootNode.
+    """
+
+    def __init__(
+        self,
+        data,
+        serviceName,
+        operationName,
+        filename=None,
+        rootTrace=True,
+        filterProxy=False,
+        tags=None,
+        exclusionSet=None,
+        skipInitializationForTest=False,
+        useParquet=False,
+    ) -> None:
+        self.operationName = operationName
+        self.serviceName = serviceName
+        self.tags = []
+        self.filename = filename
+        self.filesz = os.path.getsize(filename) if os.path.exists(filename) else 0
+        self.rootNode = None
+        self.nodeHT = {}
+        self.tagHT = {}  # nullify once its use is over
+        self.processName = {}
+        self.hostMap = {}  # maps service to host name
+        self.regionMap = {}  # maps process ID to region/zone info
+        self.totalShrink = 0
+        self.totalDrop = 0
+        self.shrinkCounter = 0
+        self.testing = {}
+        self.exclusiveExampleMap = {}
+        self.inclusiveExampleMap = {}
+        self.numErrors = 0
+        self.proxyNodes = {}  # maps sid to child count, for sanity checks
+        self.filterProxy = filterProxy
+        self.numProxyRoots = 0  # number of proxy nodes that are roots
+        self.exclusionSet = (
+            exclusionSet if exclusionSet else {}
+        )  # operations to exlude from the graph
+
+        # Used for testing to skip initialization.
+        if skipInitializationForTest:
+            return
+
+        try:
+            if useParquet:
+                potentialRoots, isCtfTest = self.parseNodeFromParquet(data)
+            else:
+                potentialRoots, isCtfTest = self.parseNode(data)
+            self.isCtfTest = isCtfTest
+        except Exception as e:
+            logging.warning(f"self.parseNode failed in file {filename}!")
+            logging.warning(f"Exception: {e}")
+            return
+
+        if len(potentialRoots) == 0:
+            logging.warning(f"no root node in file {filename}!")
+            return
+
+        if rootTrace:  # the root span must be the service+operation
+            if len(potentialRoots) != 1:
+                logging.warning(f"{len(potentialRoots)} roots node in file {filename}!")
+                return
+            if not potentialRoots[0] or not self.checkRootAndWarn(
+                potentialRoots[0],
+                filename,
+                rootTrace,
+            ):
+                return
+            else:
+                self.rootNode = potentialRoots[0]
+        else:  # randomly choose some one node whose service and op names match
+            for candidate in potentialRoots:
+                someRoot = self.findARoot(candidate)
+                if not someRoot or not self.checkRootAndWarn(
+                    someRoot,
+                    filename,
+                    rootTrace,
+                ):
+                    continue
+                # make someRoot's parent as None
+                someRoot.parent = None
+                someRoot.parentSpanId = None
+                # set someRoot as the rootNode
+                self.rootNode = someRoot
+                break
+
+            if not self.rootNode:
+                logging.warning(
+                    f"rootTrace == {rootTrace} but no matching node found in file {filename}!",
+                )
+                return
+
+        self.sanitizeOverflowingChildren(self.rootNode)
+        # Remove operation in exclusionDict from the graph
+        self.removeExcludedOps(self.rootNode, self.exclusionSet)
+        # record each tag that is found in the node.
+        self.tags = self.GetMatchingTagsInTree(tags if tags else [], self.rootNode)
+        self.tagHT = {}  # No needed anymore.
+
+        if debug_on:
+            logging.debug(f"{self.totalShrink} of duation compressed")
+            logging.debug(f"{self.shrinkCounter} spans shrank")
+            logging.debug(f"{self.totalDrop} spans dropped")
+            logging.debug(f"total executionTime {self.rootNode.duration}")
+
+    def GetMatchingTagsInNode(self, tags, node):
+        if not node:
+            return []
+        if len(tags) == 0:
+            return []
+        if node.sid not in self.tagHT:
+            return []
+        matchingTags = []
+        for dictionary in self.tagHT[node.sid]:
+            k = dictionary["key"] if "key" in dictionary else ""
+            v = dictionary["value"] if "value" in dictionary else ""
+            matchingTags += [
+                item
+                for item in tags
+                if (k == item[common.TAG_NAME]) and (v == item[common.TAG_VALUE])
+            ]
+        debug_on and (len(matchingTags) > 0) and logging.debug(
+            f"matching tags found: {self.filename}: {node.sid}",
+        )
+        return matchingTags
+
+    def GetMatchingTagsInTree(self, tags, rootNode, curSearchDepth=1):
+        matchingTags = self.GetMatchingTagsInNode(tags, rootNode)
+        if len(matchingTags) == len(tags):
+            return matchingTags
+
+        newDepth = curSearchDepth + 1
+        remainingTags = GetRemainingTags(matchingTags, tags, newDepth)
+        for child in rootNode.children:
+            moreMatches = self.GetMatchingTagsInTree(remainingTags, child, newDepth)
+            if len(moreMatches) > 0:
+                matchingTags += moreMatches
+                remainingTags = GetRemainingTags(moreMatches, remainingTags, newDepth)
+        return matchingTags
+
+    def findARoot(self, node):
+        # a DFS for finding the first node that matches the required service and operation name.
+        if (
+            self.processName[node.pid] == self.serviceName
+            and node.opName == self.operationName
+        ):
+            return node
+        for c in node.children:
+            found = self.findARoot(c)
+            if found:
+                return found
+        return None
+
+    # input args:
+    # - node: curr node
+    # - depth: the depth of curr node
+    # - stopErrNodeDepth: the depth of the closest ancestor (to this node) that
+    #                     did not error out
+    # - errCounts: a map from opCallpath to error counts
+    # - errCallChainCounts: a map from opCallPath to error call-chain counts
+    # - selfErrDepthList: a list of self error depth
+    # - depthMap: a map from depth (key) to ErrCountsData
+    # - propLengthMap: a map from propagation length (key) to count of self errors
+    # - resiliencyMap: a map from canonicalOpName to ErrCountsData
+    #        though we only update the propagated and stopped errors in this case
+    #
+    # return:
+    # numAllErrors: the number of all errored out nodes in the program
+    #
+    # For computing error stats, we assume that the root node has depth 1
+    def computeErrorStats(
+        self,
+        node,
+        depth,
+        stopErrNodeDepth,
+        errCounts,
+        errCallChainCounts,
+        selfErrDepthList,
+        stoppedErrDepthList,
+        depthMap,
+        propLengthMap,
+        resiliencyMap,
+    ):
+        numAllErrors = 0
+        childHasError = False
+
+        if node.returnError:
+            newStopErrNodeDepth = stopErrNodeDepth
+        else:
+            newStopErrNodeDepth = depth
+
+        # a DFS traversal
+        for c in node.children:
+            if c.returnError:
+                childHasError = True
+            numAllErrors += self.computeErrorStats(
+                c,
+                depth + 1,
+                newStopErrNodeDepth,
+                errCounts,
+                errCallChainCounts,
+                selfErrDepthList,
+                stoppedErrDepthList,
+                depthMap,
+                propLengthMap,
+                resiliencyMap,
+            )
+
+        # update maps with my own stats
+        op = self.canonicalOpName(node)
+        opCallpath = self.getCallPath(node)
+        if node.returnError:
+            numAllErrors = numAllErrors + 1
+            if childHasError:  # node has propagated error
+                accumulateInDict(
+                    errCounts,
+                    opCallpath,
+                    ErrCountsData(propagatedErrors=1),
+                )
+                accumulateInDict(depthMap, depth, ErrCountsData(propagatedErrors=1))
+                accumulateInDict(resiliencyMap, op, ErrCountsData(propagatedErrors=1))
+            else:  # node has self error
+                selfErrDepthList.append(depth)
+                accumulateInDict(errCounts, opCallpath, ErrCountsData(selfErrors=1))
+                accumulateInDict(errCallChainCounts, opCallpath, 1)
+                accumulateInDict(depthMap, depth, ErrCountsData(selfErrors=1))
+                # my depth should always be greater than stopErrNodeDepth,
+                # which is the depth of one of my proper ancestor; note that
+                # the root node starts with depth 1
+                accumulateInDict(propLengthMap, (depth - stopErrNodeDepth), 1)
+        elif childHasError:  # node has suppressed error
+            stoppedErrDepthList.append(depth)
+            accumulateInDict(errCounts, opCallpath, ErrCountsData(stoppedErrors=1))
+            accumulateInDict(depthMap, depth, ErrCountsData(stoppedErrors=1))
+            accumulateInDict(resiliencyMap, op, ErrCountsData(stoppedErrors=1))
+
+        return numAllErrors
+
+    def computeGraphStats(self, node):
+        # a DFS
+        descendants = 0
+        depth = 0  # the root node has depth 1 (+1 at return)
+        for c in node.children:
+            moreDescendants, newDepth = self.computeGraphStats(c)
+            descendants = descendants + moreDescendants
+            depth = newDepth if newDepth > depth else depth
+        return descendants + 1, depth + 1
+
+    def checkRootAndWarn(self, node, filename, rootTrace):
+        if (
+            self.processName[node.pid] != self.serviceName
+            or node.opName != self.operationName
+        ):
+            logging.warning(
+                (
+                    f"rootTrace == {rootTrace}, expected serviceName={self.serviceName} and found {self.processName[node.pid]}. "
+                    f"Expected operationName={self.operationName} and found {node.opName} in file {filename}",
+                ),
+            )
+            return False
+        return True
+
+    def setTestResult(self, result):
+        self.testing = result
+
+    def checkMapContent(self, expected, result, mapName):
+        for k, v in expected.items():
+            if k not in result:
+                return f"missing key {k!s} in {mapName}"
+            if v != result[k]:
+                # special handling of user-defined type
+                if isinstance(result[k], ErrCountsData):
+                    if v == result[k].toArray():
+                        continue
+                return f"in {mapName} key {k!s}: expected {v!s} found {result[k]!s}"
+        for k in result:
+            if k not in expected:
+                return f"extra key {k!s} in {mapName}"
+        return True
+
+    def checkResults(
+        self,
+        cpp,
+        work,
+        timeSavedOnW,
+        timeSavedOnCPAllSeries,
+        errorCPMetrics,
+    ):
+        # Check if the critical path found by our algorithms matches the one
+        # recorded in the "testing" section.
+        if self.testing == {}:
+            return None  # nothing to validate
+
+        opTimeMap = {}
+        for k, v in cpp.items():
+            op = getLeafNodeFromCallPath(k)
+            if op in opTimeMap:
+                opTimeMap[op] += v.excl
+            else:
+                opTimeMap[op] = v.excl
+
+        map_tag_res_msg_tuples = [
+            (OP_TIME_EXCLUSIVE, opTimeMap, "opTimeExclusive"),
+            (
+                ERR_CP_CALLPATH_EXCLUSIVE,
+                errorCPMetrics.errCPCallpathTimeExclusive,
+                "errCPCallpathTimeExclusive",
+            ),
+            (ERR_CP_ERR_COUNTS, errorCPMetrics.errCPErrCounts, "errCPErrCounts"),
+        ]
+        val_tag_res_msg_tuples = [
+            (TOTAL_WORK, work, "total work"),
+            (TIME_SAVED_ON_WORK, timeSavedOnW, "time saved on work"),
+            (TIME_SAVED_ON_CP, timeSavedOnCPAllSeries, "time saved on CP"),
+        ]
+        for tag, res, msg in map_tag_res_msg_tuples:
+            if tag not in self.testing:
+                continue
+            expected = self.testing[tag]
+            check = self.checkMapContent(expected, res, msg)
+            if not check:
+                return check
+
+        for tag, res, msg in val_tag_res_msg_tuples:
+            expected = self.testing[tag]
+            if expected != res:
+                return f"wrong {msg}: expected {expected!s} found {res!s}"
+
+        return True
+
+    def getPeerService(self, tags):
+        for dictionary in tags:
+            k = dictionary["key"].lower() if "key" in dictionary else None
+            v = dictionary["value"] if "value" in dictionary else None
+            if k == PEER_SERVICE:
+                return v
+        return None
+
+    def getSpanKind(self, tags):
+        for dictionary in tags:
+            k = dictionary["key"].lower() if "key" in dictionary else ""
+            v = dictionary["value"] if "value" in dictionary else ""
+            if k == SPAN_KIND:
+                if v.lower() == SERVER:
+                    return SpanKind.SERVER
+                if v.lower() == CLIENT:
+                    return SpanKind.CLIENT
+                return SpanKind.UNKNOWN
+        return SpanKind.UNKNOWN
+
+    def parseForErrorReturn(self, tags, logs):
+        for dictionary in tags:
+            k = dictionary["key"].lower() if "key" in dictionary else None
+            t = dictionary["type"].lower() if "type" in dictionary else None
+            v = dictionary["value"] if "value" in dictionary else False
+            if k == "error" and (t == "string" or v):
+                return True
+            if k == "http.status_code" and int(v) >= 400:
+                return True
+            if k == "grpc.status" and (v != "OK" and v):
+                return True
+
+        for entry in logs:
+            fields = entry[FIELDS] if FIELDS in entry else []
+            for dictionary in fields:
+                k = dictionary["key"].lower() if "key" in dictionary else None
+                if k == "error.object":
+                    return True
+                if k == "error" and (
+                    "type" in dictionary and dictionary["type"].lower() == "string"
+                ):
+                    return True
+                if k == "event" and (
+                    "value" in dictionary and dictionary["value"].lower() == "error"
+                ):
+                    return True
+        return False
+
+    def parseForErrorReturnFromParquet(self, statusCode, error, _errorMessage, rpcSystem):
+        # TODO: errorMessage is not used yet, YARPC is not landed yet
+        if error:
+            return True
+        if rpcSystem and rpcSystem.lower() == "grpc" and statusCode != 0:
+            return True
+        if rpcSystem and rpcSystem.lower() == "http" and statusCode >= 400:
+            return True
+        return False
+
+    # For all nodes that are identified as isErrPropNode(), pass through the child's error to this node.
+    # We expect the node to have a single child. Violations will be logged.
+    # Post order traversal.
+    def propagateErrors(self, me, errPropSpans):
+        if len(me.children) == 0:
+            return
+        for c in list(me.children.keys()):
+            self.propagateErrors(c, errPropSpans)
+
+        if me.sid not in errPropSpans:
+            return
+
+        if len(me.children) != 1:
+            debug_on and logging.debug(
+                f"Expected 1 child, but Span {me.sid}'s has {len(me.children)} children in: file = {self.filename}",
+            )
+            return
+
+        child = next(iter(me.children.keys()))
+        if (not me.returnError) and (child.returnError):
+            me.returnError = child.returnError
+
+    def buildParentChildRelationships(self, potentialRoots):
+        for spanId in self.nodeHT:
+            me = self.nodeHT[spanId]
+            parentId = me.parentSpanId
+            if not parentId:
+                potentialRoots.append(me)
+                continue
+            if parentId not in self.nodeHT:
+                potentialRoots.append(me)
+                continue
+
+            # Parent is a proxy node; short wire it
+            if parentId in self.proxyNodes:
+                self.proxyNodes[parentId] += 1
+                proxyGraphNode = self.nodeHT[parentId]
+                parentId = proxyGraphNode.parentSpanId
+                if parentId not in self.nodeHT:
+                    self.numProxyRoots += 1
+                    potentialRoots.append(me)
+                    continue
+
+            parent = self.nodeHT[parentId]
+            me.setParent(parent)
+            if spanId not in self.proxyNodes:
+                parent.addChild(me)
+
+
+    def propagateErrorsToRoots(self, potentialRoots, errPropNodes):
+        for root in potentialRoots:
+            self.propagateErrors(root, errPropNodes)
+
+    def storeNodeData(self, thisSpan, node, serviceName, operationName, errPropNodes, spanTags):
+        self.nodeHT[thisSpan] = node
+        self.tagHT[thisSpan] = spanTags
+        if self.filterProxy:
+            if isProxyNode(serviceName, operationName):
+                self.proxyNodes[thisSpan] = 0
+            if isErrPropNode(serviceName, operationName):
+                errPropNodes[thisSpan] = 0
+
+    def parseNode(self, jsonData):
+        # given jaeger jsonData blob, build the Graph().
+
+        potentialRoots = []
+        numErrors = 0
+        isCtfTest = False
+        errPropNodes = {}
+
+        # pass 1: record service names and other KV data first
+        for item in jsonData["data"]:
+            for p in item[PROCESSES]:
+                self.processName[p] = item[PROCESSES][p]["serviceName"]
+                if isTestTraceByServiceName(self.processName[p]):
+                    isCtfTest = True
+                if TAGS in item[PROCESSES][p]:
+                    for dictionary in item[PROCESSES][p][TAGS]:
+                        if dictionary["key"] == HOSTNAME:
+                            self.hostMap[p] = dictionary["value"]
+                        elif dictionary["key"] == "region":
+                            self.regionMap[p] = dictionary["value"]
+                        elif dictionary["key"] == "zone" and p not in self.regionMap:
+                            self.regionMap[p] = dictionary["value"]
+
+        # pass 2: extract all spans and create one GraphNode for each.
+        for item in jsonData["data"]:
+            for span in item[SPANS]:
+                thisSpan = span[SPAN_ID]
+                parentSpanId = None
+                # We only care about CHILD_OF spans reachable from the root.
+                for parent in span[REFERENCES]:
+                    if parent[REF_TYPE] == CHILD_OF:
+                        parentSpanId = parent[SPAN_ID]
+
+                spanTags = span[TAGS] if (TAGS in span) else {}
+                spanLogs = span[LOGS] if (LOGS in span) else {}
+                hasError = self.parseForErrorReturn(spanTags, spanLogs)
+                if hasError:
+                    numErrors += 1
+
+                spanKind = self.getSpanKind(spanTags)
+                peerService = self.getPeerService(spanTags)
+
+                opName = span[OPERATION_NAME]
+                pid = span[PROCESS_ID]
+                if isTestTraceByOpName(opName):
+                    isCtfTest = True
+
+                node = GraphNode(
+                    thisSpan,
+                    span[START_TIME],
+                    span[DURATION],
+                    parentSpanId,  # no parent YET, only spanID is available.
+                    opName,
+                    pid,
+                    spanKind,
+                    peerService,
+                    hasError,
+                )
+                self.storeNodeData(thisSpan, node, self.processName[pid], opName, errPropNodes, spanTags)
+
+        self.numErrors = numErrors
+
+        # pass 3: build parent-child relationships
+        self.buildParentChildRelationships(potentialRoots)
+
+        # pass 4. Propagate errors for nodes identified as errorProps.
+        self.propagateErrorsToRoots(potentialRoots, errPropNodes)
+
+        # for testing only, we keep the expected results in TESTING section of JSON.
+        # pass 5: record test results
+        if TESTING in jsonData and len(jsonData[TESTING]) > 0:
+            self.setTestResult(jsonData[TESTING])
+
+        return potentialRoots, isCtfTest
+
+    def parseNodeFromParquet(self, parquetData):
+        # Builds graph from Parquet data and returns potential roots.
+        '''
+        parquetData: a dictionary containing the data from a parquet file.
+        '''
+        # TODO: we need to map 'Kind' from integer back into 'server'/'client' in order to do error analysis.
+        # Note: we don't really care about 'Links' https://opentelemetry.io/docs/concepts/signals/traces/#span-links so far.
+        # Instead we assume if the ParentSpanID is non empty then it's a valid parent-child relationship.
+        potentialRoots = []
+        numErrors = 0
+        isCtfTest = False
+        errPropNodes = {}
+        pidMap = {}  # Mapping from serviceName to a unique pid, required by findAllRoots() and other functions.
+
+        parquetSpanSets = parquetData[PARQUET_SPAN_SET]
+
+        # Pass 1: Record service names, hostnames, and generate unique pids based on (serviceName, hostName) tuple
+        for item in parquetSpanSets:
+            process = item[PARQUET_PROCESS]
+            serviceName = process[PARQUET_SERVICE_NAME]
+            hostName = process[PARQUET_HOSTNAME]
+
+            # Use a tuple (serviceName, hostName) as the unique key
+            service_host_key = (serviceName, hostName)
+
+            # If this service + host combination hasn't been assigned a pid yet, assign a new one
+            if service_host_key not in pidMap:
+                pid = len(pidMap) + 1  # Generate a unique pid
+                pidMap[service_host_key] = pid
+                self.processName[pid] = serviceName
+                self.hostMap[pid] = hostName
+
+            if isTestTraceByServiceName(serviceName):
+                isCtfTest = True
+
+        # Pass 2: Extract spans and create one GraphNode for each
+        for item in parquetSpanSets:
+            spans = item[PARQUET_SPANS]
+            for span in spans:
+                # Convert SpanID and ParentSpanID to hex strings
+                thisSpan = common.intToHexString(span[PARQUET_SPAN_ID])
+                parentSpanId = common.intToHexString(span[PARQUET_PARENT_SPAN_ID]) if span.get(PARQUET_PARENT_SPAN_ID) else None
+
+                # Extract other span information
+                spanKind = span[PARQUET_KIND]
+                operationName = span[PARQUET_OPERATION_NAME]
+                serviceName = item[PARQUET_PROCESS][PARQUET_SERVICE_NAME]
+                hostName = item[PARQUET_PROCESS][PARQUET_HOSTNAME]
+
+                if isTestTraceByOpName(operationName):
+                    isCtfTest = True
+
+                # Use the tuple (serviceName, hostName) as the key to get the pid from pidMap
+                service_host_key = (serviceName, hostName)
+                pid = pidMap[service_host_key]
+
+                # Error checking
+                statusCode = span.get(PARQUET_RPC_STATUS_CODE, None)
+                error = span.get(PARQUET_ERROR, None)
+                errorMessage = span.get(PARQUET_ERROR_MESSAGE, None)
+                rpcSystem = span.get(PARQUET_RPC_SYSTEM, None)
+
+                hasError = self.parseForErrorReturnFromParquet(statusCode, error, errorMessage, rpcSystem)
+
+                if hasError:
+                    numErrors += 1
+
+                spanTags = span.get(PARQUET_TAGS, []) # TODO: this needs to be verified. For now we are not going to test on user-defined tags.
+
+                # Create the GraphNode for the span, and assign the pid
+                node = GraphNode(
+                    thisSpan,
+                    span[PARQUET_START_TIME],
+                    span[PARQUET_DURATION],
+                    parentSpanId,
+                    operationName,
+                    pid,
+                    spanKind,
+                    None,  # Peer service not present in the data structure
+                    hasError
+                )
+
+                # Store the node and span data
+                self.storeNodeData(thisSpan, node, serviceName, operationName, errPropNodes, spanTags)
+
+
+        self.numErrors = numErrors
+
+        # Pass 3: Build parent-child relationships
+        self.buildParentChildRelationships(potentialRoots)
+
+        # Pass 4: Propagate errors
+        self.propagateErrorsToRoots(potentialRoots, errPropNodes)
+
+        return potentialRoots, isCtfTest
+
+    def removeExcludedOps(self, curNode, exclusionSet):
+        removeList = []
+        for c in curNode.children:
+            serviceName = self.processName[c.pid]
+            opName = c.opName
+            if (serviceName, opName) in exclusionSet:
+                removeList.append(c)
+                # logging.info(f"dropping { (serviceName, opName)}")
+            else:
+                # recursion
+                self.removeExcludedOps(c, exclusionSet)
+        # now delete the list of items marked for deletion.
+        for r in removeList:
+            r.parent = None
+            del curNode.children[r]
+
+    def sanitizeOverflowingChildren(self, curNode):
+        # if a child overflows or underflows its parent, it will be truncated/deleted to match/adhere to parent timeline.
+        parentStart = curNode.startTime
+        parentEnd = curNode.endTime
+
+        removeList = []
+        for c in curNode.children:
+            childStart = c.startTime
+            childEnd = c.endTime
+
+            debug_on and logging.debug(f"working on parent {curNode}, child {c}")
+            debug_on and logging.debug(
+                f"parent start {parentStart}, parent end {parentEnd}",
+            )
+            debug_on and logging.debug(
+                f"child start {childStart}, child end {childEnd}",
+            )
+
+            if isClientServerCall(self.hostMap, curNode, c):
+                debug_on and logging.debug(
+                    f"{curNode.sid}, {curNode.opName}, {c.sid}, {c.opName}, case 0",
+                )
+                # So, curNode is client and c is a server.
+                # Don't chop c to adjust to curNode's times.
+                # continue recursion
+                self.sanitizeOverflowingChildren(c)
+            elif childStart >= parentStart and childEnd <= parentEnd:
+                # case 1: everything looks good
+                # |----parent----|
+                #   |----child--|
+                debug_on and logging.debug("Case 1")
+                # continue recursion
+                self.sanitizeOverflowingChildren(c)
+            elif (
+                childStart < parentStart
+                and childEnd <= parentEnd
+                and childEnd > parentStart
+            ):
+                # case 2: child start before parent, truncate is needed
+                #      |----parent----|
+                #   |----child--|
+                debug_on and logging.debug("Case 2")
+                shrunk = parentStart - childStart
+                self.totalShrink += shrunk
+                self.shrinkCounter += 1
+                c.startTime = parentStart
+                c.duration -= shrunk
+                debug_on and self.dumpShrinkStats(curNode, c, shrunk)
+                # continue recursion
+                self.sanitizeOverflowingChildren(c)
+            elif (
+                childStart >= parentStart
+                and childEnd > parentEnd
+                and childStart < parentEnd
+            ):
+                # case 3: child end after parent, truncate is needed
+                #      |----parent----|
+                #              |----child--|
+                debug_on and logging.debug("Case 3")
+                shrunk = childEnd - parentEnd
+                self.totalShrink += shrunk
+                self.shrinkCounter += 1
+                c.duration -= shrunk
+                c.endTime -= shrunk
+                debug_on and self.dumpShrinkStats(curNode, c, shrunk)
+                # continue recursion
+                self.sanitizeOverflowingChildren(c)
+            else:
+                # case 4: child outside of parent rantge =>  drop the child span
+                #      |----parent----|
+                #                        |----child--|
+                # or
+                #                      |----parent----|
+                #       |----child--|
+                debug_on and logging.debug("Case 4")
+                debug_on and self.dumpDeletionStats(curNode, c, c.duration)
+                removeList.append(c)
+                # no recursion; all descendants will become unreachable from the root.
+
+        # now delete the list of items marked for deletion.
+        for r in removeList:
+            r.parent = None
+            del curNode.children[r]
+
+    def dumpShrinkStats(self, curNode, child, shrunk):
+        logging.debug(
+            (
+                f" shrunk node {curNode} id:{curNode.sid} duration {curNode.duration} by {shrunk}: child {child} "
+                f"id:{child.sid} => {shrunk / curNode.duration * 100}  reduction",
+            ),
+        )
+
+    def dumpDeletionStats(self, curNode, child, shrunk):
+        if curNode.duration > 0:
+            logging.debug(
+                (
+                    f" delete: parent node {curNode} id:{curNode.sid}  duration {curNode.duration} with child {child} id:{child.sid} "
+                    f"of {shrunk} => {shrunk / curNode.duration * 100}  reduction",
+                ),
+            )
+
+    # --- computeCriticalPath and subsequent methods will be added in PR 9c ---

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,1563 @@
+# ruff: noqa: I001
+from unittest import TestCase
+
+import crisp.common as common
+import crisp.graph as graph
+from crisp.graph import Graph, GraphNode, SpanKind
+from crisp.constants import SYNTHETIC_ERR_CP_ROOT, SYNTHETIC_FULL_ERR_NON_CP_ROOT
+from crisp.configuration import is_optimistic_enabled, get_server_lengthening_factor
+from unittest import mock
+
+
+# This creates a graph with call tree:
+# A ([S1] O1) -> B ([S2] O2) -> C ([S3] O3)
+#                            -> D ([S4] O4)
+# A runs 0-100
+# B runs 10-70
+# C runs 25-45
+# D runs 30-50, errors out
+def sampleGraph():
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                    "S3": {
+                        "serviceName": "S3",
+                        "tags": [],
+                    },
+                    "S4": {
+                        "serviceName": "S4",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "references": [],
+                        "startTime": 0,
+                        "duration": 100,
+                        "processID": "S1",
+                        "warnings": None,
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "O2",
+                        "startTime": 10,
+                        "duration": 60,
+                        "processID": "S2",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "C",
+                        "operationName": "O3",
+                        "startTime": 25,
+                        "duration": 20,
+                        "processID": "S3",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "D",
+                        "operationName": "O4",
+                        "startTime": 30,
+                        "duration": 20,
+                        "processID": "S4",
+                        "warnings": None,
+                        "tags": [
+                            {
+                                "key": "error",
+                                "type": "string",
+                                "value": "ClientSideError",
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    return Graph(jsonData, "S1", "O1", "", "")
+
+
+# This creates a graph with call tree:
+# A ([S1] O1) -> B ([S2] proxy-relay) -> C ([S3] proxy-relay) -> D ([S4] O2)
+def proxy_graph():
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                    "S3": {
+                        "serviceName": "S3",
+                        "tags": [],
+                    },
+                    "S4": {
+                        "serviceName": "S4",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "references": [],
+                        "startTime": 0,
+                        "duration": 100,
+                        "processID": "S1",
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "proxy-relay",
+                        "startTime": 10,
+                        "duration": 10,
+                        "processID": "S2",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "C",
+                        "operationName": "proxy-relay",
+                        "startTime": 12,
+                        "duration": 3,
+                        "processID": "S3",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "D",
+                        "operationName": "O2",
+                        "startTime": 30,
+                        "duration": 40,
+                        "processID": "S4",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "C",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    return Graph(jsonData, "S1", "O1", "", "", filterProxy=True)
+
+
+# This creates a graph with call tree:
+# A ([S1] O1) -> P1 ([err-prop-svc] relay-op) -> P2 ([err-prop-svc] relay-op) -> B ([S2] O2)
+def errprop_graph():
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                    "err-prop-svc": {
+                        "serviceName": "err-prop-svc",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "references": [],
+                        "startTime": 0,
+                        "duration": 100,
+                        "processID": "S1",
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "P1",
+                        "operationName": "relay-op",
+                        "startTime": 10,
+                        "duration": 80,
+                        "processID": "err-prop-svc",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "P2",
+                        "operationName": "relay-op",
+                        "startTime": 20,
+                        "duration": 50,
+                        "processID": "err-prop-svc",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "P1",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "O2",
+                        "startTime": 30,
+                        "duration": 40,
+                        "processID": "S2",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "P2",
+                            },
+                        ],
+                        "tags": [
+                            {
+                                "key": "error",
+                                "type": "bool",
+                                "value": True,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    return Graph(jsonData, "S1", "O1", "", "", filterProxy=True)
+
+
+# This creates a graph with call tree:
+# A ([S1] O1 TAG_K1:V1) -> B ([S2] O2 TAG_K2:V2) -> C ([S3] O3 TAG_K3:V3)
+#                            -> D ([S4] O4 TAG_K4:V4)
+# A runs 0-100
+# B runs 10-70
+# C runs 25-45
+# D runs 30-50
+def tagMatchGraph(tags):
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                    "S3": {
+                        "serviceName": "S3",
+                        "tags": [],
+                    },
+                    "S4": {
+                        "serviceName": "S4",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "references": [],
+                        "startTime": 0,
+                        "duration": 100,
+                        "processID": "S1",
+                        "warnings": None,
+                        "tags": [
+                            {
+                                "key": "k1",
+                                "type": "string",
+                                "value": "v1",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "O2",
+                        "startTime": 10,
+                        "duration": 60,
+                        "processID": "S2",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                        "tags": [
+                            {
+                                "key": "k2",
+                                "type": "string",
+                                "value": "v2",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "C",
+                        "operationName": "O3",
+                        "startTime": 25,
+                        "duration": 20,
+                        "processID": "S3",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                        "tags": [
+                            {
+                                "key": "k3",
+                                "type": "string",
+                                "value": "v3",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "D",
+                        "operationName": "O4",
+                        "startTime": 30,
+                        "duration": 20,
+                        "processID": "S4",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                        "tags": [
+                            {
+                                "key": "k4",
+                                "type": "string",
+                                "value": "v4",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    return Graph(
+        data=jsonData,
+        serviceName="S1",
+        operationName="O1",
+        filename="",
+        rootTrace=True,  # Correctly set rootTrace as a boolean
+        tags=tags,
+        useParquet=False,
+    )
+
+
+class GraphTestCase(TestCase):
+    def setUp(self):
+        from crisp.utils import span_utils
+        # Register generic proxy/errprop/test-trace names used by tests in this class.
+        span_utils.PROXY_ONLY_OPS.append("proxy-relay")
+        span_utils.ERR_PROP_SERVICE_OP_PAIRS.append(("err-prop-svc", "relay-op"))
+        span_utils.TEST_TRACE_SERVICES.extend(
+            ["test-svc-1", "test-executor", "test-accounts", "e2e-test-proxy"]
+        )
+        span_utils.TEST_TRACE_OP_PREFIXES.extend(
+            ["[mytest.Root]", "[mytest.Action]", "[MYTEST.Run]", "[MYTEST.TestAccounts]", "[MYTEST.Teardown]"]
+        )
+
+    def tearDown(self):
+        from crisp.utils import span_utils
+        span_utils.PROXY_ONLY_OPS.remove("proxy-relay")
+        span_utils.ERR_PROP_SERVICE_OP_PAIRS.remove(("err-prop-svc", "relay-op"))
+        for s in ["test-svc-1", "test-executor", "test-accounts", "e2e-test-proxy"]:
+            span_utils.TEST_TRACE_SERVICES.remove(s)
+        for p in ["[mytest.Root]", "[mytest.Action]", "[MYTEST.Run]", "[MYTEST.TestAccounts]", "[MYTEST.Teardown]"]:
+            span_utils.TEST_TRACE_OP_PREFIXES.remove(p)
+
+    def test_proxyErrorProp(self):
+        g = errprop_graph()
+        assert g.rootNode.sid == "A"
+        assert not g.rootNode.returnError
+        children = list(g.rootNode.children.keys())
+        assert len(children) == 1
+        ch = children[0]
+        assert ch.sid == "P1"
+        assert ch.returnError
+        ch = next(iter(ch.children.keys()))
+        assert ch.sid == "P2"
+        assert ch.returnError
+
+    def test_proxy(self):
+        g = proxy_graph()
+        assert g.rootNode.sid == "A"
+        children = list(g.rootNode.children.keys())
+        assert len(children) == 1
+        ch = children[0]
+        assert ch.sid == "D"
+        assert len(ch.children) == 0
+
+    def test_isProxy(self):
+        assert not graph.isProxyNode("x", "y")
+        assert graph.isProxyNode("any-service", "proxy-relay")
+        assert graph.isProxyNode("dummy", "proxy-relay")
+        assert not graph.isProxyNode("proxy-relay", "dummy")
+
+    def test_isErrorProp(self):
+        assert not graph.isErrPropNode("x", "y")
+        assert graph.isErrPropNode("err-prop-svc", "relay-op")
+
+    def test_isTestTrace(self):
+        assert graph.isTestTraceByServiceName("test-svc-1")
+        assert graph.isTestTraceByServiceName("test-executor")
+        assert graph.isTestTraceByServiceName("test-accounts")
+        assert graph.isTestTraceByServiceName("e2e-test-proxy")
+        assert not graph.isTestTraceByServiceName("foo")
+        assert not graph.isTestTraceByServiceName("")
+
+        assert graph.isTestTraceByOpName("[mytest.Root]")
+        assert graph.isTestTraceByOpName("[mytest.Action] test:...")
+        assert graph.isTestTraceByOpName("[mytest.Action] something")
+        assert graph.isTestTraceByOpName("[MYTEST.Run] test:...")
+        assert graph.isTestTraceByOpName("[MYTEST.TestAccounts] Populate")
+        assert graph.isTestTraceByOpName("[MYTEST.Teardown]")
+        assert not graph.isTestTraceByOpName("foo")
+        assert not graph.isTestTraceByOpName("")
+
+    def test_parseForErrorReturn(self):
+        tag1 = [{"key": "error", "type": "bool", "value": True}]
+        tag2 = [{"key": "http.status_code", "value": "403"}]
+        tag3 = [{"key": "grpc.status", "value": "fail"}]
+        log1 = [{"fields": [{"key": "error.object"}]}]
+        log2 = [{"fields": [{"key": "error", "type": "string"}]}]
+        log3 = [{"fields": [{"key": "event", "value": "error"}]}]
+
+        m = sampleGraph()
+
+        assert not m.parseForErrorReturn({}, [])
+        assert m.parseForErrorReturn(tag1, [])
+        assert m.parseForErrorReturn(tag2, [])
+        assert m.parseForErrorReturn(tag3, [])
+        assert m.parseForErrorReturn({}, log1)
+        assert m.parseForErrorReturn({}, log2)
+        assert m.parseForErrorReturn({}, log3)
+
+    def test_isAcceptableParentChildDuration(self):
+        p = graph.GraphNode(
+            sid="A",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="O1",
+            processID="P1",
+            spanKind=graph.SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        c = graph.GraphNode(
+            sid="B",
+            startTime=1000,
+            duration=100,
+            parentSpanId="",
+            opName="O2",
+            processID="P2",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+
+        c.duration = get_server_lengthening_factor() * p.duration - 1
+        assert graph.isAcceptableParentChildDuration(p, c)
+
+        c.duration = get_server_lengthening_factor() * p.duration + 1
+        assert not graph.isAcceptableParentChildDuration(p, c)
+
+    def test_isClientServerCall_with_invalid_span_combinations(self):
+        p = graph.GraphNode(
+            sid="A",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="O1",
+            processID="P1",
+            spanKind=graph.SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        c = graph.GraphNode(
+            sid="B",
+            startTime=1000,
+            duration=10,
+            parentSpanId="",
+            opName="O2",
+            processID="P2",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+        d = graph.GraphNode(
+            sid="C",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="O3",
+            processID="P3",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+
+        c.setParent(p)
+        p.addChild(c)
+        assert graph.isCleanClientServerCall(p, c)
+
+        # client->client => false
+        c.spanKind = graph.SpanKind.CLIENT
+        p.spanKind = graph.SpanKind.CLIENT
+        assert not graph.isCleanClientServerCall(p, c)
+
+        # unknown->client => false
+        p.spanKind = graph.SpanKind.UNKNOWN
+        c.spanKind = graph.SpanKind.CLIENT
+        assert not graph.isCleanClientServerCall(p, c)
+
+        # unknown->unknown => false
+        p.spanKind = graph.SpanKind.UNKNOWN
+        c.spanKind = graph.SpanKind.UNKNOWN
+        assert not graph.isCleanClientServerCall(p, c)
+
+        # server->server => false
+        c.spanKind = graph.SpanKind.SERVER
+        c.spanKind = graph.SpanKind.SERVER
+        assert not graph.isCleanClientServerCall(p, c)
+
+        # unknown->server => false
+        c.spanKind = graph.SpanKind.UNKNOWN
+        c.spanKind = graph.SpanKind.SERVER
+        assert not graph.isCleanClientServerCall(p, c)
+
+        c.spanKind = graph.SpanKind.CLIENT
+        c.spanKind = graph.SpanKind.SERVER
+        # Multichild => false
+        d.setParent(p)
+        p.addChild(d)
+        assert not graph.isClientServerCall({}, p, c)
+
+    def test_isFuzzyServerCall(self):
+        g = graph.GraphNode(
+            sid="A",
+            startTime=0,
+            duration=1000,
+            parentSpanId="",
+            opName="O1",
+            processID="P1",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+        p = graph.GraphNode(
+            sid="B",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="O2",
+            processID="P2",
+            spanKind=graph.SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        c = graph.GraphNode(
+            sid="C",
+            startTime=0,
+            duration=10,
+            parentSpanId="",
+            opName="O3",
+            processID="P3",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+        d = graph.GraphNode(
+            sid="C",
+            startTime=0,
+            duration=10,
+            parentSpanId="",
+            opName="O3",
+            processID="P3",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+
+        c.setParent(p)
+        p.addChild(c)
+        p.setParent(g)
+        g.addChild(p)
+        assert graph.isFuzzyClientServerCall(p, c)
+
+        # client->unknown->server => True
+        g.spanKind = graph.SpanKind.SERVER
+        p.spanKind = graph.SpanKind.UNKNOWN
+        c.spanKind = graph.SpanKind.SERVER
+        assert graph.isFuzzyClientServerCall(p, c)
+
+        # *->server->server => False
+        p.spanKind = graph.SpanKind.SERVER
+        c.spanKind = graph.SpanKind.SERVER
+        assert not graph.isFuzzyClientServerCall(p, c)
+
+        # unknown->unknown->server => False
+        g.spanKind = graph.SpanKind.UNKNOWN
+        p.spanKind = graph.SpanKind.UNKNOWN
+        c.spanKind = graph.SpanKind.SERVER
+        assert not graph.isFuzzyClientServerCall(p, c)
+
+        # None->unknown->server => False
+        p.parent = None
+        p.spanKind = graph.SpanKind.UNKNOWN
+        c.spanKind = graph.SpanKind.SERVER
+        assert not graph.isFuzzyClientServerCall(p, c)
+
+        p.parent = g
+
+        # multichildren => false
+        d.setParent(p)
+        p.addChild(d)
+        g.spanKind = graph.SpanKind.SERVER
+        p.spanKind = graph.SpanKind.UNKNOWN
+        c.spanKind = graph.SpanKind.SERVER
+        assert not graph.isFuzzyClientServerCall(p, c)
+
+    def test_onDifferentHosts(self):
+        p = graph.GraphNode(
+            sid="A",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="O1",
+            processID="P1",
+            spanKind=graph.SpanKind.UNKNOWN,
+            peerService=None,
+            returnError=False,
+        )
+        c = graph.GraphNode(
+            sid="B",
+            startTime=1000,
+            duration=10,
+            parentSpanId="",
+            opName="O2",
+            processID="P2",
+            spanKind=graph.SpanKind.UNKNOWN,
+            peerService=None,
+            returnError=False,
+        )
+        d = graph.GraphNode(
+            sid="C",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="O3",
+            processID="P3",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+
+        c.setParent(p)
+        p.addChild(c)
+        assert graph.onDifferentHosts({"P1": "H1", "P2": "H2"}, p, c)
+        # On same host => false
+        assert not graph.onDifferentHosts({"P1": "H1", "P2": "H1"}, p, c)
+        # No host for parent => false
+        assert not graph.onDifferentHosts({"P5": "H1", "P2": "H1"}, p, c)
+        # No host for child => false
+        assert not graph.onDifferentHosts({"P1": "H1", "P10": "H1"}, p, c)
+        # No host for parent and child => false
+        assert not graph.onDifferentHosts({}, p, c)
+        # Multichild => false
+        d.setParent(p)
+        p.addChild(d)
+        assert not graph.onDifferentHosts({"P1": "H1", "P2": "H2"}, p, c)
+
+    def test_isClientServerCall_with_intermediate_unknown_span(self):
+        p = graph.GraphNode(
+            sid="A",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="O1",
+            processID="P1",
+            spanKind=graph.SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        c = graph.GraphNode(
+            sid="B",
+            startTime=1000,
+            duration=10,
+            parentSpanId="",
+            opName="O2",
+            processID="P2",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+
+        c.setParent(p)
+        p.addChild(c)
+        assert graph.isClientServerCall({}, p, c)
+
+        g = graph.GraphNode(
+            sid="A",
+            startTime=0,
+            duration=1000,
+            parentSpanId="",
+            opName="O1",
+            processID="P1",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+        p = graph.GraphNode(
+            sid="B",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="O2",
+            processID="P2",
+            spanKind=graph.SpanKind.UNKNOWN,
+            peerService=None,
+            returnError=False,
+        )
+        c = graph.GraphNode(
+            sid="C",
+            startTime=0,
+            duration=10,
+            parentSpanId="",
+            opName="O3",
+            processID="P3",
+            spanKind=graph.SpanKind.SERVER,
+            peerService=None,
+            returnError=False,
+        )
+
+        c.setParent(p)
+        p.addChild(c)
+        p.setParent(g)
+        g.addChild(p)
+        assert graph.isClientServerCall({}, p, c)
+
+        # *->server->server => False
+        p.spanKind = graph.SpanKind.SERVER
+        c.spanKind = graph.SpanKind.SERVER
+        assert not graph.isClientServerCall({}, p, c)
+
+        assert graph.isClientServerCall({"P2": "H1", "P3": "H2"}, p, c)
+
+    def test_getCPSize(self):
+        cct = {"A->B": 21, "A->B->C": 1}
+        expect = 1 + 3 + 1 + 2 + 1 + 5 + 1 + 1
+        assert graph.getCPSize(cct) == expect
+
+    def test_GetRemainingTags(self):
+        foundTags = [
+            {common.TAG_NAME: "a", common.TAG_VALUE: "b", common.TAG_SEARCH_DEPTH: 5},
+        ]
+        allTags = [
+            {common.TAG_NAME: "a", common.TAG_VALUE: "b", common.TAG_SEARCH_DEPTH: 5},
+            {common.TAG_NAME: "a", common.TAG_VALUE: "b", common.TAG_SEARCH_DEPTH: 4},
+            {common.TAG_NAME: "c", common.TAG_VALUE: "d", common.TAG_SEARCH_DEPTH: 10},
+        ]
+        remainingTags = graph.GetRemainingTags(foundTags, allTags, 5)
+        expected = [
+            {common.TAG_NAME: "c", common.TAG_VALUE: "d", common.TAG_SEARCH_DEPTH: 10},
+        ]
+        assert expected == remainingTags
+
+    def test_GetMatchingTagsInTree(self):
+        searchTags = [
+            {common.TAG_NAME: "k1", common.TAG_VALUE: "v1", common.TAG_SEARCH_DEPTH: 1},
+            {common.TAG_NAME: "k3", common.TAG_VALUE: "v3", common.TAG_SEARCH_DEPTH: 2},
+            {
+                common.TAG_NAME: "k4",
+                common.TAG_VALUE: "v4",
+                common.TAG_SEARCH_DEPTH: 10,
+            },
+        ]
+
+        expected = [
+            {common.TAG_NAME: "k1", common.TAG_VALUE: "v1", common.TAG_SEARCH_DEPTH: 1},
+            {
+                common.TAG_NAME: "k4",
+                common.TAG_VALUE: "v4",
+                common.TAG_SEARCH_DEPTH: 10,
+            },
+        ]
+        g = tagMatchGraph(searchTags)
+        assert expected == g.tags
+
+
+class TestQuantizedMetrics(TestCase):
+    def test_empty_histogram(self):
+        instance = graph.QuantizedMetrics({})
+        self.assertIsNone(instance.p100)
+        self.assertIsNone(instance.p0)
+        self.assertIsNone(instance.items)
+        self.assertIsNone(instance.avg)
+        self.assertIsNone(instance.p50)
+        self.assertIsNone(instance.p90)
+        self.assertIsNone(instance.p95)
+        self.assertIsNone(instance.p99)
+
+    def test_non_empty_histogram(self):
+        h = {1: 5, 10: 8, 101: 1, 102: 2, 110: 3, 510: 2, 1000: 10, 2000: 1}
+
+        data = sorted(
+            [1] * 5
+            + [10] * 8
+            + [101] * 1
+            + [102] * 2
+            + [110] * 3
+            + [510] * 2
+            + [1000] * 10
+            + [2000] * 1,
+        )
+        avg = sum(data) // len(data)
+        p0 = data[0]
+        p100 = data[-1]
+        p50 = data[int(len(data) * 0.5)]
+        p90 = data[int(len(data) * 0.9)]
+        p95 = data[int(len(data) * 0.95)]
+        p99 = data[int(len(data) * 0.99)]
+
+        q = graph.QuantizedMetrics(h)
+        self.assertEqual(2000, q.p100)
+        self.assertEqual(1, q.p0)
+        self.assertEqual(q.items, len(data))
+        avg = 0
+        items = 0
+        for k, v in h.items():
+            avg += k * v
+            items += v
+
+        self.assertEqual(int(avg / items), int(q.avg))
+        self.assertEqual(p0, q.p0)
+        self.assertEqual(p50, q.p50)
+        self.assertEqual(p90, q.p90)
+        self.assertEqual(p95, q.p95)
+        self.assertEqual(p99, q.p99)
+        self.assertEqual(p100, q.p100)
+
+    @mock.patch('os.path.exists', return_value=False)
+    def test_graph_init_file_does_not_exist(self, _mock_exists):
+        # Arrange
+        data = mock.MagicMock()
+        serviceName = "TestService"
+        operationName = "TestOperation"
+        filename = "non_existent_file.json"
+
+        # Act
+        g = graph.Graph(
+            data=data,
+            serviceName=serviceName,
+            operationName=operationName,
+            filename=filename
+        )
+
+        # Assert
+        self.assertEqual(g.filesz, 0)  # Since the file doesn't exist, size should be 0
+
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('os.path.getsize', return_value=1024)
+    @mock.patch('crisp.graph.Graph.parseNode', side_effect=Exception("JSON parsing error"))
+    @mock.patch('logging.warning')
+    def test_graph_parse_exception(self, mock_logging_warning, mock_parseNode, _mock_getsize, _mock_exists):
+        # Arrange
+        data = mock.MagicMock()
+        serviceName = "TestService"
+        operationName = "TestOperation"
+        filename = "test.json"
+
+        # Act
+        g = graph.Graph(
+            data=data,
+            serviceName=serviceName,
+            operationName=operationName,
+            filename=filename,
+            useParquet=False
+        )
+
+        # Assert
+        mock_parseNode.assert_called_once_with(data)
+        mock_logging_warning.assert_any_call("self.parseNode failed in file test.json!")
+        mock_logging_warning.assert_any_call("Exception: JSON parsing error")
+        self.assertIsNone(g.rootNode)  # Should handle the exception gracefully
+
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('os.path.getsize', return_value=1024)
+    @mock.patch('crisp.graph.Graph.parseNodeFromParquet', side_effect=Exception("Parquet parsing error"))
+    @mock.patch('logging.warning')
+    def test_graph_parquet_parse_exception(self, mock_logging_warning, mock_parseNodeFromParquet, _mock_getsize, _mock_exists):
+        # Arrange
+        data = mock.MagicMock()
+        serviceName = "TestService"
+        operationName = "TestOperation"
+        filename = "test.parquet"
+
+        # Act
+        g = graph.Graph(
+            data=data,
+            serviceName=serviceName,
+            operationName=operationName,
+            filename=filename,
+            useParquet=True
+        )
+
+        # Assert
+        mock_parseNodeFromParquet.assert_called_once_with(data)
+        mock_logging_warning.assert_any_call("self.parseNode failed in file test.parquet!")
+        mock_logging_warning.assert_any_call("Exception: Parquet parsing error")
+        self.assertIsNone(g.rootNode)  # Should handle the exception gracefully
+
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('os.path.getsize', return_value=1024)
+    @mock.patch('crisp.graph.Graph.checkRootAndWarn', return_value=True)  # Mock checkRootAndWarn
+    @mock.patch('crisp.graph.Graph.parseNode')
+    @mock.patch('crisp.graph.Graph.parseNodeFromParquet')
+    def test_graph_init_with_parquet(self, mock_parseNodeFromParquet, mock_parseNode, mock_checkRootAndWarn, _mock_getsize, _mock_exists):
+        # Arrange
+        data = mock.MagicMock()
+        serviceName = "TestService"
+        operationName = "TestOperation"
+        filename = "test.parquet"
+
+        # Create a mock root node with necessary attributes
+        mock_root_node = mock.MagicMock()
+        mock_root_node.pid = "S1"
+        mock_root_node.opName = operationName
+
+        # Mock the Parquet parsing function to return a valid root node
+        mock_parseNodeFromParquet.return_value = ([mock_root_node], False)
+
+        # Act
+        g = graph.Graph(
+            data=data,
+            serviceName=serviceName,
+            operationName=operationName,
+            filename=filename,
+            useParquet=True
+        )
+
+        # Assert
+        mock_parseNodeFromParquet.assert_called_once_with(data)
+        mock_parseNode.assert_not_called()  # parseNode should not be called
+        mock_checkRootAndWarn.assert_called_once_with(mock_root_node, filename, True)  # checkRootAndWarn should be called
+        self.assertEqual(g.filename, filename)
+        self.assertEqual(g.filesz, 1024)
+        self.assertEqual(g.rootNode, mock_root_node)  # Check that the root node is set
+
+
+class TestParseForErrorReturnFromParquet(TestCase):
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('os.path.getsize', return_value=1024)
+    def setUp(self, _mock_getsize, _mock_exists):
+        # Initialize a Graph for testing
+        self.graph = Graph([], "testService", "testOperation", filename="testfile.txt", skipInitializationForTest=True)
+
+    def test_http_status_code_400(self):
+        # Test typical HTTP error code (>= 400)
+        self.assertTrue(self.graph.parseForErrorReturnFromParquet(statusCode=400, error=False, _errorMessage=None, rpcSystem="http"))
+
+    def test_http_status_code_200(self):
+        # Test HTTP success code
+        self.assertFalse(self.graph.parseForErrorReturnFromParquet(statusCode=200, error=False, _errorMessage=None, rpcSystem="http"))
+
+    def test_grpc_status_error(self):
+        # Test gRPC non-zero status (error)
+        self.assertTrue(self.graph.parseForErrorReturnFromParquet(statusCode=1, error=False, _errorMessage=None, rpcSystem="grpc"))
+
+    def test_grpc_status_success(self):
+        # Test gRPC zero status (success)
+        self.assertFalse(self.graph.parseForErrorReturnFromParquet(statusCode=0, error=False, _errorMessage=None, rpcSystem="grpc"))
+
+    def test_error_flag(self):
+        # Test when the error flag is True
+        self.assertTrue(self.graph.parseForErrorReturnFromParquet(statusCode=200, error=True, _errorMessage=None, rpcSystem="http"))
+
+    def test_no_error_conditions(self):
+        # Test when none of the error conditions are met
+        self.assertFalse(self.graph.parseForErrorReturnFromParquet(statusCode=200, error=False, _errorMessage=None, rpcSystem="http"))
+
+class MockDict(dict):
+    def __getitem__(self, key):
+        if key == "B":
+            raise KeyError("B")
+        return super().__getitem__(key)
+
+class TestBuildParentChildRelationships(TestCase):
+
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('os.path.getsize', return_value=1024)
+    def setUp(self, _mock_getsize, _mock_exists):
+        # Initialize a mock Graph for testing, passing a valid filename
+        self.graph = Graph([], "testService", "testOperation", filename="mockfile.txt", skipInitializationForTest=True)
+        self.graph.nodeHT = {}
+        self.graph.proxyNodes = {}
+
+    def test_no_parent(self):
+        # Arrange: A node with no parentSpanId
+        node = mock.MagicMock()
+        node.parentSpanId = None
+        self.graph.nodeHT["A"] = node
+
+        potentialRoots = []
+
+        # Act
+        self.graph.buildParentChildRelationships(potentialRoots)
+
+        # Assert: Node "A" should be added to potentialRoots
+        self.assertIn(node, potentialRoots)
+        node.setParent.assert_not_called()  # No parent should be set
+        node.addChild.assert_not_called()   # No children should be added
+
+    def test_parent_not_in_nodeHT(self):
+        # Arrange: A node whose parent is not in nodeHT
+        node = mock.MagicMock()
+        node.parentSpanId = "B"
+        self.graph.nodeHT["A"] = node
+
+        potentialRoots = []
+
+        # Act
+        self.graph.buildParentChildRelationships(potentialRoots)
+
+        # Assert: Node "A" should be added to potentialRoots as parent is missing
+        self.assertIn(node, potentialRoots)
+        node.setParent.assert_not_called()
+        node.addChild.assert_not_called()
+
+    def test_proxy_node_with_no_parent(self):
+        # Arrange: A proxy node whose parent is not in nodeHT
+        node = mock.MagicMock()
+        node.parentSpanId = "B"
+        self.graph.nodeHT["A"] = node
+
+        proxyNode = mock.MagicMock()
+        proxyNode.parentSpanId = "C"
+        self.graph.nodeHT["B"] = proxyNode
+        self.graph.proxyNodes = {"B": 0}  # B is a proxy node
+
+        potentialRoots = []
+
+        # Act
+        self.graph.buildParentChildRelationships(potentialRoots)
+
+        # Assert: Node "A" should be added to potentialRoots as the proxy parent's parent is missing
+        self.assertIn(node, potentialRoots)
+        self.assertEqual(self.graph.numProxyRoots, 1)
+
+class TestParseNodeFromParquet(TestCase):
+
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('os.path.getsize', return_value=1024)
+    @mock.patch('crisp.graph.Graph.buildParentChildRelationships')
+    @mock.patch('crisp.graph.Graph.propagateErrorsToRoots')
+    @mock.patch('crisp.graph.Graph.storeNodeData')
+    @mock.patch('crisp.graph.Graph.parseForErrorReturnFromParquet', return_value=False)
+    def test_parse_node_from_parquet_success(self, _mock_parse_error, mock_store_node_data, mock_propagate_errors,
+                                             mock_build_parent_child_relationships, _mock_getsize, _mock_exists):
+        # Arrange
+        g = Graph([], "testService", "testOperation", filename="mockfile.txt", skipInitializationForTest=True)
+
+        # Corrected Sample parquetData input
+        parquetData = {
+            'span_set': [  # Corrected key
+                {
+                    'process': {  # Corrected key
+                        'service_name': 'service1',  # Corrected key
+                        'host_name': 'host1'  # Corrected key
+                    },
+                    'spans': [  # Corrected key
+                        {
+                            'span_id': 1,  # Corrected key
+                            'parent_span_id': None,
+                            'start_time_unix_nano': 1000,
+                            'duration_nano': 500,
+                            'kind': 1,
+                            'operation_name': 'operation1',
+                            'status_code': 200,
+                        },
+                        {
+                            'span_id': 2,
+                            'parent_span_id': 1,
+                            'start_time_unix_nano': 2000,
+                            'duration_nano': 300,
+                            'kind': 2,
+                            'operation_name': 'operation2',
+                            'status_code': 200,
+                        },
+                    ]
+                }
+            ]
+        }
+
+        # Act
+        potentialRoots, isCtfTest = g.parseNodeFromParquet(parquetData)
+
+        # Debugging: Print out the contents of potentialRoots
+        print(f"Potential roots: {potentialRoots}")
+
+        # Assert
+        self.assertFalse(isCtfTest)
+        mock_store_node_data.assert_called()
+        mock_build_parent_child_relationships.assert_called_once()
+        mock_propagate_errors.assert_called_once()
+
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('os.path.getsize', return_value=1024)
+    @mock.patch('crisp.graph.Graph.buildParentChildRelationships')
+    @mock.patch('crisp.graph.Graph.propagateErrorsToRoots')
+    @mock.patch('crisp.graph.Graph.storeNodeData')
+    @mock.patch('crisp.graph.Graph.parseForErrorReturnFromParquet', return_value=True)
+    def test_parse_node_from_parquet_with_errors(self, _mock_parse_error, mock_store_node_data, mock_propagate_errors,
+                                                 mock_build_parent_child_relationships, _mock_getsize, _mock_exists):
+        # Arrange
+        g = Graph([], "testService", "testOperation", filename="mockfile.txt", skipInitializationForTest=True)
+
+        # Corrected Sample parquetData with spans that have errors
+        parquetData = {
+            'span_set': [  # Corrected key
+                {
+                    'process': {  # Corrected key
+                        'service_name': 'service1',  # Corrected key
+                        'host_name': 'host1'  # Corrected key
+                    },
+                    'spans': [  # Corrected key
+                        {
+                            'span_id': 1,  # Corrected key
+                            'parent_span_id': None,
+                            'start_time_unix_nano': 1000,
+                            'duration_nano': 500,
+                            'kind': 1,
+                            'operation_name': 'operation1',
+                            'status_code': 500,  # Status code triggering an error
+                        }
+                    ]
+                }
+            ]
+        }
+
+        # Act
+        potentialRoots, isCtfTest = g.parseNodeFromParquet(parquetData)
+
+        # Assert
+        self.assertEqual(g.numErrors, 1)  # Since the mock returns True for errors
+        mock_store_node_data.assert_called()
+        mock_build_parent_child_relationships.assert_called_once()
+        mock_propagate_errors.assert_called_once()
+
+
+class TestExtractRootSpanMetadata(TestCase):
+    """Test cases for extract_root_span_metadata function."""
+
+    def test_extract_root_span_metadata_with_valid_trace(self):
+        """Test extracting metadata from a valid trace with root span."""
+        trace_data = {
+            "data": [
+                {
+                    "processes": {
+                        "p1": {"serviceName": "test-service"},
+                        "p2": {"serviceName": "other-service"}
+                    },
+                    "spans": [
+                        {
+                            "spanID": "root-span",
+                            "processID": "p1",
+                            "operationName": "GET /api/test",
+                            "references": []  # No parent references = root span
+                        },
+                        {
+                            "spanID": "child-span",
+                            "processID": "p2",
+                            "operationName": "db.query",
+                            "references": [{"refType": "CHILD_OF", "spanID": "root-span"}]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        service_name, operation_name = graph.extract_root_span_metadata(trace_data)
+
+        self.assertEqual(service_name, "test-service")
+        self.assertEqual(operation_name, "GET /api/test")
+
+    def test_extract_root_span_metadata_with_multiple_roots(self):
+        """Test extracting metadata when multiple root spans exist."""
+        trace_data = {
+            "data": [
+                {
+                    "processes": {
+                        "p1": {"serviceName": "first-service"},
+                        "p2": {"serviceName": "second-service"}
+                    },
+                    "spans": [
+                        {
+                            "spanID": "root1",
+                            "processID": "p1",
+                            "operationName": "operation1",
+                            "references": []
+                        },
+                        {
+                            "spanID": "root2",
+                            "processID": "p2",
+                            "operationName": "operation2",
+                            "references": []
+                        }
+                    ]
+                }
+            ]
+        }
+
+        service_name, operation_name = graph.extract_root_span_metadata(trace_data)
+
+        # Should return the first root span found
+        self.assertEqual(service_name, "first-service")
+        self.assertEqual(operation_name, "operation1")
+
+    def test_extract_root_span_metadata_with_missing_process_name(self):
+        """Test extracting metadata when process name is missing."""
+        trace_data = {
+            "data": [
+                {
+                    "processes": {
+                        "p1": {}  # Missing serviceName
+                    },
+                    "spans": [
+                        {
+                            "spanID": "root-span",
+                            "processID": "p1",
+                            "operationName": "test-operation",
+                            "references": []
+                        }
+                    ]
+                }
+            ]
+        }
+
+        service_name, operation_name = graph.extract_root_span_metadata(trace_data)
+
+        self.assertEqual(service_name, "")
+        self.assertEqual(operation_name, "test-operation")
+
+    def test_extract_root_span_metadata_with_missing_operation_name(self):
+        """Test extracting metadata when operation name is missing."""
+        trace_data = {
+            "data": [
+                {
+                    "processes": {
+                        "p1": {"serviceName": "test-service"}
+                    },
+                    "spans": [
+                        {
+                            "spanID": "root-span",
+                            "processID": "p1",
+                            "references": []
+                            # Missing operationName
+                        }
+                    ]
+                }
+            ]
+        }
+
+        service_name, operation_name = graph.extract_root_span_metadata(trace_data)
+
+        self.assertEqual(service_name, "test-service")
+        self.assertEqual(operation_name, "")
+
+    def test_extract_root_span_metadata_with_no_root_spans(self):
+        """Test extracting metadata when no root spans exist."""
+        trace_data = {
+            "data": [
+                {
+                    "processes": {
+                        "p1": {"serviceName": "test-service"}
+                    },
+                    "spans": [
+                        {
+                            "spanID": "child-span",
+                            "processID": "p1",
+                            "operationName": "child-operation",
+                            "references": [{"refType": "CHILD_OF", "spanID": "missing-parent"}]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        service_name, operation_name = graph.extract_root_span_metadata(trace_data)
+
+        # Should fallback to defaults
+        self.assertEqual(service_name, "")
+        self.assertEqual(operation_name, "")
+
+    def test_extract_root_span_metadata_with_empty_trace(self):
+        """Test extracting metadata from empty trace data."""
+        trace_data = {"data": []}
+
+        service_name, operation_name = graph.extract_root_span_metadata(trace_data)
+
+        # Should fallback to defaults
+        self.assertEqual(service_name, "")
+        self.assertEqual(operation_name, "")
+
+    def test_extract_root_span_metadata_with_malformed_trace(self):
+        """Test extracting metadata from malformed trace data."""
+        trace_data = {"invalid": "structure"}
+
+        service_name, operation_name = graph.extract_root_span_metadata(trace_data)
+
+        # Should fallback to defaults when parsing fails
+        self.assertEqual(service_name, "")
+        self.assertEqual(operation_name, "")
+
+    def test_extract_root_span_metadata_with_missing_process_id(self):
+        """Test extracting metadata when span references non-existent process ID."""
+        trace_data = {
+            "data": [
+                {
+                    "processes": {
+                        "p1": {"serviceName": "test-service"}
+                    },
+                    "spans": [
+                        {
+                            "spanID": "root-span",
+                            "processID": "p999",  # Non-existent process ID
+                            "operationName": "test-operation",
+                            "references": []
+                        }
+                    ]
+                }
+            ]
+        }
+
+        service_name, operation_name = graph.extract_root_span_metadata(trace_data)
+
+        self.assertEqual(service_name, "")  # Fallback when process not found
+        self.assertEqual(operation_name, "test-operation")
+
+
+class TestCheckResults(TestCase):
+    """Test the checkResults method which validates testing section."""
+
+    def test_checkResults_with_valid_testing_data(self):
+        """Test checkResults correctly validates opTimeExclusive using getLeafNodeFromCallPath."""
+        from crisp.shared.models import MetricVals  # noqa: PLC0415
+        from crisp.shared.models import ErrorCPMetrics  # noqa: PLC0415
+
+        # Create a Graph instance with skipInitializationForTest=True
+        g = Graph(
+            data="test-trace",  # traceID
+            serviceName="test-service",
+            operationName="test-op",
+            filename="test.json",
+            skipInitializationForTest=True
+        )
+
+        # Set up testing expectations
+        g.setTestResult({
+            "opTimeExclusive": {
+                "O1": 100,
+                "O2": 50,
+            },
+            "totalWork": 200,
+            "timeSavedOnWork": 30,
+            "timeSavedOnCP": 25,
+        })
+
+        # Create call path profile with full paths
+        # The checkResults method should use getLeafNodeFromCallPath to extract just the operation name
+        cpp_dict = {
+            "[S1] O1": MetricVals(inc=100, excl=100, freq=1, sid="trace1"),
+            "[S1] O1->[S2] O2": MetricVals(inc=50, excl=50, freq=1, sid="trace1"),
+        }
+
+        # Create ErrorCPMetrics with required parameters
+        errorCPMetrics = ErrorCPMetrics(
+            errCPCallpathTimeExclusive={},
+            errCPErrCounts={},
+            savingPotential=0,
+            numCPErrors=0,
+            numRelatedToCPErrors=0
+        )
+
+        # Call checkResults - should use getLeafNodeFromCallPath at line 469
+        result = g.checkResults(
+            cpp=cpp_dict,
+            work=200,
+            timeSavedOnW=30,
+            timeSavedOnCPAllSeries=25,
+            errorCPMetrics=errorCPMetrics
+        )
+
+        # Should return True if validation passes
+        self.assertTrue(result)
+
+    def test_checkResults_returns_none_when_no_testing_data(self):
+        """Test checkResults returns None when testing section is empty."""
+        from crisp.shared.models import ErrorCPMetrics  # noqa: PLC0415
+
+        g = Graph(
+            data="test-trace",  # traceID
+            serviceName="test-service",
+            operationName="test-op",
+            filename="test.json",
+            skipInitializationForTest=True
+        )
+        # Don't set testing data (defaults to {})
+
+        errorCPMetrics = ErrorCPMetrics(
+            errCPCallpathTimeExclusive={},
+            errCPErrCounts={},
+            savingPotential=0,
+            numCPErrors=0,
+            numRelatedToCPErrors=0
+        )
+
+        result = g.checkResults(
+            cpp={},
+            work=0,
+            timeSavedOnW=0,
+            timeSavedOnCPAllSeries=0,
+            errorCPMetrics=errorCPMetrics
+        )
+
+        # Should return None when no testing data
+        self.assertIsNone(result)
+
+    def test_checkResults_aggregates_duplicate_operations(self):
+        """Test that checkResults correctly aggregates operations with same name from different call paths."""
+        from crisp.shared.models import MetricVals  # noqa: PLC0415
+        from crisp.shared.models import ErrorCPMetrics  # noqa: PLC0415
+
+        g = Graph(
+            data="test-trace",  # traceID
+            serviceName="test-service",
+            operationName="test-op",
+            filename="test.json",
+            skipInitializationForTest=True
+        )
+
+        # Set up testing expectations - O2 should have total of 75 (50+25)
+        g.setTestResult({
+            "opTimeExclusive": {
+                "O1": 100,
+                "O2": 75,  # Sum of two different call paths
+            },
+            "totalWork": 200,
+            "timeSavedOnWork": 0,
+            "timeSavedOnCP": 0,
+        })
+
+        # Create call path profile with multiple paths ending in O2
+        cpp_dict = {
+            "[S1] O1": MetricVals(inc=100, excl=100, freq=1, sid="trace1"),
+            "[S1] O1->[S2] O2": MetricVals(inc=50, excl=50, freq=1, sid="trace1"),
+            "[S1] O1->[S3] O2": MetricVals(inc=25, excl=25, freq=1, sid="trace1"),
+        }
+
+        errorCPMetrics = ErrorCPMetrics(
+            errCPCallpathTimeExclusive={},
+            errCPErrCounts={},
+            savingPotential=0,
+            numCPErrors=0,
+            numRelatedToCPErrors=0
+        )
+
+        # Should correctly aggregate O2: 50 + 25 = 75
+        result = g.checkResults(
+            cpp=cpp_dict,
+            work=200,
+            timeSavedOnW=0,
+            timeSavedOnCPAllSeries=0,
+            errorCPMetrics=errorCPMetrics
+        )
+
+        self.assertTrue(result)


### PR DESCRIPTION
## Summary

Ports the first ~960 lines of internal `graph.py` into `crisp/graph.py`.
This covers everything needed to parse a Jaeger trace and build the in-memory
`Graph` data structure. The critical-path computation methods
(`computeCriticalPath` onward) will follow in PRs 9c–9e.

### `crisp/graph.py` — what's included

**Module-level standalone functions** (verbatim, import paths rewritten):
- `isAcceptableParentChildDuration`, `isFuzzyClientServerCall`,
  `isCleanClientServerCall`, `onDifferentHosts`, `adjustChildDuration`,
  `isClientServerCall` — span-relationship classifiers used during graph
  sanitization
- `get_split_child_trace_ids` — detects child trace IDs from split-point
  markers in oversized Jaeger traces
- `extract_root_span_metadata` — extracts service/operation name from the
  root span of a trace

**`Graph` class — build phase** (lines 212–960):
- `__init__` — parses trace data, builds node table, sanitizes overflows,
  matches tags, sets root node
- `GetMatchingTagsInNode` / `GetMatchingTagsInTree` / `findARoot` — tag
  matching and root search
- `computeErrorStats` / `computeGraphStats` / `checkRootAndWarn` — graph-wide
  statistics and validation
- `setTestResult` / `checkMapContent` / `checkResults` — self-test harness
  (driven by `testing` key in Jaeger JSON)
- `getPeerService` / `getSpanKind` / `parseForErrorReturn` /
  `parseForErrorReturnFromParquet` — per-span attribute extraction
- `propagateErrors` / `buildParentChildRelationships` /
  `propagateErrorsToRoots` / `storeNodeData` — graph wiring
- `parseNode` — Jaeger JSON → graph (pass 1–5)
- `parseNodeFromParquet` — Parquet schema → graph
- `removeExcludedOps` / `sanitizeOverflowingChildren` /
  `dumpShrinkStats` / `dumpDeletionStats` — graph cleanup

A placeholder comment marks where `computeCriticalPath` will be inserted in
PR 9c, keeping the file syntactically valid.

### Import path changes (only change from verbatim)
`uber.tooling.program_analysis.critical_path.*` → `crisp.*` throughout.
One internal system name ("BITs traces") removed from a docstring.

### `tests/test_graph.py` — 42 tests

Covers all build-phase methods. All Uber-internal service/operation names in
test fixtures replaced with generic equivalents (e.g. `"my-service"`,
`"ExampleService::doThing"`, `"proxy-relay"`) that exercise the same code
paths. 15 computation-phase tests deferred to PRs 9c/9d and recorded in
`crisp/LAYERS.md`.

## Test plan

- [x] `bazel test //...` — all 5 targets pass (284 tests)
- [x] `grep -n "uber\." crisp/graph.py tests/test_graph.py` — empty
