### PR TITLE
port(crisp): add graph.py — critical-path computation and time-saved methods (PR 9c)

### DIFF
--- a/crisp/LAYERS.md
+++ b/crisp/LAYERS.md
@@ -82,15 +82,15 @@ When porting, apply this decision in order:
 | `tests/test_common.py::TestGetTBClient.*` (×3)                        | PR 11             | TBClient not yet ported.                                                                              |
 | `tests/test_common.py::TestDirExistsOnTB.*`                           | PR 11             | TBClient not yet ported.                                                                              |
 | `tests/test_common.py::TestBlobExistsOnTB.*`                          | PR 11             | TBClient not yet ported.                                                                              |
-| `tests/test_graph.py::GraphTestCase::test_findCriticalPath`            | PR 9c             | `findCriticalPath` not yet ported.                                                                    |
-| `tests/test_graph.py::GraphTestCase::test_findErrorsOnCriticalPath`    | PR 9c             | `findErrorsOnCriticalPath` not yet ported.                                                            |
-| `tests/test_graph.py::GraphTestCase::test_computeTimeSaved`            | PR 9c             | `computeTimeSaved` not yet ported.                                                                    |
-| `tests/test_graph.py::GraphTestCase::test_rootReturnError`             | PR 9c             | `findErrorsOnCriticalPath` not yet ported.                                                            |
-| `tests/test_graph.py::GraphTestCase::test_metrics1`                    | PR 9c             | `findCriticalPath`, `accumeCPMetrics`, `accumeErrorCPMetrics` not yet ported.                        |
-| `tests/test_graph.py::GraphTestCase::test_metrics2`                    | PR 9c             | Same as above.                                                                                        |
-| `tests/test_graph.py::GraphTestCase::test_timeskewMetrics`             | PR 9c             | Same as above.                                                                                        |
-| `tests/test_graph.py::GraphTestCase::test_overlapedSerialCalls`        | PR 9c             | `findCriticalPath`, `accumeCPMetrics` not yet ported.                                                 |
-| `tests/test_graph.py::GraphTestCase::test_exclusion`                   | PR 9c             | `findCriticalPath` not yet ported.                                                                    |
+| `tests/test_graph.py::GraphTestCase::test_findCriticalPath`            | PR 9d             | `findCriticalPath` not yet ported.                                                                    |
+| `tests/test_graph.py::GraphTestCase::test_findErrorsOnCriticalPath`    | PR 9d             | `findErrorsOnCriticalPath` not yet ported.                                                            |
+| `tests/test_graph.py::GraphTestCase::test_computeTimeSaved`            | PR 9d             | `computeTimeSaved` not yet ported.                                                                    |
+| `tests/test_graph.py::GraphTestCase::test_rootReturnError`             | PR 9d             | `findErrorsOnCriticalPath` not yet ported.                                                            |
+| `tests/test_graph.py::GraphTestCase::test_metrics1`                    | PR 9d             | `findCriticalPath`, `accumeCPMetrics`, `accumeErrorCPMetrics` not yet ported.                        |
+| `tests/test_graph.py::GraphTestCase::test_metrics2`                    | PR 9d             | Same as above.                                                                                        |
+| `tests/test_graph.py::GraphTestCase::test_timeskewMetrics`             | PR 9d             | Same as above.                                                                                        |
+| `tests/test_graph.py::GraphTestCase::test_overlapedSerialCalls`        | PR 9d             | `findCriticalPath`, `accumeCPMetrics` not yet ported.                                                 |
+| `tests/test_graph.py::GraphTestCase::test_exclusion`                   | PR 9d             | `findCriticalPath` not yet ported.                                                                    |
 | `tests/test_graph.py::GraphTestCase::test_computeErrDepthHisto`        | PR 9d             | `computeErrDepthHisto`, `computeSupressErrDepthHisto` not yet ported.                                 |
 | `tests/test_graph.py::GraphTestCase::test_getOutboundCount_*` (×5)     | PR 9d             | `getOutboundCount` not yet ported.                                                                    |
 | `tests/test_graph.py::GraphTestCase::test_getAllOutboundCounts`         | PR 9d             | `getAllOutboundCounts` not yet ported.                                                                 |

--- a/crisp/graph.py
+++ b/crisp/graph.py
@@ -960,4 +960,973 @@ class Graph:
                 ),
             )
 
-    # --- computeCriticalPath and subsequent methods will be added in PR 9c ---
+    def computeCriticalPath(self, curNode):
+        # Recursively find the critical path for curNode.
+        debug_on and logging.debug(
+            f"Working on CP parent {curNode} {self.canonicalOpName(curNode)}",
+        )
+
+        # step 0. curNode is obviously on the critical path.
+        criticalPath = [curNode]
+
+        if len(curNode.children) == 0:
+            debug_on and logging.debug(f"{curNode} has no children")
+            return criticalPath
+
+        # step 1. reverse sort all children of curNode by their end time.
+        sortedChildren = sorted(curNode.children, key=lambda x: x.endTime)[::-1]
+
+        # step 2. begin by the child who finishes last
+        lrc = sortedChildren[0]
+        criticalPath.extend(self.computeCriticalPath(lrc))
+        lastStartTime = lrc.startTime
+
+        for cn in sortedChildren[
+            1:
+        ]:  # first one (actually the last one) is already added
+            # step 3. get the child who finished just before the start of lrc's start
+            if self.happensBefore(curNode, sortedChildren, cn, lrc):
+                debug_on and logging.debug(
+                    f"Adding child {cn} {self.canonicalOpName(cn)} to CP",
+                )
+                # # step 4. recur on cn, which is on the critical path.
+                criticalPath.extend(self.computeCriticalPath(cn))
+                lrc = cn
+                lastStartTime = min(lastStartTime, cn.startTime)
+            else:
+                debug_on and logging.debug(
+                    f"NOT adding child {cn} {self.canonicalOpName(cn)} to CP",
+                )
+
+            debug_on and logging.debug(f"lastStartTime = {lastStartTime}")
+        return criticalPath
+
+    # isRPCNode returns true if the node is a server or client node, not a user-defined span.
+    def isRPCNode(self, node):
+        return node.spanKind == SpanKind.SERVER or node.spanKind == SpanKind.CLIENT
+
+    # computePropToRootGraph is used to build an error flamegraph
+    def computePropToRootGraph(self, rootNode=None):
+        """Compute error propagation to root graph.
+
+        Args:
+            rootNode: Optional root node to start from. If None, uses self.rootNode.
+        """
+        node = self._get_root_node(rootNode)
+
+        def callerCalleeSpansInTheSameService(parent, child):
+            return self.processName[parent.pid] == self.processName[child.pid]
+
+        def visitChildrenOfErroringParent(errMap, myPath, parentNode, parentSvcName):
+            # Nodes that return an error (both internal and user-defined)
+            haveErrChild = sum(computePropToRootGraphInternal(errMap, myPath, cn, parentSvcName)
+                               for cn in parentNode.children)
+            # Accumulate error if none of the children reported error
+            if haveErrChild == 0:
+                accumulateInDict(errMap, myPath, 1)
+            return 1  # Since parentNode.returnError is True
+
+        def computePropToRootGraphInternal(errMap, parent, curNode, currentService):
+            nodeService = self.processName[curNode.pid]
+            myPath = self.appendCallPath(parent, curNode)
+
+            if self.isRPCNode(curNode):
+                # Internal node (client/server span)
+                currentService = nodeService
+                if not curNode.returnError:
+                    # Internal node without error: stop propagation
+                    return 0
+                # Proceed to traverse children with error
+                return visitChildrenOfErroringParent(errMap, myPath, curNode, currentService)
+
+            if curNode.returnError:
+                # User-defined span that returns an error
+                currentService = nodeService  # Update current service
+                # Proceed to traverse children with error
+                return visitChildrenOfErroringParent(errMap, myPath, curNode, currentService)
+
+            # User-defined span that does not return an error
+            # Will proceed to a child only if the child is within the same process boundary.
+            haveErrChild = 0
+            for cn in curNode.children:
+                if callerCalleeSpansInTheSameService(curNode, cn):
+                    haveErrChild += computePropToRootGraphInternal(
+                        errMap, myPath, cn, currentService
+                    )
+            # Since curNode.returnError is False, we don't accumulate error here
+            # Return 1 if any child reported an error
+            return 1 if haveErrChild else 0
+
+        errMap = {}
+        rootService = self.processName[node.pid]
+        computePropToRootGraphInternal(errMap, "", node, rootService)
+        return errMap
+
+    # This function computes errors along the critical path (errCP).  That is, we add a node to the errCP
+    # if and only if the node is on the critical path and a) returning an error or b) a ancestor of another
+    # node on the critical path and returning an error
+    def computeErrorsOnCriticalPath(self, curNode):
+        # Recursively find the critical path for curNode.
+        debug_on and logging.debug(
+            f"Working on errCP parent {curNode} {self.canonicalOpName(curNode)}",
+        )
+
+        # step 0. base case
+        if len(curNode.children) == 0:
+            debug_on and logging.debug(f"{curNode} has no children")
+            errCP = [curNode] if curNode.returnError else []
+            return errCP
+
+        # step 1. reverse sort all children of curNode by their end time.
+        sortedChildren = sorted(curNode.children, key=lambda x: x.endTime)[::-1]
+
+        # step 2. begin by the child who finishes last
+        errCP = []
+        lrc = sortedChildren[0]
+        errCP.extend(self.computeErrorsOnCriticalPath(lrc))
+        lastStartTime = lrc.startTime
+
+        # first one (actually the last one) is already added
+        for cn in sortedChildren[1:]:
+            # step 3. get the child who finished just before the start of lrc's start
+            if self.happensBefore(curNode, sortedChildren, cn, lrc):
+                debug_on and logging.debug(
+                    f"Adding child {cn} {self.canonicalOpName(cn)} to errCP",
+                )
+                # step 4. recur on cn, which is on the critical path.
+                errCP.extend(self.computeErrorsOnCriticalPath(cn))
+                lrc = cn
+                lastStartTime = min(lastStartTime, cn.startTime)
+            else:
+                debug_on and logging.debug(
+                    f"NOT adding child {cn} {self.canonicalOpName(cn)} to errCP",
+                )
+
+            debug_on and logging.debug(f"lastStartTime = {lastStartTime}")
+
+        # step 5. add curNode to front assuming some descendant contains error
+        #         or if curNode itself returns error
+        if errCP != [] or curNode.returnError:
+            errCP.insert(0, curNode)
+
+        return errCP
+
+    # This function computes full errors on the critical path (fullErrCP).  The computation is
+    # similar to computErrorsOnCriticalPath except that the computed fullErrCP additionally includes
+    # some nodes F that is not necessarily on the critical path.  A node F can be in fullErrCP
+    # but not in errCP if and only if F has some acenstor G who is on the critical path, G errors
+    # out, and F and G are connected via a chain of nodes who all errored out.
+    #
+    # Example:
+    #   |--- root ---------------------------------|
+    #    |--- A ---------------------------------|
+    #      |--- B ------|--|           |
+    #        |--D ---|  |--- C --------|
+    #
+    # The graph shows that
+    # root -> A -> B -> D
+    #           -> C
+    #
+    # here -> indicates call, and B and C overlap (in parallel).
+    # Assume that A, B, D errored out
+    # Then, the function returns [root, A, B, D].  Note that B and D are not on the critrical path
+    #   but they are included because they are connected to A (which is on the critical path) via a
+    #   chain of nodes that errored out.  Also note that if A hadn't errored out, this function
+    #   would have returned [] (i.e., no errors along the critical path, which is root -> A -> C.
+    #
+    # We should only recur on a curNode if and only if either curNode is on CP or curNode is not on
+    # CP but is connected to an ancestor on CP via a chain of nodes that errored out
+    # Inupt: self (the graph), curNode that we are considering, and onCP that indicate whether the
+    # curNode is onCP or not.
+    def computeFullErrorsOnCriticalPath(self, curNode, onCP):
+        # Recursively find the critical path for curNode.
+        debug_on and logging.debug(
+            f"Working on fullErrCP parent {curNode} {self.canonicalOpName(curNode)}",
+        )
+
+        # step 0. base case
+        # we can stop recurring if curNode does not error out and is not on the critical path
+        if not curNode.returnError and not onCP:
+            return []
+
+        # otherwise curNode either errored out or is on the critical path
+        if len(curNode.children) == 0:
+            debug_on and logging.debug(f"{curNode} has no children")
+            if curNode.returnError:
+                return [curNode]
+            return []
+
+        # step 1. reverse sort all children of curNode by their end time.
+        sortedChildren = sorted(curNode.children, key=lambda x: x.endTime)[::-1]
+
+        # step 2. begin by the child who finishes last
+        fullErrCP = []
+        lrc = sortedChildren[0]
+        # propagate the onCP from curNode: lrc is on the CP if and only if curNode is on the CP
+        fullErrCP.extend(self.computeFullErrorsOnCriticalPath(lrc, onCP))
+        lastStartTime = lrc.startTime
+
+        # first one (actually the last one) is already added
+        for cn in sortedChildren[1:]:
+            # step 3. get the child who finished just before the start of lrc's start
+            if self.happensBefore(curNode, sortedChildren, cn, lrc):
+                debug_on and logging.debug(
+                    f"Recur on child {cn} {self.canonicalOpName(cn)} for fullErrCP, on CP? {onCP}",
+                )
+                # step 4a. recur on the new lrc, who gets parent's onCP
+                fullErrCP.extend(self.computeFullErrorsOnCriticalPath(cn, onCP))
+                lrc = cn
+                lastStartTime = min(lastStartTime, cn.startTime)
+            else:
+                if curNode.returnError:
+                    debug_on and logging.debug(
+                        f"Recur on child {cn} {self.canonicalOpName(cn)} for fullErrCP, on CP? False",
+                    )
+                    # step 4b. recur on cn because curNode (its parent) errored out and is on the critical path.
+                    fullErrCP.extend(
+                        self.computeFullErrorsOnCriticalPath(cn, onCP=False),
+                    )
+            debug_on and logging.debug(f"lastStartTime = {lastStartTime}")
+
+        # step 5. add curNode to front assuming some descendant contains error
+        #         or if curNode itself returns error
+        #         Note that if we got to this point, the curNode must be on the CP or returns error
+        if fullErrCP != [] or curNode.returnError:
+            fullErrCP.insert(0, curNode)
+
+        return fullErrCP
+
+    # This function returns the (total work, work saved) under curNode
+    # When span A invokes span B, we don't know whether span A is doing other useful work
+    # concurrently before B returns or A is simply blocked on B.  There is no way to tell
+    # based on the trace info in the jaeger file.  For now, we will assume A is doing useful work.
+    # As such, we might be overcounting the total work and undercounting timeSavedOnWork due
+    # to error.
+    def computeTimeSavedOnWork(self, curNode):
+        # base case
+        totalWork = curNode.duration
+        timeSavedOnWork = curNode.duration if curNode.returnError else 0
+
+        # will skip if no children
+        for cn in curNode.children:
+            cnWork, cnTimeSaved = self.computeTimeSavedOnWork(cn)
+            totalWork += cnWork
+            timeSavedOnWork += cnTimeSaved
+        return totalWork, timeSavedOnWork
+
+    def calcTimeSaved(self, origLrcEndTime, newLrcEndTime, overlap):
+        saving = origLrcEndTime - newLrcEndTime
+        assert saving >= 0
+        if saving > overlap:
+            timeSaved = saving - overlap
+        else:
+            timeSaved = 0
+        return timeSaved
+
+    # getPBlocks returns a list of PBlocks, where each PBlock is a set of transitively overlapping children.
+    # The list is sorted by the end time of the PBlocks.
+    # For example, consider we have 4 children A, B, C, and D, where A overlaps with B, B overlaps with C, but A
+    # does not overlap with C and finally D does not overlap with any of A, B, or C.
+    # Then, getPBlocks will return a list of 3 PBlocks: [A, B, C], [D].
+    def getPBlocks(self, curNode):
+        pBlocks = []
+        if len(curNode.children) == 0:
+            return pBlocks
+
+        # Put all children in in heapq by their end time.
+        pq = []
+        for c in curNode.children:
+            # Since we need a MAX heap, we use negative end time.
+            heapq.heappush(pq, (-c.endTime, c))
+
+        _, lrc = heapq.heappop(pq)
+        overlap = 0
+        curPBlock = PBlock(curNode, lrc, overlap)
+
+        while len(pq) > 0:
+            # Pop the next child from the heap.
+            _, lrc = heapq.heappop(pq)
+            if curPBlock.HappensAfter(self, lrc):
+                # overlap how much pred overlaps with pBlock
+                overlap = max(0, lrc.endTime - curPBlock.startTime)
+                pBlocks.append(curPBlock)
+                # Start a new block.
+                curPBlock = PBlock(curNode, lrc, overlap)
+            else:  # span is in this block.
+                curPBlock.Add(lrc)
+
+        # Add the last (first in time order) block.
+        pBlocks.append(curPBlock)
+        return pBlocks
+
+    # computeTimeSavedForPBlockPessimistic computes the time saved on the critical path for a PBlock if the error-returing chidren are
+    # eliminated (recursively).
+    # The algorithm is recursive, hence, some child may shrink in length instead of being eliminated.
+    # The "pessimism" comes from the fact that we only consider those children that will end the block.
+    # Time reduced by any of their predecessors (if any) is not considered.
+    # In the following figure: where the pBlock contains 5 children X, A, B, Y, and C.
+    # X runs from 0 to 20; A runs from 20 to 50; B runs from 50 to 100; Y runs from 10 to 30; C runs from 30 to 80.
+    #   |(0)--- root (pBlock) --------------------------------------------(100)|
+    #   |(0)---X---(20)||(20) --- A ---(50)||(50)------------B------------(100)|
+    #         |(10)---Y---(30)||(30) ---------------C------------(80)|
+    # Assume, X shrinks by 10 time units; A shrinks by 20 time units; B shrinks by 30 time units; Y shrinks by 10 time units; C shrinks by 5
+    # time units.
+    # Then, the time saved considers only B and C's shrinkage, ignoring the rest because they are the only two canidates to end the block.
+    # The time saved due to B's shrinkage is 30 time units => 30 time units shirnk for the pBlock.
+    # The time saved due to C's shrinkage is 5 time units => 5 + 20 (distance from the end of C to end of the pBlock)= 25 time units shirnk
+    # for the pBlock.
+    # The resulting time saved is the lesser of the two => 25 time units.
+    # The algorithm proceeds by identifying the last retunring child LRC in the pBlock.
+    # It then computes the time saved for the LRC and checks if a new child happens to become the LRC after the shrinkage.
+    # As soon as we find an a child whose shrunk (if any) time is the LRC, we stop processing any more children because they will only
+    # shrink to a smaller time, where as this one ends later than the rest.
+    # The end time of such "processed" LRC subtracted from the end time of the pBlock is the time saved on the pBlock.
+    # Another way to look at the pessimistic algorithm is that the "start time" of any span does not change; only the end times change, leaving  # noqa: E501
+    # only the last child to dictate the time reduction.
+    def computeTimeSavedForPBlockPessimistic(
+        self,
+        pBlock: PBlock,
+        timeSavedAttribute: str,
+        perBlockFunctionPtr,
+    ):
+        assert len(pBlock.spanSet) > 0
+        # Put all children in to heapq by their end time.
+        UNPROCESSED = 1
+        PROCESSED = 0
+        pq = []
+        for c in pBlock.spanSet:
+            # Since we need a MAX heap, we use negative end time.
+            # Here we want the PROCESSED ones to come out first when times are equal, initially, all are UNPROCESSED.
+            heapq.heappush(pq, (-c.endTime, UNPROCESSED, c))
+
+        while len(pq) > 0:
+            # Pop the next child from the heap.
+            # If it is PROCESSED, we are done with this block.
+            # If it is UNPROCESSED, we need to process it.
+            curEndTime, isProcessed, lrc = heapq.heappop(pq)
+            # if lrc is PROCESSED, we are done with this block.
+            if isProcessed == PROCESSED:
+                # this is the LRC of the block.
+                # Compute the time saved on the block.
+                timeSaved = self.calcTimeSaved(
+                    pBlock.endTime,
+                    -curEndTime,
+                    pBlock.overlap,
+                )
+                assert timeSaved <= (pBlock.endTime - pBlock.startTime)
+                return timeSaved
+            # else => UNPROCESSED
+            lrcTimeSaved = self.computeTimeSavedOnCPReal(
+                lrc,
+                timeSavedAttribute,
+                perBlockFunctionPtr,
+            )
+            assert lrcTimeSaved <= lrc.duration
+            lrcNewEndTime = lrc.endTime - lrcTimeSaved
+            # Push it back into the pq.
+            heapq.heappush(pq, (-lrcNewEndTime, PROCESSED, lrc))
+
+        # should never reach here
+        raise AssertionError
+
+    # Traverse the children block by block, where each block is a set of overlapping children.
+    # For each block, compute the time saved and add it to the total time saved.
+    def computeTimeSavedOnCPReal(
+        self,
+        curNode,
+        timeSavedAttribute: str,
+        perBlockFunctionPtr,
+    ):
+        # Using setattr to make the function generic.
+        setattr(curNode, timeSavedAttribute, 0)
+
+        # step 0, base case
+        # if curNode itself returns error, its time saved is the entire duration
+        if curNode.returnError:
+            v = curNode.duration
+            setattr(curNode, timeSavedAttribute, v)
+            return v
+
+        # if curNode has no children, we are done
+        if len(curNode.children) == 0:
+            return 0
+
+        pBlocks = self.getPBlocks(curNode)
+        assert len(pBlocks) > 0
+        timeSaved = 0
+        for pBlock in pBlocks:
+            v = perBlockFunctionPtr(pBlock, timeSavedAttribute, perBlockFunctionPtr)
+            assert v <= (pBlock.endTime - pBlock.startTime)
+            assert v >= 0
+            timeSaved += v
+
+        # While the time saved in each PBlock is guaranteed to be less than or equal to the duration of the PBlock,
+        # the total time saved is not guaranteed to be less than or equal to the duration of the curNode since the
+        # PBlocks may slightly overlap by the definition of "HappensBefore".
+        # Adjust the time saved to be less than or equal to the duration of the curNode.
+        assert timeSaved >= 0
+        # assert timeSaved <= curNode.duration
+        timeSaved = min(timeSaved, curNode.duration)
+        setattr(curNode, timeSavedAttribute, timeSaved)
+        return timeSaved
+
+    def computeTimeSavedOnCPPessimistic(self, curNode):
+        return self.computeTimeSavedOnCPReal(
+            curNode,
+            "timeSavedOnCPPessimistic",
+            self.computeTimeSavedForPBlockPessimistic,
+        )
+
+    # computeTimeSavedForChain recursively computes the time saved for a chain of spans that were originally in series.
+    # The chain in formed end to start. For each node, its immediate predecessor is the one that happens before it.
+    def computeTimeSavedForChain(
+        self,
+        chainEndNode,
+        pBlock,
+        resultCache,
+        sortedpeers,
+        timeSavedAttribute: str,
+        perBlockFunctionPtr,
+    ):
+        assert chainEndNode
+
+        if chainEndNode in resultCache:
+            return resultCache[chainEndNode]
+
+        timesavedOptimistic = self.computeTimeSavedOnCPReal(
+            chainEndNode,
+            timeSavedAttribute,
+            perBlockFunctionPtr,
+        )
+        setattr(chainEndNode, timeSavedAttribute, timesavedOptimistic)
+
+        # Find predecessors of chainEndNode in sortedpeers.
+        for idx, p in enumerate(sortedpeers):
+            if self.happensBefore(pBlock.parent, pBlock.spanSet, p, chainEndNode):
+                timesavedOptimistic += self.computeTimeSavedForChain(
+                    p,
+                    pBlock,
+                    resultCache,
+                    sortedpeers[idx + 1 :],
+                    timeSavedAttribute,
+                    perBlockFunctionPtr,
+                )
+                break
+
+        resultCache[chainEndNode] = timesavedOptimistic
+        return timesavedOptimistic
+
+    # Returns the spanset of Pblock ordered by thier end time (high to low),
+    # and returns a dict of span -> index in the sorted list.
+    def GetCandidateBlockEndingSpans(self, pBlock: PBlock):
+        assert len(pBlock.spanSet) > 0
+
+        # 1. Sort by span end time to get the LRC in the pBlock.
+        # 2. Get all spans in parallel with LRC.
+
+        # 1. Sort by span end time to get the LRC in the pBlock.
+        sortedSpans = sorted(pBlock.spanSet, key=lambda x: x.endTime)[::-1]
+        lrc = sortedSpans[0]
+
+        # 2. Get all spans in parallel with LRC.
+        blockEndCandidateSpans = {}
+        blockEndCandidateSpans[lrc] = 0
+
+        for idx, s in enumerate(sortedSpans[1:]):
+            # We have visited all spans that are in parallel with LRC.
+            if self.happensBefore(pBlock.parent, sortedSpans, s, lrc):
+                break
+            # Skip the span if it is in series with any of the blockEndCandidateSpans.
+            for k in blockEndCandidateSpans.keys():
+                if self.happensBefore(pBlock.parent, sortedSpans, s, k):
+                    continue
+            blockEndCandidateSpans[s] = idx
+        return sortedSpans, blockEndCandidateSpans
+
+    # This function computes the time saved in a PBlock if the error-returing chidren were eliminated (recursively).
+    # The algorithm is recursive, hence, some child may shrink in length instead of being eliminated.
+    # This is similar to computeTimeSavedForPBlockPessimistic but the time saved is computed for all children forming a chain of successors/predecessor,  # noqa: E501
+    # not just the last ones.
+    # Similar to computeTimeSavedForPBlockPessimistic, it is seeded with the set of block-ending spans that are in parallel.
+    # The "optimism" comes from the fact that by such shrinkage of the chain, spans that were previously in series may now become in parallel.  # noqa: E501
+    # In the following figure: where the pBlock contains 5 children X, A, B, Y, and C.
+    # X runs from 0 to 20; A runs from 20 to 50; B runs from 50 to 100; Y runs from 0 to 30; C runs from 30 to 80.
+    #   |(0)--- root (pBlock) --------------------------------------------(100)|
+    #   |(0)---X---(20)||(20) --- A ---(50)||(50)------------B------------(100)|
+    #   |(0)----Y------(30)||(30) ---------------C------------(80)|
+    # Assume, X shrinks by 10 time units; A shrinks by 20 time units; B shrinks by 30 time units; Y shrinks by 20 time units; C shrinks by 5 time units.  # noqa: E501
+    # There are two chains: X->A->B and Y->C. The time saved considers both chains.
+    # The time saved in X->A->B is 10 + 20 + 30 = 60 time units. This would make the pBlock end at 40 time units.
+    # The time saved in Y->C is 20 + 5 = 25 time units. This would make the pBlock end at 55 time units.
+    # The resulting time saved is the longest chain Y->C and the time saved is 100 - 55 = 45 time units.
+    # Notice here that X was originally in series with C but after the shrinkage, they are in parallel, which is allowed in this optimistic algorithm.  # noqa: E501
+    def computeTimeSavedForPBlockOptimistic(
+        self,
+        pBlock: PBlock,
+        timeSavedAttribute: str,
+        perBlockFunctionPtr,
+    ):
+        # 1. Get the sorted spans and the candidate block ending spans.
+        # 2. Get the longest chains ending in each of blockEndCandidateSpans.
+        # 3. Compute the time saved for each chain.
+        # 4. Return the time saved via the longest chain after reducing their lenths.
+
+        # 1. Get the sorted spans and the candidate block ending spans.
+        sortedSpans, blockEndCandidateSpans = self.GetCandidateBlockEndingSpans(pBlock)
+
+        # 2. Get the longest chains ending in each of blockEndCandidateSpans.
+        #    Each chain is a list of spans.
+        longestSofar = -1
+        resultCache = {}
+
+        for span, idx in blockEndCandidateSpans.items():
+            peerStartIdx = idx + 1
+            timeSaved = self.computeTimeSavedForChain(
+                span,
+                pBlock,
+                resultCache,
+                sortedSpans[peerStartIdx:],
+                timeSavedAttribute,
+                perBlockFunctionPtr,
+            )
+            longestSofar = max(longestSofar, span.endTime - timeSaved)
+
+        assert longestSofar >= 0
+        return max(0, pBlock.endTime - longestSofar - pBlock.overlap)
+
+    def computeTimeSavedOnCPOptimistic(self, curNode):
+        return self.computeTimeSavedOnCPReal(
+            curNode,
+            "timeSavedOnCPOptimistic",
+            self.computeTimeSavedForPBlockOptimistic,
+        )
+
+    # GetNonTransitiveHBInPBlock returns a dictionary of non-transitive happens-before (hb) relationships for each span in the pBlock.
+    # The dictionary is keyed by the span and the value is a set of spans that are in series with the key span.
+    # Consider the following pBlock with 4 span A, B, C, and D.
+    #  |------A------|  |------B------|
+    #         |------C------------------|  |------D------|
+    # The dictionary will be:
+    #  A -> {} # no predecessors.
+    #  B -> {A} # A happend before B.
+    #  C -> {} # no predecessors.
+    #  D -> {C, B} # C and B happen before D. Although A happens before B, it is already in the set of B hence not added.
+
+    def GetNonTransitiveHBInPBlock(self, pBlock: PBlock) -> dict[GraphNode, set]:
+        # A dictionary of non-transitive happens-before (hb) relationships for each span in the pBlock.
+        hbCache = {}
+        # Sort by span end time to process from end to start.
+        sortedSpans = sorted(pBlock.spanSet, key=lambda x: x.endTime)[::-1]
+        ws = {sortedSpans[0]}
+        hbCache[sortedSpans[0]] = set()
+        for s in sortedSpans[1:]:
+            removeList = []
+            for inflight in ws:
+                if not self.happensBeforeSimple(s, inflight):
+                    continue
+                # s is in series with inflight (directly or transitively)
+
+                # Easy case for adding to the set if it is directly in series with inflight.
+                if len(hbCache[inflight]) == 0:
+                    hbCache[inflight].add(s)
+                    continue
+
+                inseriesCount = 0
+                for span in hbCache[inflight]:
+                    if self.happensBeforeSimple(s, span):
+                        inseriesCount += 1
+                # if s is in series with all inflight spans, remove inflight from ws.
+                if inseriesCount == len(hbCache[inflight]):
+                    removeList.append(inflight)
+                elif inseriesCount == 0:
+                    # No transitivity found, hence add it.
+                    hbCache[inflight].add(s)
+                else:
+                    # if s is in series with some but not all inflight spans, do nothing
+                    pass
+
+            # Remove finished from the ws.
+            for r in removeList:
+                ws.remove(r)
+
+            ws.add(s)
+            hbCache[s] = set()
+        return hbCache
+
+    # ComputeAllSeriesTimeSavedForPBlock and ComputeAllSeriesTimeSavedForNode together compute the time saved in a PBlock if the
+    # error-returing chidren were eliminated (recursively).
+    # The algorithm is recursive, hence, some child may shrink in length instead of being eliminated.
+    # This is similar to computeTimeSavedForPBlockOptimistic but it honors all series relationships observed originally.
+    # When a span shrinks, it will drag its successors with it but the grad is capped by the next span in series.
+    # In the following figure: where the pBlock contains 4 children X, A, B, and Y.
+    # X runs from 0 to 20; A runs from 20 to 50; B runs from 60 to 100; Y runs from 0 to 30.
+    #   |(0)--- root (pBlock) --------------------------------------------(100)|
+    #   |(0)---X---(20)||(20) --- A ---(50)|  |(60)----------B------------(100)|
+    #   |(0)----Y------(30)|
+    # Assume, X shrinks by 10 time units; A shrinks by 20 time units; B shrinks by 30 time units; Y shrinks by 5 time units.
+    # Note: there is a 10 time unit gap between A and B.
+    # The time saved considers all series relationships.
+    # The algorithm computes that Y (25) + (10 space betwee B and its original immediate predecessor) + B (30) = 65 time units as the longest chain.  # noqa: E501
+    # The resulting time saved is 100 - 65 = 35 time units.
+    # Notice here that shrinking of X  and A  makes them X (10) + A (10) = 20 time units.
+    # Naively dragging B left by 20 time units would make lose its series relationship with Y.
+    # After Y shrinks it is 25 time units whereas X+A are 20 time units. Hence, Y is the new immediate predecessor of B.
+    # Further more, since there was a 10 time unit gap between A and B originally, that gap is preserved now between Y and B.
+    # The resulting graph can be seen as below:
+    #   |(0)--- root (pBlock) --------------------------------------------(100)|
+    #   |(0)X(10)||(10)A(20)|         |(35)----B---------(65)|
+    #   |(0)----Y------------(25)|
+
+    def ComputeAllSeriesTimeSavedForNode(
+        self,
+        pBlock,
+        hbCache,
+        timeSavedCache,
+        node,
+        timeSavedAttribute: str,
+        perBlockFunctionPtr,
+    ):
+        # Compute the time saved for all spans in series with node (recursively).
+        # hbCache is a dictionary of non-transitive happens-before (hb) relationships for each span in the pBlock.
+        # timeSavedCache is a dictionary of time saved for each span in the pBlock.
+        # node is the span for which we are computing the time saved.
+        if node in timeSavedCache:
+            return timeSavedCache[node]
+
+        nodeTimeSaved = self.computeTimeSavedOnCPReal(
+            node,
+            timeSavedAttribute,
+            perBlockFunctionPtr,
+        )
+        assert nodeTimeSaved >= 0
+        assert nodeTimeSaved <= node.duration
+        minDistance = node.startTime - pBlock.startTime
+        endTimes = {}
+
+        # Obtain how much the predecessors can save.
+        for pred in hbCache[node]:
+            minDistance = max(0, min(minDistance, node.startTime - pred.endTime))
+            predSaved = self.ComputeAllSeriesTimeSavedForNode(
+                pBlock,
+                hbCache,
+                timeSavedCache,
+                pred,
+                timeSavedAttribute,
+                perBlockFunctionPtr,
+            )
+            endTimes[pred] = pred.endTime - predSaved
+
+        # Pick the last finishing predecessor to compute the time saved.
+        logestPredEndTime = pBlock.startTime
+        for endTime in endTimes.values():
+            logestPredEndTime = max(logestPredEndTime, endTime)
+
+        nodeExecutionTime = node.duration - nodeTimeSaved
+        nodeNewEndTime = logestPredEndTime + minDistance + nodeExecutionTime
+        assert nodeNewEndTime <= node.endTime
+        nodeTotalTimeSaved = node.endTime - nodeNewEndTime
+        timeSavedCache[node] = nodeTotalTimeSaved
+        return nodeTotalTimeSaved
+
+    # ComputeAllSeriesTimeSavedForPBlock finds all block ending spans in the pBlock
+    # and computes the time saved for each of them using ComputeAllSeriesTimeSavedForNode.
+    # The time saved is based on least time saved among all candidates.
+    def ComputeAllSeriesTimeSavedForPBlock(
+        self,
+        pBlock,
+        timeSavedAttribute,
+        perBlockFunctionPtr,
+    ):
+        hbCache = self.GetNonTransitiveHBInPBlock(pBlock)
+        _, blockEndCandidateSpans = self.GetCandidateBlockEndingSpans(pBlock)
+
+        # Get the new endtimes for each of blockEndCandidateSpans.
+        longestSofar = -1
+
+        timeSavedCache = {}
+        for span in blockEndCandidateSpans.keys():
+            timeSaved = self.ComputeAllSeriesTimeSavedForNode(
+                pBlock,
+                hbCache,
+                timeSavedCache,
+                span,
+                timeSavedAttribute,
+                perBlockFunctionPtr,
+            )
+            assert timeSaved >= 0
+            assert timeSaved <= pBlock.endTime - pBlock.startTime
+            longestSofar = max(longestSofar, span.endTime - timeSaved)
+
+        assert longestSofar >= 0
+        assert longestSofar <= pBlock.endTime
+        return max(0, pBlock.endTime - longestSofar - pBlock.overlap)
+
+    def ComputeAllSeriesTimeSaved(self, curNode):
+        return self.computeTimeSavedOnCPReal(
+            curNode,
+            "timeSavedOnCPAllSeries",
+            self.ComputeAllSeriesTimeSavedForPBlock,
+        )
+
+
+
+    # ComputeAllSeriesTimeChangeForNode is similar to ComputeAllSeriesTimeSavedForNode.
+    # Instead of computing the time saved, it computes the time change (-ve means saved, +ve means grown).
+    # The time growth is the amount of time that the pBlock would have grown if we injected a delay of deltaDurationMicroSec in each span.
+    # The time saved in the pBlock is the negative of the time growth.
+    # The algorithm is recursive.
+    # When a span grows, it will delay its successors with it.
+    def ComputeAllSeriesTimeChangeForNode(
+        self,
+        pBlock,
+        hbCache,
+        timeDeltaCache,
+        node,
+        timeDeltaAttribute: str,
+        perBlockFunctionPtr,
+        deltaDurationMicroSec: int,
+        targetService=None,
+        targetOperation=None,
+    ):
+        # Compute the time delta for all spans in series with node (recursively).
+        # hbCache is a dictionary of non-transitive happens-before (hb) relationships for each span in the pBlock.
+        # timeDeltaCache is a dictionary of time saved for each span in the pBlock.
+        # node is the span for which we are computing the time saved.
+        if node in timeDeltaCache:
+            return timeDeltaCache[node]
+
+        nodeTimeDelta = self.computeTimeChangeOnCPReal(
+            node,
+            timeDeltaAttribute,
+            perBlockFunctionPtr,
+            deltaDurationMicroSec,
+            targetService,
+            targetOperation,
+        )
+        if deltaDurationMicroSec < 0:
+            # cannot reduce the time of a span by more than its duration.
+            assert nodeTimeDelta >= -node.duration
+        else:
+            # cannot increase the time of a span by a negative value.
+            assert nodeTimeDelta >= 0
+
+        # We need to respect the minimum distance between the start of the span and the start of the pBlock.
+        minDistance = node.startTime - pBlock.startTime
+        endTimes = {}
+
+        # Obtain how much the predecessors can change.
+        for pred in hbCache[node]:
+            # What ever is the least distance between one of the in-series predecessors and the node, use that, but not less than 0.
+            minDistance = max(0, min(minDistance, node.startTime - pred.endTime))
+            predDelta = self.ComputeAllSeriesTimeChangeForNode(
+                pBlock,
+                hbCache,
+                timeDeltaCache,
+                pred,
+                timeDeltaAttribute,
+                perBlockFunctionPtr,
+                deltaDurationMicroSec,
+                targetService,
+                targetOperation,
+            )
+            endTimes[pred] = pred.endTime + predDelta # -ve predDelta will reduce the end time.
+
+        # Pick the last finishing predecessor to compute the time saved.
+        logestPredEndTime = pBlock.startTime
+        for endTime in endTimes.values():
+            logestPredEndTime = max(logestPredEndTime, endTime)
+
+        nodeExecutionTime = node.duration + nodeTimeDelta # -ve nodeTimeDelta will reduce the end time.
+        nodeNewEndTime = logestPredEndTime + minDistance + nodeExecutionTime
+        if deltaDurationMicroSec >= 0:
+            assert nodeNewEndTime >= node.endTime
+        else:
+            assert nodeNewEndTime <= node.endTime
+        nodeTotalTimeDelta = nodeNewEndTime - node.endTime
+        timeDeltaCache[node] = nodeTotalTimeDelta
+        return nodeTotalTimeDelta
+
+    # ComputeAllSeriesTimeGrowthForPBlock finds all block ending spans in the pBlock
+    # and computes the time changed for each of them using ComputeAllSeriesTimeChangeForNode.
+    # The time growth is the maximum growth and time reduction is the minimum reduction based on the in-series candidates.
+    def ComputeAllSeriesTimeChangeForPBlock(
+        self,
+        pBlock,
+        timeDeltaAttribute,
+        perBlockFunctionPtr,
+        deltaDurationMicroSec: int,
+        targetService=None,
+        targetOperation=None,
+    ):
+        hbCache = self.GetNonTransitiveHBInPBlock(pBlock)
+        _, blockEndCandidateSpans = self.GetCandidateBlockEndingSpans(pBlock)
+
+        # Get the new endtimes for each of blockEndCandidateSpans.
+        longestSofar = -1
+
+        timeDeltaCache = {}
+        for span in blockEndCandidateSpans.keys():
+            timeDelta = self.ComputeAllSeriesTimeChangeForNode(
+                pBlock,
+                hbCache,
+                timeDeltaCache,
+                span,
+                timeDeltaAttribute,
+                perBlockFunctionPtr,
+                deltaDurationMicroSec,
+                targetService,
+                targetOperation,
+            )
+            if deltaDurationMicroSec >= 0:
+                assert timeDelta >= 0
+            else:
+                assert -timeDelta <= pBlock.endTime - pBlock.startTime
+            longestSofar = max(longestSofar, span.endTime + timeDelta)
+
+        assert longestSofar >= 0
+        if deltaDurationMicroSec >= 0:
+            assert longestSofar >= pBlock.endTime
+            # use max to keep the number +ve.
+            finalChange = longestSofar - pBlock.endTime - pBlock.overlap # since we assumed series, if there was an overlap, discount it.
+            return max(0, finalChange)
+        else:
+            assert longestSofar <= pBlock.endTime
+            finalChange = pBlock.endTime - longestSofar + pBlock.overlap # since we assumed series, if there was an overlap, discount it.
+        # pBlock.endTime - longestSofar will be a +ve number because longestSofar is smaller than pBlock.endTime
+        # use min to keep the number -ve.
+            return min(0, -finalChange)
+
+    def ComputeAllSeriesTimeChange(self,
+                                   curNode,
+                                   deltaDurationMicroSec: int,
+                                   targetService=None,
+                                   targetOperation=None):
+        return self.computeTimeChangeOnCPReal(
+            curNode,
+            "timeChangeOnCPAllSeries",
+            self.ComputeAllSeriesTimeChangeForPBlock,
+            deltaDurationMicroSec,
+            targetService,
+            targetOperation,
+        )
+    # Traverse the children block by block, where each block is a set of overlapping children.
+    # For each block, compute the time changed and add it to the total time changed.
+    def computeTimeChangeOnCPReal(
+        self,
+        curNode,
+        timeDeltaAttribute: str,
+        perBlockFunctionPtr,
+        deltaDurationMicroSec: int, # this is the amount of time that we are going to inject in each span.
+        # positive value means that we are going to delay the span by that amount of time.
+        # negative value means that we are going to shrink the span by that amount of time.
+        targetService=None,
+        targetOperation=None,
+    ):
+        # Using setattr to make the function generic.
+        setattr(curNode, timeDeltaAttribute, 0)
+
+        # Determine whether the delta applies to this node.
+        # When targetService/targetOperation are specified, only matching SERVER spans get the delta.
+        # When they are None, all SERVER spans get the delta (original behavior).
+        if targetService is not None and targetOperation is not None:
+            node_matches = (
+                curNode.spanKind == SpanKind.SERVER
+                and self.processName.get(curNode.pid, '') == targetService
+                and curNode.opName == targetOperation
+            )
+        else:
+            node_matches = curNode.spanKind == SpanKind.SERVER
+
+        deltaDuration = deltaDurationMicroSec if node_matches else 0
+
+        # cannot reduce the time of a span by more than its duration.
+        if deltaDuration < 0:
+            assert -deltaDuration <= curNode.duration
+
+        if len(curNode.children) == 0:
+            setattr(curNode, timeDeltaAttribute, deltaDuration)
+            return deltaDuration
+
+        pBlocks = self.getPBlocks(curNode)
+        assert len(pBlocks) > 0
+        for pBlock in pBlocks:
+            v = perBlockFunctionPtr(pBlock, timeDeltaAttribute, perBlockFunctionPtr, deltaDurationMicroSec, targetService, targetOperation)
+            if deltaDurationMicroSec < 0:
+                # cannot reduce the time of a span by more than its duration.
+                assert v <= (pBlock.endTime - pBlock.startTime)
+            else:
+                # cannot increase the time of a span by a negative value.
+                assert v >= 0
+            # accumulate the time deltas in each PBlock.
+            # for +ve  deltaDurationMicroSec it will be growing and for -ve deltaDurationMicroSec it will be shrinking.
+            deltaDuration += v
+
+        # The total time saved  (-ve deltaDuration) is not guaranteed to be less than or equal to the duration of the curNode since the
+        # PBlocks may slightly overlap by the definition of "HappensBefore".
+        # Adjust the time saved to be less than or equal to the duration of the curNode.
+        if deltaDurationMicroSec < 0:
+            deltaDuration = max(deltaDuration, -curNode.duration)
+        # there is no limit to how much a span can grow.
+        setattr(curNode, timeDeltaAttribute, deltaDuration)
+        return deltaDuration
+
+    def numSyncEventsInWindowInclusive(self, children, startTime, endTime):
+        numEvents = 0
+
+        for c in children:
+            if c.startTime >= startTime and c.startTime <= endTime:
+                numEvents = numEvents + 1
+            if c.endTime >= startTime and c.endTime <= endTime:
+                numEvents = numEvents + 1
+        return numEvents
+
+    # happensBeforeSimple returns true if the end of childBefore happens before the start of childLater.
+    def happensBeforeSimple(self, childBefore, childLater):
+        # happensBefore returns true if the end of childBefore happens before
+        # the start of childLater.
+
+        # Astart------Aend Bstart-----Bend
+        if childBefore.endTime <= childLater.startTime:
+            return True
+        return False
+
+    def happensBefore(self, parent, children, childBefore, childLater):
+        # happensBefore returns true if the end of childBefore happens before
+        # the start of childLater. however, there is some heuristic to
+        # accomodate clock skew.
+
+        # obviously A HB B if
+        # Astart------Aend Bstart-----Bend
+        if childBefore.endTime < childLater.startTime:
+            return True
+
+        # allow a 1 % overlap with earlier child starting prior to the later child
+        # Allow this:
+        # Astart------Aend
+        #            Bstart-----Bend
+        # Don't allow this
+        # Astart-------Aend
+        #            Bstart-----Bend
+        #     Cstart---Cend
+        if (
+            (childBefore.endTime < childLater.endTime)
+            and (childBefore.startTime < childLater.startTime)
+            and (
+                (childBefore.endTime - childLater.startTime) / parent.duration
+                < get_overlap_allowance()
+            )
+        ):
+            # Now check that there is no other overlapping child in this region
+            nEvt = self.numSyncEventsInWindowInclusive(
+                children,
+                childLater.startTime,
+                childBefore.endTime,
+            )
+            debug_on and logging.debug(
+                f"nEvt for {self.canonicalOpName(childBefore)} = {nEvt}",
+            )
+            if nEvt == 2:  # there can two and only 2 events in this window
+                return True
+        return False
+
+    # --- _get_root_node and subsequent methods will be added in PR 9d ---


### PR DESCRIPTION
## Summary

Extends `crisp/graph.py` with 26 methods covering critical-path computation,
time-saved analysis, and the happens-before / sync-event helpers. All methods
are ported verbatim from internal `graph.py` lines 959–1927; no logic changes.

### Methods added

| Group | Methods |
|---|---|
| Critical path core | `computeCriticalPath`, `isRPCNode`, `computePropToRootGraph` |
| Error CP | `computeErrorsOnCriticalPath`, `computeFullErrorsOnCriticalPath` |
| Time-saved work | `computeTimeSavedOnWork`, `calcTimeSaved`, `getPBlocks` |
| Time-saved CP (pessimistic) | `computeTimeSavedForPBlockPessimistic`, `computeTimeSavedOnCPReal`, `computeTimeSavedOnCPPessimistic`, `computeTimeSavedForChain` |
| Time-saved CP (optimistic) | `GetCandidateBlockEndingSpans`, `computeTimeSavedForPBlockOptimistic`, `computeTimeSavedOnCPOptimistic`, `GetNonTransitiveHBInPBlock` |
| All-series time-saved | `ComputeAllSeriesTimeSavedForNode`, `ComputeAllSeriesTimeSavedForPBlock`, `ComputeAllSeriesTimeSaved` |
| All-series time-change | `ComputeAllSeriesTimeChangeForNode`, `ComputeAllSeriesTimeChangeForPBlock`, `ComputeAllSeriesTimeChange`, `computeTimeChangeOnCPReal` |
| Happens-before / sync | `numSyncEventsInWindowInclusive`, `happensBeforeSimple`, `happensBefore` |

A placeholder comment marks where `_get_root_node` (PR 9d) will be inserted,
keeping the file syntactically valid.

### No new tests in this PR

All computation methods in this PR are only exercised through `findCriticalPath`
and `computeTimeSaved`, which land in PR 9d. The 9 deferred tests
(`test_findCriticalPath`, `test_metrics1/2`, `test_timeskewMetrics`, etc.)
are updated in `crisp/LAYERS.md` from "PR 9c" → "PR 9d" and will be unblocked
there.

### `crisp/LAYERS.md`

All 9 deferred test entries previously targeting PR 9c updated to PR 9d.

## Test plan

- [x] `bazel test //...` — all 5 existing targets pass (no regressions)
- [x] `grep -n "uber\." crisp/graph.py` — empty
