### PR TITLE
port(crisp): add graph.py — final methods and unblock 14 deferred tests (PR 9d)

### DIFF
--- a/crisp/LAYERS.md
+++ b/crisp/LAYERS.md
@@ -82,17 +82,4 @@ When porting, apply this decision in order:
 | `tests/test_common.py::TestGetTBClient.*` (×3)                        | PR 11             | TBClient not yet ported.                                                                              |
 | `tests/test_common.py::TestDirExistsOnTB.*`                           | PR 11             | TBClient not yet ported.                                                                              |
 | `tests/test_common.py::TestBlobExistsOnTB.*`                          | PR 11             | TBClient not yet ported.                                                                              |
-| `tests/test_graph.py::GraphTestCase::test_findCriticalPath`            | PR 9d             | `findCriticalPath` not yet ported.                                                                    |
-| `tests/test_graph.py::GraphTestCase::test_findErrorsOnCriticalPath`    | PR 9d             | `findErrorsOnCriticalPath` not yet ported.                                                            |
-| `tests/test_graph.py::GraphTestCase::test_computeTimeSaved`            | PR 9d             | `computeTimeSaved` not yet ported.                                                                    |
-| `tests/test_graph.py::GraphTestCase::test_rootReturnError`             | PR 9d             | `findErrorsOnCriticalPath` not yet ported.                                                            |
-| `tests/test_graph.py::GraphTestCase::test_metrics1`                    | PR 9d             | `findCriticalPath`, `accumeCPMetrics`, `accumeErrorCPMetrics` not yet ported.                        |
-| `tests/test_graph.py::GraphTestCase::test_metrics2`                    | PR 9d             | Same as above.                                                                                        |
-| `tests/test_graph.py::GraphTestCase::test_timeskewMetrics`             | PR 9d             | Same as above.                                                                                        |
-| `tests/test_graph.py::GraphTestCase::test_overlapedSerialCalls`        | PR 9d             | `findCriticalPath`, `accumeCPMetrics` not yet ported.                                                 |
-| `tests/test_graph.py::GraphTestCase::test_exclusion`                   | PR 9d             | `findCriticalPath` not yet ported.                                                                    |
-| `tests/test_graph.py::GraphTestCase::test_computeErrDepthHisto`        | PR 9d             | `computeErrDepthHisto`, `computeSupressErrDepthHisto` not yet ported.                                 |
-| `tests/test_graph.py::GraphTestCase::test_getOutboundCount_*` (×5)     | PR 9d             | `getOutboundCount` not yet ported.                                                                    |
-| `tests/test_graph.py::GraphTestCase::test_getAllOutboundCounts`         | PR 9d             | `getAllOutboundCounts` not yet ported.                                                                 |
-| `tests/test_graph.py::GraphTestCase::test_getCycles`                   | PR 9d             | `getCycles` not yet ported.                                                                           |
-| `tests/test_graph.py::TestCrossRegionDetection.*` (×5)                 | PR 9d             | `getCrossRegionCalls` not yet ported.                                                                 |
+| *(all PR 9d items unblocked — see port/pr-09d-graph-final commit)*      | —                 | —                                                                                                     |

--- a/crisp/graph.py
+++ b/crisp/graph.py
@@ -1929,4 +1929,735 @@ class Graph:
                 return True
         return False
 
-    # --- _get_root_node and subsequent methods will be added in PR 9d ---
+    def _get_root_node(self, rootNode=None):
+        """Get the root node to use for analysis.
+
+        Args:
+            rootNode: Optional root node. If None, uses self.rootNode.
+
+        Returns:
+            The root node to use for analysis.
+        """
+        return rootNode if rootNode is not None else self.rootNode
+
+    def findCriticalPath(self, rootNode=None):
+        """Find the critical path starting from the given root node.
+
+        Args:
+            rootNode: Optional root node to start from. If None, uses self.rootNode.
+        """
+        node = self._get_root_node(rootNode)
+        res = self.computeCriticalPath(node)
+        return res
+
+    def findErrorsOnCriticalPath(self, rootNode=None):
+        """Find errors on the critical path starting from the given root node.
+
+        Args:
+            rootNode: Optional root node to start from. If None, uses self.rootNode.
+        """
+        node = self._get_root_node(rootNode)
+        fullErrCP = self.computeFullErrorsOnCriticalPath(node, onCP=True)
+        return fullErrCP
+
+    def computeTimeChange(self, deltaDurationMicroSec, rootNode=None, targetService=None, targetOperation=None):
+        """Compute time change for the given root node.
+
+        Args:
+            deltaDurationMicroSec: Time delta in microseconds.
+            rootNode: Optional root node to start from. If None, uses self.rootNode.
+            targetService: Optional service name to filter. When set (along with
+                targetOperation), only SERVER spans matching both are affected.
+            targetOperation: Optional operation name to filter.
+        """
+        node = self._get_root_node(rootNode)
+        timeChangeOnCPAllSeries = self.ComputeAllSeriesTimeChange(
+            node, deltaDurationMicroSec, targetService, targetOperation,
+        )
+
+        return timeChangeOnCPAllSeries
+
+    def _findMatchingNodes(self, node, targetService, targetOperation, result):
+        """Recursively find all SERVER nodes matching target service+operation."""
+        if (
+            node.spanKind == SpanKind.SERVER
+            and self.processName.get(node.pid, '') == targetService
+            and node.opName == targetOperation
+        ):
+            result.append(node)
+        for child in node.children:
+            self._findMatchingNodes(child, targetService, targetOperation, result)
+
+    def computeProjectedCPMetrics(self, deltaMicroSec, targetService, targetOperation, rootNode=None):
+        """Compute projected CPMetrics by mutating target span durations,
+        recomputing the critical path, and restoring originals.
+
+        Context-insensitive: ALL instances of targetService+targetOperation
+        get the delta applied regardless of call-path context.
+
+        The workflow is:
+          1. Find matching spans and save originals
+          2. Mutate durations (with containment floor) and cascade to ancestors
+          3. Recompute critical path + CPMetrics on the mutated graph
+          4. Restore all originals (try/finally for safety)
+          5. Compute analytical latency change via computeTimeChange
+
+        The containment floor ensures no node shrinks below the time range
+        occupied by its children (children have fixed absolute timestamps).
+        This keeps both inclusive and exclusive times physically consistent
+        in the projected flame graph.
+
+        Args:
+            deltaMicroSec: Time delta in microseconds (negative = faster, positive = slower).
+            targetService: Service name to target.
+            targetOperation: Operation name to target.
+            rootNode: Optional root node. If None, uses self.rootNode.
+
+        Returns:
+            Tuple of (projected_CPMetrics, projected_latency_change) where
+            projected_CPMetrics is a CallPathProfile and projected_latency_change
+            is the time delta on the critical path in microseconds.
+        """
+        node = self._get_root_node(rootNode)
+
+        # Step 1: Identify all SERVER spans matching the target service+operation.
+        matching_nodes = []
+        self._findMatchingNodes(node, targetService, targetOperation, matching_nodes)
+
+        # Step 2: Mutate each matching node and propagate the change to ancestors.
+        # originals stores (duration, endTime) for every mutated node so we can
+        # restore the graph after recomputing the critical path.
+        originals = {}
+        for n in matching_nodes:
+            # --- Containment floor for the target node ---
+            # A node must still encompass all its children after mutation.
+            # Children have fixed absolute timestamps (we don't reposition them),
+            # so the node's endTime can't go below its latest child's endTime.
+            #
+            #   min_duration = max(child.endTime) - node.startTime
+            #
+            # Example: node [0..200], children [10..90] and [50..130].
+            #   max(endTime) - start = 130 - 0 = 130  (all children fit)
+            #   sum(durations) = 160         → 40  (WRONG: child2 extends to 130)
+            #
+            # Leaf spans (no children) can shrink all the way to 0.
+            if n.children:
+                max_child_end = max(c.endTime for c in n.children)
+                min_duration = max(0, max_child_end - n.startTime)
+            else:
+                min_duration = 0
+
+            originals[n] = (n.duration, n.endTime)
+            old_duration = n.duration
+            n.duration = max(min_duration, n.duration + deltaMicroSec)
+            n.endTime = n.startTime + n.duration
+            # effective_delta is the *actual* change after floor clamping,
+            # which may be smaller in magnitude than the requested delta.
+            effective_delta = n.duration - old_duration
+
+            # --- Cascade to ancestors ---
+            # Propagate the duration change up the parent chain so that the
+            # root's inclusive time (e2e latency) reflects the child's change.
+            # The same containment floor rule applies: an ancestor can't shrink
+            # below its children's time extent (which includes the just-mutated
+            # target and any unmutated siblings).
+            # effective_delta is recalculated at each level; if an ancestor is
+            # clamped (e.g. a sibling extends further), less delta propagates up.
+            ancestor = n.parent
+            while ancestor is not None:
+                if ancestor not in originals:
+                    originals[ancestor] = (ancestor.duration, ancestor.endTime)
+                old_ancestor_dur = ancestor.duration
+                max_child_end = max(c.endTime for c in ancestor.children)
+                ancestor_floor = max(0, max_child_end - ancestor.startTime)
+                ancestor.duration = max(ancestor_floor, ancestor.duration + effective_delta)
+                ancestor.endTime = ancestor.startTime + ancestor.duration
+                effective_delta = ancestor.duration - old_ancestor_dur
+                if effective_delta == 0:
+                    break
+                ancestor = ancestor.parent
+
+        # Step 3: Recompute CP and CPMetrics on the mutated graph.
+        # The finally block guarantees restoration even if an exception occurs.
+        try:
+            projected_cp = self.findCriticalPath(rootNode=node)
+            projected_CPMetrics, _ = self.accumeCPMetrics(
+                projected_cp, self.filename or "", node,
+            )
+        finally:
+            # Step 4: Restore all mutated nodes to their original state.
+            for n, (orig_dur, orig_end) in originals.items():
+                n.duration = orig_dur
+                n.endTime = orig_end
+
+        # Step 5: Analytical latency change on the *original* (restored) graph.
+        # computeTimeChange asserts -delta <= duration for each matching span,
+        # so cap the effective delta to the smallest matching span's duration.
+        effective_delta = deltaMicroSec
+        if matching_nodes and deltaMicroSec < 0:
+            min_duration = min(n.duration for n in matching_nodes)
+            effective_delta = max(deltaMicroSec, -min_duration)
+
+        projected_latency = self.computeTimeChange(
+            effective_delta, rootNode=node,
+            targetService=targetService, targetOperation=targetOperation,
+        )
+
+        return projected_CPMetrics, projected_latency
+
+    def computeTimeSaved(self, rootNode=None):
+        """Compute time saved metrics for the given root node.
+
+        Args:
+            rootNode: Optional root node to start from. If None, uses self.rootNode.
+        """
+        node = self._get_root_node(rootNode)
+        totalWork, timeSavedOnW = self.computeTimeSavedOnWork(node)
+        # timeSavedOnCP = self.computeTimeSavedOnCPOld(node)
+        timeSavedOnCPOptimistic = (
+            self.computeTimeSavedOnCPOptimistic(node)
+            if is_optimistic_enabled()
+            else 0
+        )
+        timeSavedOnCPPessimistic = (
+            self.computeTimeSavedOnCPPessimistic(node)
+            if is_pessimistic_enabled()
+            else 0
+        )
+        timeSavedOnCPAllSeries = self.ComputeAllSeriesTimeSaved(node)
+
+        return (
+            totalWork,
+            timeSavedOnW,
+            timeSavedOnCPPessimistic,
+            timeSavedOnCPOptimistic,
+            timeSavedOnCPAllSeries,
+        )
+
+    def canonicalOpName(self, node):
+        # return the canonical name of the span in "[serviceName] operationName" fashion
+        return "[" + self.processName[node.pid] + "] " + node.opName
+
+    def appendCallPath(self, prefix, graphNode):
+        # appendCallPath appends canoncal name of graphNode to running prefix
+        str = self.canonicalOpName(graphNode)
+        if len(prefix):
+            str = prefix + "->" + str
+        return str
+
+    def getCallPath(self, graphNode):
+        # getCallPath obtains the stringified form of how the rootnode reaches graphNode
+        # the operation names are joined with "->".
+        # TODO: this can be optimized via memoization.
+        str = self.canonicalOpName(graphNode)
+        while graphNode.parent:
+            str = self.canonicalOpName(graphNode.parent) + "->" + str
+            graphNode = graphNode.parent
+        return str
+
+    def sanitizeExclusiveTime(self, timeMap):
+        for k, v in timeMap.items():
+            if v < 0:
+                debug_on and logging.debug(
+                    f"In {self.filename} zero out time entry for key {k}",
+                )
+                timeMap[k] = 0
+
+    # Accumulate inclusive and exclustive metrics for regular critical path.
+    # Include both flat (just the operation no call path) and call path profiles.
+    # Maintain an example of worst case span seen for each call path.
+    def accumeCPMetrics(self, criticalPath, traceId, rootNode):
+        cpp = CallPathProfile({}, 1, traceId)
+        sidTimeExclusive = {}
+        for n in reversed(criticalPath):
+            sid = n.sid
+            opCallpath = self.getCallPath(n)
+            metricVal = MetricVals(
+                inc=n.duration,
+                excl=n.duration,
+                freq=1,
+                sid=sid,
+            )
+            cpp.Upsert(opCallpath, metricVal)
+            accumulateInDict(sidTimeExclusive, sid, n.duration)
+
+            if n == rootNode:
+                continue
+
+            # for exclusive metrics, subtract the child's duration from its parent.
+            # if the parent is visited after the child(ren) we will have an existing
+            # -ve value to which a positive value will be added above.
+            parentCC = self.getCallPath(n.parent)
+            cpp.Upsert(
+                parentCC,
+                MetricVals(inc=0, excl=-n.duration, freq=0, sid=-1),
+            )
+            accumulateInDict(sidTimeExclusive, n.parent.sid, -n.duration)
+
+        # due to how we fix time skew, we might have ended up with negative exclusive times
+        # go through the dictionaries and zero out the negative time entries
+        cpp.Sanitize("excl", debug_on)
+        self.sanitizeExclusiveTime(sidTimeExclusive)
+
+        return cpp, sidTimeExclusive
+
+    def handleFullErrCPMetrics(self, fullErrCP, sidTimeExclusive):
+        errCPCallpathTimeExclusive = {}
+        errCPErrCounts = {}
+        # a set containing nodes whose children along the fullErrCP returned errors
+        childReturnedErrors = set()
+        sidFullErrTimeExclusive = {}
+        numCPErrors = 0
+        numRelatedToCPErrors = 0
+        # a map [OpName]: <timeSaved, latency, opCount> ((SavingData)
+        # though we don't use the latency here; it's used when we aggregate
+        # across traces
+        savingPotential = {}
+
+        for n in reversed(fullErrCP):
+            sid = n.sid
+            op = self.canonicalOpName(n)
+            opCallpath = self.getCallPath(n)
+
+            if n.returnError:
+                # if sid is in sidTimeExclusive, it is on the critical path
+                if sid in sidTimeExclusive:
+                    sidTimeEx = sidTimeExclusive[sid]
+                    accumulateInDict(
+                        savingPotential,
+                        op,
+                        SavingData(n.timeSavedOnCPAllSeries, 0, 1),
+                    )
+                    opCallpath = SYNTHETIC_ERR_CP_ROOT + "->" + opCallpath
+                    numCPErrors = numCPErrors + 1
+
+                else:  # this is a node that is not actually on the critical path
+                    accumulateInDict(sidFullErrTimeExclusive, sid, n.duration)
+                    # this must to be true as only rootNode has no parent and
+                    # rootNode must be on the critical path
+                    assert n.parent
+                    accumulateInDict(sidFullErrTimeExclusive, n.parent.sid, -n.duration)
+
+                    # in the flamegraph, for a node that is not on the CP, it has either its duration
+                    # along the full-error callpath or the sum of durations of all its error-ed out
+                    # children if the sum is larger than its duration
+                    sidTimeEx = sidFullErrTimeExclusive[sid]
+                    if sidTimeEx < 0:
+                        sidTimeEx = 0
+                    opCallpath = SYNTHETIC_FULL_ERR_NON_CP_ROOT + "->" + opCallpath
+                    numRelatedToCPErrors = numRelatedToCPErrors + 1
+
+                accumulateInDict(errCPCallpathTimeExclusive, opCallpath, sidTimeEx)
+                if len(n.children) == 0 or n not in childReturnedErrors:
+                    # n is the leaf node in the path that returns error; increment self error count
+                    accumulateInDict(
+                        errCPErrCounts,
+                        opCallpath,
+                        ErrCountsData(selfErrors=1),
+                    )
+                elif n in childReturnedErrors:
+                    # both n and at least one of its children return errors
+                    accumulateInDict(
+                        errCPErrCounts,
+                        opCallpath,
+                        ErrCountsData(propagatedErrors=1),
+                    )
+                # since n returned an error, add n's parent into the childReturnedError set
+                childReturnedErrors.add(n.parent)
+
+            elif n in childReturnedErrors:
+                opCallpath = SYNTHETIC_ERR_CP_ROOT + "->" + opCallpath
+                # n itself did not return error but at least one of its children did
+                accumulateInDict(
+                    errCPErrCounts,
+                    opCallpath,
+                    ErrCountsData(stoppedErrors=1),
+                )
+
+        return (
+            errCPCallpathTimeExclusive,
+            errCPErrCounts,
+            numCPErrors,
+            numRelatedToCPErrors,
+            savingPotential,
+        )
+
+    # Accumulate inclusive and exclustive metrics for error critical path.
+    # Include both flat (just the operation no call path) and call path profiles.
+    # Need the opTimeExclusive result from the regular critical path metrics
+
+    def accumeErrorCPMetrics(self, fullErrCP, sidTimeExclusive):
+        (
+            errCPCallpathTimeExclusive,
+            errCPErrCounts,
+            numCPErrors,
+            numRelatedToCPErrors,
+            savingPotential,
+        ) = self.handleFullErrCPMetrics(fullErrCP, sidTimeExclusive)
+
+        return ErrorCPMetrics(
+            errCPCallpathTimeExclusive,
+            errCPErrCounts,
+            savingPotential,
+            numCPErrors,
+            numRelatedToCPErrors,
+        )
+
+    def computeErrDepthHisto(
+        self,
+        curNode: GraphNode,
+        myDepth: int,
+        propToRootHisto: dict,
+        notPropToRootHisto: dict,
+        proprgatesToRoot: bool,
+        childFilter: Callable[[GraphNode], bool],
+    ) -> None:
+        # chain to root broken
+        if not curNode.returnError:
+            proprgatesToRoot = False
+
+        # iterate over childeren
+        childHasError = False
+        for c in curNode.children:
+            if c.returnError:
+                childHasError = True
+
+            if childFilter(c):
+                self.computeErrDepthHisto(
+                    c,
+                    myDepth + 1,
+                    propToRootHisto,
+                    notPropToRootHisto,
+                    proprgatesToRoot,
+                    childFilter,
+                )
+
+        if curNode.returnError:
+            if not childHasError:  # this is self error.
+                if proprgatesToRoot:
+                    accumulateInDict(propToRootHisto, myDepth, 1)
+                else:
+                    accumulateInDict(notPropToRootHisto, myDepth, 1)
+            else:
+                pass  # this is Prop error
+
+    def computeSupressErrDepthHisto(
+        self,
+        curNode: GraphNode,
+        myDepth: int,
+        histo: dict,
+        childFilter: Callable[[GraphNode], bool],
+    ) -> None:
+        # iterate over childeren
+        childHasError = False
+        for c in curNode.children:
+            if c.returnError:
+                childHasError = True
+
+            if childFilter(c):
+                self.computeSupressErrDepthHisto(c, myDepth + 1, histo, childFilter)
+
+        if not curNode.returnError and childHasError:
+            accumulateInDict(histo, myDepth, 1)
+
+    # computes the max depth of self error that propagated to root
+    def computeMaxErrDepthPropagatedToRoot(self, curNode, myDepth):
+        maxDepth = DEFAULT_MAX_DEPTH
+
+        if not curNode.returnError:
+            # base case: if I don't error out, we are done;
+            return maxDepth  # should be -1
+
+        elif len(curNode.children) == 0:
+            # another base case: if I error out but I have no children,
+            # the max self error depth is then myDepth
+            return myDepth
+
+        # if I have children, continue to traverse
+        for c in curNode.children:
+            chDepth = self.computeMaxErrDepthPropagatedToRoot(c, myDepth + 1)
+            if chDepth > maxDepth:
+                maxDepth = chDepth
+        return maxDepth
+
+    def getErrDepthHisto(self, filter: Callable[[GraphNode], bool]):
+        propToRootHisto = {}
+        notPropToRootHisto = {}
+        self.computeErrDepthHisto(
+            self.rootNode,
+            1,
+            propToRootHisto,
+            notPropToRootHisto,
+            True,
+            filter,
+        )
+        propToRootHistoQuantized = QuantizedMetrics(propToRootHisto)
+        notPropToRootHistoQuantized = QuantizedMetrics(notPropToRootHisto)
+        return propToRootHistoQuantized, notPropToRootHistoQuantized
+
+    def getSupressErrDepthHisto(self, filter: Callable[[GraphNode], bool]):
+        histo = {}
+        self.computeSupressErrDepthHisto(self.rootNode, 1, histo, filter)
+        histoQuantized = QuantizedMetrics(histo)
+        return histoQuantized
+
+    def getAllOutboundCounts(self) -> dict:
+        '''
+        Walk all spans using BFS and count outbound connections for each service.
+        Returns a dictionary mapping service names to lists of outbound counts.
+        '''
+        if self.rootNode is None:
+            return {}
+
+        service_counts = {}
+        queue = [self.rootNode]
+        visited = set()
+
+        while queue:
+            node = queue.pop(0)
+
+            if node.sid in visited:
+                continue
+            visited.add(node.sid)
+
+            service_name = self.processName[node.pid]
+            outbound_count = len(node.children)
+
+            if service_name not in service_counts:
+                service_counts[service_name] = []
+            service_counts[service_name].append(outbound_count)
+
+            queue.extend(node.children)
+
+        return service_counts
+
+    def getOutboundCount(self, serviceName: str) -> list:
+        '''
+        Walk all spans using BFS and count outbound connections for each span
+        of the given service name. Returns a list of outbound counts for the service.
+        '''
+        all_counts = self.getAllOutboundCounts()
+        return all_counts.get(serviceName, [])
+
+    def getMetrics(
+        self,
+        traceID,
+        criticalPath,
+        fullErrCP,
+        totalWork,
+        timeSavedOnWork,
+        timeSavedOnCPPessimistic,
+        timeSavedOnCPOptimistic,
+        timeSavedOnCPAllSeries,
+        propToRootErrCCT,
+        rootNode=None,
+    ):
+        """Get metrics for the given root node.
+
+        Args:
+            traceID: Trace identifier
+            criticalPath: Critical path nodes
+            fullErrCP: Full error critical path
+            totalWork: Total work computed
+            timeSavedOnWork: Time saved on work
+            timeSavedOnCPPessimistic: Time saved on CP (pessimistic)
+            timeSavedOnCPOptimistic: Time saved on CP (optimistic)
+            timeSavedOnCPAllSeries: Time saved on CP (all series)
+            propToRootErrCCT: Propagated to root error CCT
+            rootNode: Optional root node to use. If None, uses self.rootNode.
+
+        Returns:
+            Metrics object for this root node
+        """
+        node = self._get_root_node(rootNode)
+
+        # these are used to populate ErrorMetrics (see comment above the
+        # class definition for more detailed description)
+        errCounts = {}  # map from opCallpath to ErrCountsData
+        errCallChainCounts = {}  # map from opCallPath to error callchain counts
+        selfErrDepthList = []  # a list of self-error depth
+        stoppedErrDepthList = []  # a list of stopped-error depth
+        depthMap = {}  # map from depth to ErrCountsData
+        propLengthMap = {}  # map from propagation length to # of selr errors
+        resiliencyMap = {}  # map from opName to ErrCountsData
+
+        # Compute inclusive and exclustive metrics for regular and error critical path.
+        CPMetrics, sidTimeExclusive = self.accumeCPMetrics(criticalPath, traceID, node)
+        traceSz = self.filesz
+        errCPMetrics = self.accumeErrorCPMetrics(fullErrCP, sidTimeExclusive)
+        descendants, depth = self.computeGraphStats(node)
+        maxErrDepthPropToRoot = -1
+
+        # we assume the root node has depth 1
+        if node.returnError:
+            maxErrDepthPropToRoot = self.computeMaxErrDepthPropagatedToRoot(
+                node,
+                1,
+            )
+            stopErrNodeDepth = 0
+        else:
+            stopErrNodeDepth = 1
+        numAllErrors = self.computeErrorStats(
+            node,
+            1,
+            stopErrNodeDepth,
+            errCounts,
+            errCallChainCounts,
+            selfErrDepthList,
+            stoppedErrDepthList,
+            depthMap,
+            propLengthMap,
+            resiliencyMap,
+        )
+
+        cpSet = set(criticalPath)
+        propToRootHistoQuantized, notPropToRootHistoQuantized = self.getErrDepthHisto(
+            lambda x: True,  # noqa: ARG005
+        )
+        (
+            propToRootOnCPHistoQuantized,
+            notPropToRootOnCPHistoQuantized,
+        ) = self.getErrDepthHisto(lambda x: x in cpSet)
+
+        supressHistoQuantized = self.getSupressErrDepthHisto(lambda x: True)  # noqa: ARG005
+        supressOnCPHistoQuantized = self.getSupressErrDepthHisto(lambda x: x in cpSet)
+
+        errMetrics = ErrorMetrics(
+            numAllErrors,
+            errCounts,
+            errCallChainCounts,
+            selfErrDepthList,
+            stoppedErrDepthList,
+            depthMap,
+            propLengthMap,
+            resiliencyMap,
+            maxErrDepthPropToRoot,
+            propToRootHistoQuantized,
+            notPropToRootHistoQuantized,
+            propToRootOnCPHistoQuantized,
+            notPropToRootOnCPHistoQuantized,
+            supressHistoQuantized,
+            supressOnCPHistoQuantized,
+        )
+
+        if debug_on and self.numProxyRoots != 0:
+            logging.debug(f"file {self.filename} has {self.numProxyRoots} proxy roots")
+
+        cycles = {}
+        self.getCycles(node, [], [], cycles)
+
+        crossRegionCalls = {}
+        self.getCrossRegionCalls(node, crossRegionCalls)
+
+        return Metrics(
+            traceID,
+            traceSz,
+            CPMetrics,
+            errCPMetrics,
+            errMetrics,
+            totalWork,
+            timeSavedOnWork,
+            node.duration,
+            timeSavedOnCPPessimistic,
+            timeSavedOnCPOptimistic,
+            timeSavedOnCPAllSeries,
+            node.sid,
+            descendants,
+            depth,
+            len(criticalPath),
+            node.returnError,
+            propToRootErrCCT,
+            self.isCtfTest,
+            self.numProxyRoots,
+            self.tags,
+            cycles,
+            crossRegionCalls,
+        )
+
+    def getCycles(self, node, nodeCallPath, opCallPath, cycles):
+        if self.canonicalOpName(node) in opCallPath:
+            # Find the last occurence of the operation in the call path
+            parent_self_ind = len(opCallPath) - opCallPath[::-1].index(self.canonicalOpName(node)) - 1
+            parent_self = nodeCallPath[parent_self_ind]
+            if node.spanKind == SpanKind.CLIENT and parent_self.spanKind == SpanKind.CLIENT:
+                if len(set(opCallPath[parent_self_ind:])) > 1:
+                    cycles[node.sid] = opCallPath[parent_self_ind:]+[self.canonicalOpName(node)]  # noqa: RUF005
+                    logging.debug(f"Cycle detected in {self.filename} for {self.canonicalOpName(node)}, spanID: {node.sid}")
+                    logging.debug(f"call path: {' -> '.join(opCallPath[parent_self_ind:])} -> {self.canonicalOpName(node)}")
+                else:
+                    cycles[node.sid] = opCallPath[parent_self_ind:]+[self.canonicalOpName(node)]  # noqa: RUF005
+                    logging.debug(f"Cycle detected in {self.filename} for {self.canonicalOpName(node)}, spanID: {node.sid}")
+                    logging.debug("But there is only one operation in the cycle")
+        nodeCallPath.append(node)
+        opCallPath.append(self.canonicalOpName(node))
+        for childNode in node.children:
+            self.getCycles(childNode, nodeCallPath, opCallPath, cycles)
+        nodeCallPath.pop()
+        opCallPath.pop()
+
+    def getCrossRegionCalls(self, node, crossRegionCalls):
+        """
+        Detect cross-region calls where parent and child are in different regions
+        and have the exact same operation name.
+        """
+        # Check if this node has a parent
+        if node.parent:
+            parent = node.parent
+            # Get region/zone info for parent and child
+            parentRegionInfo = self.regionMap.get(parent.pid)
+            childRegionInfo = self.regionMap.get(node.pid)
+
+            if parentRegionInfo and childRegionInfo:
+                # Extract region names by stripping trailing digits from region codes
+                # (e.g. "us-west-1" stays "uswest", "eu-west-1a" becomes "euwest")
+                parentRegion = ''.join(c for c in parentRegionInfo if c.isalpha())
+                childRegion = ''.join(c for c in childRegionInfo if c.isalpha())
+
+                # Check if they are in different regions and have the same operation name
+                if (parentRegion != childRegion and parent.opName == node.opName):
+                    # Calculate duration information
+                    parentDuration = parent.duration if hasattr(parent, 'duration') else 0
+                    childDuration = node.duration if hasattr(node, 'duration') else 0
+                    durationRatio = parentDuration / childDuration if childDuration > 0 else 0
+
+                    crossRegionCall = {
+                        'parentSpanId': parent.sid,
+                        'childSpanId': node.sid,
+                        'operationName': node.opName,
+                        'parentRegion': parentRegion,
+                        'childRegion': childRegion,
+                        'parentService': self.processName.get(parent.pid, 'unknown'),
+                        'childService': self.processName.get(node.pid, 'unknown'),
+                        'parentDuration': parentDuration,
+                        'childDuration': childDuration,
+                        'durationRatio': round(durationRatio, 2),
+                        'callPath': self.getCallPath(node)
+                    }
+                    crossRegionCalls[node.sid] = crossRegionCall
+
+                    logging.debug(f"Cross-region call detected in {self.filename}")
+                    logging.debug(f"Parent span {parent.sid} in {parentRegion}, child span {node.sid} in {childRegion}")
+                    logging.debug(f"Operation: {node.opName}")
+
+        # Recursively check children
+        for childNode in node.children:
+            self.getCrossRegionCalls(childNode, crossRegionCalls)
+
+    def getSplitChildTraceIds(self, jsonData):
+        """
+        Identify child trace IDs from split point markers in a parent trace.
+
+        Delegates to the module-level get_split_child_trace_ids() function.
+
+        Args:
+            jsonData: Jaeger trace JSON data (same format as Graph constructor)
+
+        Returns:
+            List of dicts with child_trace_id, child_span_id,
+            split_point_span_id, and split_point_operation.
+        """
+        return get_split_child_trace_ids(jsonData)
+
+    """
+    End of class Graph definition
+    """

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1561,3 +1561,2029 @@ class TestCheckResults(TestCase):
         )
 
         self.assertTrue(result)
+
+
+def sampleGraph2():
+    # graph from test_cases/25.json
+    # then added X and Y spans that are logically in parallel with B->C with the same service and op
+    # X and Y should not show up in any of the error counts nor critical path / error critical path
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                    "S3": {
+                        "serviceName": "S3",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "startTime": 0,
+                        "duration": 700,
+                        "references": [],
+                        "processID": "S1",
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "O2",
+                        "startTime": 50,
+                        "duration": 300,
+                        "processID": "S2",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "C",
+                        "operationName": "O3",
+                        "startTime": 100,
+                        "duration": 50,
+                        "processID": "S3",
+                        "tags": [
+                            {
+                                "key": "http.status_code",
+                                "type": "int64",
+                                "value": 404,
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "D",
+                        "operationName": "O3",
+                        "startTime": 200,
+                        "duration": 50,
+                        "processID": "S3",
+                        "tags": [
+                            {
+                                "key": "http.status_code",
+                                "type": "int64",
+                                "value": 404,
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "E",
+                        "operationName": "O3",
+                        "startTime": 300,
+                        "duration": 50,
+                        "processID": "S3",
+                        "tags": [
+                            {
+                                "key": "http.status_code",
+                                "type": "int64",
+                                "value": 504,
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "F",
+                        "operationName": "O2",
+                        "startTime": 400,
+                        "duration": 300,
+                        "processID": "S2",
+                        "tags": [
+                            {
+                                "key": "http.status_code",
+                                "type": "int64",
+                                "value": 404,
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "G",
+                        "operationName": "O3",
+                        "startTime": 450,
+                        "duration": 50,
+                        "processID": "S3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "F",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "H",
+                        "operationName": "O3",
+                        "startTime": 550,
+                        "duration": 50,
+                        "processID": "S3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "F",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "I",
+                        "operationName": "O3",
+                        "startTime": 650,
+                        "duration": 50,
+                        "processID": "S3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "F",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "X",
+                        "operationName": "O2",
+                        "startTime": 100,
+                        "duration": 100,
+                        "processID": "S2",
+                        "tags": [
+                            {
+                                "key": "http.status_code",
+                                "type": "int64",
+                                "value": 404,
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "Y",
+                        "operationName": "O3",
+                        "startTime": 150,
+                        "duration": 50,
+                        "processID": "S3",
+                        "tags": [
+                            {
+                                "key": "http.status_code",
+                                "type": "int64",
+                                "value": 404,
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "X",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    return Graph(jsonData, "S1", "O1", "", "")
+
+
+def sampleGraph3():
+    # same as sampleGraph2 except that all errors along the critical path except for C
+    # are removed (i.e., spans D, E, and F).  Errors outside of critical path (X and Y) stay the same.
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                    "S3": {
+                        "serviceName": "S3",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "startTime": 0,
+                        "duration": 700,
+                        "references": [],
+                        "processID": "S1",
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "O2",
+                        "startTime": 50,
+                        "duration": 300,
+                        "processID": "S2",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "C",
+                        "operationName": "O3",
+                        "startTime": 100,
+                        "duration": 50,
+                        "processID": "S3",
+                        "tags": [
+                            {
+                                "key": "http.status_code",
+                                "type": "int64",
+                                "value": 404,
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "D",
+                        "operationName": "O3",
+                        "startTime": 200,
+                        "duration": 50,
+                        "processID": "S3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "E",
+                        "operationName": "O3",
+                        "startTime": 300,
+                        "duration": 50,
+                        "processID": "S3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "F",
+                        "operationName": "O2",
+                        "startTime": 400,
+                        "duration": 300,
+                        "processID": "S2",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "G",
+                        "operationName": "O3",
+                        "startTime": 450,
+                        "duration": 50,
+                        "processID": "S3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "F",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "H",
+                        "operationName": "O3",
+                        "startTime": 550,
+                        "duration": 50,
+                        "processID": "S3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "F",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "I",
+                        "operationName": "O3",
+                        "startTime": 650,
+                        "duration": 50,
+                        "processID": "S3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "F",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "X",
+                        "operationName": "O2",
+                        "startTime": 100,
+                        "duration": 100,
+                        "processID": "S2",
+                        "tags": [
+                            {
+                                "key": "http.status_code",
+                                "type": "int64",
+                                "value": 404,
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "Y",
+                        "operationName": "O3",
+                        "startTime": 150,
+                        "duration": 50,
+                        "processID": "S3",
+                        "tags": [
+                            {
+                                "key": "http.status_code",
+                                "type": "int64",
+                                "value": 404,
+                            },
+                        ],
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "X",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    return Graph(jsonData, "S1", "O1", "", "")
+
+
+def timeskew_graph():
+    """
+    A->B->C call chain.
+    C has time skew.
+    C and B error out.
+    """
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "references": [],
+                        "startTime": 0,
+                        "duration": 100,
+                        "processID": "S1",
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "O2",
+                        "startTime": 10,
+                        "duration": 50,
+                        "processID": "S1",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                        "tags": [
+                            {
+                                "key": "error",
+                                "type": "bool",
+                                "value": True,
+                            },
+                            {
+                                "key": "span.kind",
+                                "type": "string",
+                                "value": "client",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "C",
+                        "operationName": "O3",
+                        "startTime": 1000,
+                        "duration": 30,
+                        "processID": "S2",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                        "tags": [
+                            {
+                                "key": "error",
+                                "type": "bool",
+                                "value": True,
+                            },
+                            {
+                                "key": "span.kind",
+                                "type": "string",
+                                "value": "server",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    return Graph(jsonData, "S1", "O1", "", "")
+
+
+def mild_overlap_graph():
+    """
+    A->B
+     ->C
+    B and C overlap within the level of tolerance
+    """
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "references": [],
+                        "startTime": 0,
+                        "duration": 1000,
+                        "processID": "S1",
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "O2",
+                        "startTime": 0,
+                        "duration": 500,
+                        "processID": "S2",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "C",
+                        "operationName": "O3",
+                        "startTime": 495,
+                        "duration": 505,
+                        "processID": "S2",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    return Graph(jsonData, "S1", "O1", "", "")
+
+
+def root_error_graph():
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "references": [],
+                        "startTime": 0,
+                        "duration": 100,
+                        "processID": "S1",
+                        "tags": [
+                            {
+                                "key": "error",
+                                "type": "bool",
+                                "value": True,
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "O2",
+                        "startTime": 70,
+                        "duration": 30,
+                        "processID": "S2",
+                        "warnings": None,
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    return Graph(jsonData, "S1", "O1", "", "")
+
+
+def excludeGraph():
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "S1": {
+                        "serviceName": "S1",
+                        "tags": [],
+                    },
+                    "S2": {
+                        "serviceName": "S2",
+                        "tags": [],
+                    },
+                    "S3": {
+                        "serviceName": "S3",
+                        "tags": [],
+                    },
+                    "S4": {
+                        "serviceName": "S4",
+                        "tags": [],
+                    },
+                },
+                "traceID": "A",
+                "spans": [
+                    {
+                        "traceID": "A",
+                        "spanID": "A",
+                        "operationName": "O1",
+                        "references": [],
+                        "startTime": 0,
+                        "duration": 100,
+                        "processID": "S1",
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "B",
+                        "operationName": "O2",
+                        "startTime": 10,
+                        "duration": 60,
+                        "processID": "S2",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "A",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "C",
+                        "operationName": "O3",
+                        "startTime": 25,
+                        "duration": 20,
+                        "processID": "S3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "A",
+                        "spanID": "D",
+                        "operationName": "O4",
+                        "startTime": 30,
+                        "duration": 20,
+                        "processID": "S4",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "A",
+                                "spanID": "B",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    exclude = {("S4", "O4")}
+    return Graph(jsonData, "S1", "O1", "", "", exclusionSet=exclude)
+
+
+def crossRegionSampleGraph():
+    """Creates a sample graph with cross-region calls for testing"""
+    jsonData = {
+        "data": [
+            {
+                "processes": {
+                    "P1": {
+                        "serviceName": "ServiceA",
+                        "tags": [
+                            {"key": "region", "value": "us-west-1"},
+                            {"key": "hostname", "value": "host1"}
+                        ],
+                    },
+                    "P2": {
+                        "serviceName": "ServiceB",
+                        "tags": [
+                            {"key": "region", "value": "us-east-1"},
+                            {"key": "hostname", "value": "host2"}
+                        ],
+                    },
+                    "P3": {
+                        "serviceName": "ServiceC",
+                        "tags": [
+                            {"key": "zone", "value": "eu-west-1a"},
+                            {"key": "hostname", "value": "host3"}
+                        ],
+                    },
+                    "P4": {
+                        "serviceName": "ServiceD",
+                        "tags": [
+                            {"key": "region", "value": "us-west-1"},
+                            {"key": "hostname", "value": "host4"}
+                        ],
+                    },
+                    "P5": {
+                        "serviceName": "ServiceE",
+                        "tags": [
+                            {"key": "hostname", "value": "host5"}
+                        ],
+                    },
+                },
+                "traceID": "T1",
+                "spans": [
+                    {
+                        "traceID": "T1",
+                        "spanID": "S1",
+                        "operationName": "GetUser",
+                        "startTime": 0,
+                        "duration": 1000,
+                        "references": [],
+                        "processID": "P1",
+                    },
+                    {
+                        "traceID": "T1",
+                        "spanID": "S2",
+                        "operationName": "GetUser",
+                        "startTime": 100,
+                        "duration": 200,
+                        "processID": "P2",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "T1",
+                                "spanID": "S1",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "T1",
+                        "spanID": "S3",
+                        "operationName": "GetUser",
+                        "startTime": 150,
+                        "duration": 100,
+                        "processID": "P3",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "T1",
+                                "spanID": "S2",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "T1",
+                        "spanID": "S4",
+                        "operationName": "GetUser",
+                        "startTime": 300,
+                        "duration": 50,
+                        "processID": "P4",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "T1",
+                                "spanID": "S1",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "T1",
+                        "spanID": "S5",
+                        "operationName": "GetData",
+                        "startTime": 400,
+                        "duration": 75,
+                        "processID": "P2",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "T1",
+                                "spanID": "S1",
+                            },
+                        ],
+                    },
+                    {
+                        "traceID": "T1",
+                        "spanID": "S6",
+                        "operationName": "GetUser",
+                        "startTime": 500,
+                        "duration": 25,
+                        "processID": "P5",
+                        "references": [
+                            {
+                                "refType": "CHILD_OF",
+                                "traceID": "T1",
+                                "spanID": "S1",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    return Graph(jsonData, "ServiceA", "GetUser", "", "")
+
+
+class GraphTestCaseDeferred(TestCase):
+    """Tests unblocked in PR 9d — previously deferred."""
+
+    def test_findCriticalPath(self):
+        cp = sampleGraph().findCriticalPath()
+        assert len(cp) == 3
+        assert cp[0].sid == "A"
+        assert cp[1].sid == "B"
+        assert cp[2].sid == "D"
+
+    def test_findErrorsOnCriticalPath(self):
+        fullErrCP = sampleGraph().findErrorsOnCriticalPath()
+
+        assert len(fullErrCP) == 3
+        assert fullErrCP[0].sid == "A"
+        assert fullErrCP[1].sid == "B"
+        assert fullErrCP[2].sid == "D"
+
+    def test_computeTimeSaved(self):
+        (
+            work,
+            timeSavedOnW,
+            tsPessimistic,
+            tsOptimistic,
+            tsAllSeries,
+        ) = sampleGraph().computeTimeSaved()
+        assert work == 200
+        assert timeSavedOnW == 20
+        assert tsAllSeries == 5
+        if is_optimistic_enabled():
+            assert tsPessimistic == 5
+        else:
+            assert tsPessimistic == 0
+        if is_optimistic_enabled():
+            assert tsOptimistic == 5
+        else:
+            assert tsOptimistic == 0
+
+    def test_rootReturnError(self):
+        g = root_error_graph()
+        assert g.rootNode.returnError
+        fullErrCP = g.findErrorsOnCriticalPath()
+        assert len(fullErrCP) == 1
+        assert fullErrCP[0].sid == "A"
+
+    def test_metrics1(self):
+        g = sampleGraph2()
+
+        tsPessimistic = g.computeTimeSavedOnCPPessimistic(g.rootNode)
+        assert tsPessimistic == 450
+
+        tsOptimistic = g.computeTimeSavedOnCPOptimistic(g.rootNode)
+        assert tsOptimistic == 450
+
+        tsAllSeries = g.ComputeAllSeriesTimeSaved(g.rootNode)
+        assert tsAllSeries == 450
+
+        cp = g.findCriticalPath()
+        fullErrCP = g.findErrorsOnCriticalPath()
+        cpMetrics, sidTimeEx = g.accumeCPMetrics(cp, "0x0a", g.rootNode)
+        errCPMetrics = g.accumeErrorCPMetrics(fullErrCP, sidTimeEx)
+
+        assert len(cp) == 9
+        assert cp[0].sid == "A"
+        assert cp[1].sid == "F"
+        assert cp[2].sid == "I"
+        assert cp[3].sid == "H"
+        assert cp[4].sid == "G"
+        assert cp[5].sid == "B"
+        assert cp[6].sid == "E"
+        assert cp[7].sid == "D"
+        assert cp[8].sid == "C"
+
+        assert len(fullErrCP) == 6
+        assert fullErrCP[0].sid == "A"
+        assert fullErrCP[1].sid == "F"
+        assert fullErrCP[2].sid == "B"
+        assert fullErrCP[3].sid == "E"
+        assert fullErrCP[4].sid == "D"
+        assert fullErrCP[5].sid == "C"
+
+        prefix = SYNTHETIC_ERR_CP_ROOT + "->"
+        errCPCallPathTimeEx = errCPMetrics.errCPCallpathTimeExclusive
+        assert errCPCallPathTimeEx[prefix + "[S1] O1->[S2] O2"] == 150
+        assert errCPCallPathTimeEx[prefix + "[S1] O1->[S2] O2->[S3] O3"] == 150
+
+        errCPErrCounts = errCPMetrics.errCPErrCounts
+        assert errCPErrCounts[prefix + "[S1] O1"].toArray() == [0, 0, 1]
+        assert errCPErrCounts[prefix + "[S1] O1->[S2] O2"].toArray() == [1, 0, 1]
+        assert errCPErrCounts[prefix + "[S1] O1->[S2] O2->[S3] O3"].toArray() == [
+            3,
+            0,
+            0,
+        ]
+
+        cpp = cpMetrics.profile
+        assert len(cpp) == 3
+        assert cpp["[S1] O1"].freq == 1
+        assert cpp["[S1] O1->[S2] O2"].freq == 2
+        assert cpp["[S1] O1->[S2] O2->[S3] O3"].freq == 6
+
+        saving = errCPMetrics.savingPotential
+        assert len(saving.items()) == 2
+        assert saving["[S2] O2"].timeSaved == 300
+        assert saving["[S3] O3"].timeSaved == 150
+
+        assert errCPMetrics.numCPErrors == 4
+        assert errCPMetrics.numRelatedToCPErrors == 0
+
+        errCounts = {}
+        errCallChainCounts = {}
+        selfErrDepthList = []
+        stoppedErrDepthList = []
+        depthMap = {}
+        propLengthMap = {}
+        resiliencyMap = {}
+
+        numAllErrors = g.computeErrorStats(
+            g.rootNode,
+            1,
+            1,
+            errCounts,
+            errCallChainCounts,
+            selfErrDepthList,
+            stoppedErrDepthList,
+            depthMap,
+            propLengthMap,
+            resiliencyMap,
+        )
+        assert numAllErrors == 6
+
+        maxErrDepth = g.computeMaxErrDepthPropagatedToRoot(g.rootNode, 1)
+        assert maxErrDepth == -1
+
+        assert len(errCounts) == 3
+        assert errCounts["[S1] O1"].toArray() == [0, 0, 1]
+        assert errCounts["[S1] O1->[S2] O2"].toArray() == [1, 1, 1]
+        assert errCounts["[S1] O1->[S2] O2->[S3] O3"].toArray() == [4, 0, 0]
+
+        assert len(errCallChainCounts) == 2
+        assert errCallChainCounts["[S1] O1->[S2] O2"] == 1
+        assert errCallChainCounts["[S1] O1->[S2] O2->[S3] O3"] == 4
+
+        selfErrDepthList.sort()
+        assert len(selfErrDepthList) == 5
+        assert selfErrDepthList[0] == 2
+        assert selfErrDepthList[1] == 3
+        assert selfErrDepthList[2] == 3
+        assert selfErrDepthList[3] == 3
+        assert selfErrDepthList[4] == 3
+
+        stoppedErrDepthList.sort()
+        assert len(stoppedErrDepthList) == 2
+        assert stoppedErrDepthList[0] == 1
+        assert stoppedErrDepthList[1] == 2
+
+        assert len(depthMap) == 3
+        assert depthMap[1].toArray() == [0, 0, 1]
+        assert depthMap[2].toArray() == [1, 1, 1]
+        assert depthMap[3].toArray() == [4, 0, 0]
+
+        assert len(propLengthMap) == 2
+        assert propLengthMap[1] == 4
+        assert propLengthMap[2] == 1
+
+        assert len(resiliencyMap) == 2
+        assert resiliencyMap["[S1] O1"].toArray() == [0, 0, 1]
+        assert resiliencyMap["[S2] O2"].toArray() == [0, 1, 1]
+
+    def test_metrics2(self):
+        g = sampleGraph3()
+
+        tsPessimistic = g.computeTimeSavedOnCPPessimistic(g.rootNode)
+        assert tsPessimistic == 50
+
+        tsOptimistic = g.computeTimeSavedOnCPOptimistic(g.rootNode)
+        assert tsOptimistic == 50
+
+        tsAllSeries = g.ComputeAllSeriesTimeSaved(g.rootNode)
+        assert tsAllSeries == 50
+
+        cp = g.findCriticalPath()
+        fullErrCP = g.findErrorsOnCriticalPath()
+        cpMetrics, sidTimeEx = g.accumeCPMetrics(cp, "0x0a", g.rootNode)
+        errCPMetrics = g.accumeErrorCPMetrics(fullErrCP, sidTimeEx)
+
+        assert len(cp) == 9
+        assert cp[0].sid == "A"
+        assert cp[1].sid == "F"
+        assert cp[2].sid == "I"
+        assert cp[3].sid == "H"
+        assert cp[4].sid == "G"
+        assert cp[5].sid == "B"
+        assert cp[6].sid == "E"
+        assert cp[7].sid == "D"
+        assert cp[8].sid == "C"
+
+        assert len(fullErrCP) == 3
+        assert fullErrCP[0].sid == "A"
+        assert fullErrCP[1].sid == "B"
+        assert fullErrCP[2].sid == "C"
+
+        prefix = SYNTHETIC_ERR_CP_ROOT + "->"
+        errCPErrCounts = errCPMetrics.errCPErrCounts
+        assert (prefix + "[S1] O1") not in errCPErrCounts
+        assert errCPErrCounts[prefix + "[S1] O1->[S2] O2"].toArray() == [0, 0, 1]
+        assert errCPErrCounts[prefix + "[S1] O1->[S2] O2->[S3] O3"].toArray() == [
+            1,
+            0,
+            0,
+        ]
+
+        saving = errCPMetrics.savingPotential
+        assert len(saving.items()) == 1
+        assert saving["[S3] O3"].timeSaved == 50
+
+        assert errCPMetrics.numCPErrors == 1
+        assert errCPMetrics.numRelatedToCPErrors == 0
+
+        errCounts = {}
+        errCallChainCounts = {}
+        selfErrDepthList = []
+        stoppedErrDepthList = []
+        depthMap = {}
+        propLengthMap = {}
+        resiliencyMap = {}
+
+        numAllErrors = g.computeErrorStats(
+            g.rootNode,
+            1,
+            1,
+            errCounts,
+            errCallChainCounts,
+            selfErrDepthList,
+            stoppedErrDepthList,
+            depthMap,
+            propLengthMap,
+            resiliencyMap,
+        )
+        assert numAllErrors == 3
+
+        maxErrDepth = g.computeMaxErrDepthPropagatedToRoot(g.rootNode, 1)
+        assert maxErrDepth == -1
+
+        assert len(errCounts) == 3
+        assert errCounts["[S1] O1"].toArray() == [0, 0, 1]
+        assert errCounts["[S1] O1->[S2] O2"].toArray() == [0, 1, 1]
+        assert errCounts["[S1] O1->[S2] O2->[S3] O3"].toArray() == [2, 0, 0]
+
+        assert len(errCallChainCounts) == 1
+        assert errCallChainCounts["[S1] O1->[S2] O2->[S3] O3"] == 2
+
+        selfErrDepthList.sort()
+        assert len(selfErrDepthList) == 2
+        assert selfErrDepthList[0] == 3
+        assert selfErrDepthList[1] == 3
+
+        stoppedErrDepthList.sort()
+        assert len(stoppedErrDepthList) == 2
+        assert stoppedErrDepthList[0] == 1
+        assert stoppedErrDepthList[1] == 2
+
+        assert len(depthMap) == 3
+        assert depthMap[1].toArray() == [0, 0, 1]
+        assert depthMap[2].toArray() == [0, 1, 1]
+        assert depthMap[3].toArray() == [2, 0, 0]
+
+        assert len(propLengthMap) == 2
+        assert propLengthMap[1] == 1
+        assert propLengthMap[2] == 1
+
+        assert len(resiliencyMap) == 2
+        assert resiliencyMap["[S1] O1"].toArray() == [0, 0, 1]
+        assert resiliencyMap["[S2] O2"].toArray() == [0, 1, 1]
+
+    def test_timeskewMetrics(self):
+        g = timeskew_graph()
+
+        tsPessimistic = g.computeTimeSavedOnCPPessimistic(g.rootNode)
+        assert tsPessimistic == 50
+
+        tsOptimistic = g.computeTimeSavedOnCPOptimistic(g.rootNode)
+        assert tsOptimistic == 50
+
+        tsAllSeries = g.ComputeAllSeriesTimeSaved(g.rootNode)
+        assert tsAllSeries == 50
+
+        cp = g.findCriticalPath()
+        fullErrCP = g.findErrorsOnCriticalPath()
+        cpMetrics, sidTimeEx = g.accumeCPMetrics(cp, "0x0a", g.rootNode)
+        errCPMetrics = g.accumeErrorCPMetrics(fullErrCP, sidTimeEx)
+
+        assert len(cp) == 3
+        assert cp[0].sid == "A"
+        assert cp[1].sid == "B"
+        assert cp[2].sid == "C"
+        assert cpMetrics.profile["[S1] O1"].excl == 50
+        assert cpMetrics.profile["[S1] O1->[S1] O2"].excl == 20
+        assert cpMetrics.profile["[S1] O1->[S1] O2->[S2] O3"].excl == 30
+
+        # same as errCP
+        assert len(fullErrCP) == 3
+        assert fullErrCP[0].sid == "A"
+        assert fullErrCP[1].sid == "B"
+        assert fullErrCP[2].sid == "C"
+
+        prefix = SYNTHETIC_ERR_CP_ROOT + "->"
+        errCPCallpathTimeEx = errCPMetrics.errCPCallpathTimeExclusive
+        assert errCPCallpathTimeEx[prefix + "[S1] O1->[S1] O2"] == 20
+        assert errCPCallpathTimeEx[prefix + "[S1] O1->[S1] O2->[S2] O3"] == 30
+
+        errCPErrCounts = errCPMetrics.errCPErrCounts
+        assert errCPErrCounts[prefix + "[S1] O1"].toArray() == [0, 0, 1]
+        assert errCPErrCounts[prefix + "[S1] O1->[S1] O2"].toArray() == [0, 1, 0]
+        assert errCPErrCounts[prefix + "[S1] O1->[S1] O2->[S2] O3"].toArray() == [
+            1,
+            0,
+            0,
+        ]
+
+        saving = errCPMetrics.savingPotential
+        assert len(saving.items()) == 2
+        assert saving["[S1] O2"].timeSaved == 50
+        assert saving["[S2] O3"].timeSaved == 0
+
+        assert errCPMetrics.numCPErrors == 2
+        assert errCPMetrics.numRelatedToCPErrors == 0
+
+    def test_overlapedSerialCalls(self):
+        """
+        This test shows that some CP component can become negative.
+        An upcoming diff will fix this issue.
+        """
+        g = mild_overlap_graph()
+        cp = g.findCriticalPath()
+        cpMetrics, _ = g.accumeCPMetrics(cp, "0x0a", g.rootNode)
+
+        assert len(cp) == 3
+        assert cp[0].sid == "A"
+        assert cp[1].sid == "C"
+        assert cp[2].sid == "B"
+        # normal calculation would have resulted -5, but we sanitize out negative time entries
+        assert cpMetrics.profile["[S1] O1"].excl == 0
+        assert cpMetrics.profile["[S1] O1->[S2] O2"].excl == 500
+        assert cpMetrics.profile["[S1] O1->[S2] O3"].excl == 505
+
+    def test_exclusion(self):
+        cp = excludeGraph().findCriticalPath()
+        assert len(cp) == 3
+        assert cp[0].sid == "A"
+        assert cp[1].sid == "B"
+        assert cp[2].sid == "C"
+
+    def test_computeErrDepthHisto(self):
+        g = graph.Graph(
+            [],
+            "testService",
+            "testOperation",
+            "nofile.txt",
+            skipInitializationForTest=True,
+        )
+        #            root
+        #            /  \
+        #     (err) c1    c2
+        #          /  \     \
+        #       c3    c4    c5 (err)
+        #      /  \          \
+        # err (c6)  c7        c8 (err)
+        #     |
+        #     c9
+        root = graph.GraphNode(
+            sid=0,
+            startTime=0,
+            duration=1000,
+            parentSpanId=-1,
+            opName="root",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=False,
+        )
+        c1 = graph.GraphNode(
+            sid=1,
+            startTime=10,
+            duration=50,
+            parentSpanId=0,
+            opName="o1",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=True,
+        )
+        c2 = graph.GraphNode(
+            sid=2,
+            startTime=100,
+            duration=150,
+            parentSpanId=0,
+            opName="o2",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=False,
+        )
+        c3 = graph.GraphNode(
+            sid=3,
+            startTime=10,
+            duration=10,
+            parentSpanId=1,
+            opName="o3",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=False,
+        )
+        c4 = graph.GraphNode(
+            sid=4,
+            startTime=20,
+            duration=10,
+            parentSpanId=1,
+            opName="o4",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=False,
+        )
+        c5 = graph.GraphNode(
+            sid=5,
+            startTime=110,
+            duration=10,
+            parentSpanId=2,
+            opName="o5",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=True,
+        )
+        c6 = graph.GraphNode(
+            sid=6,
+            startTime=10,
+            duration=1,
+            parentSpanId=3,
+            opName="o6",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=True,
+        )
+        c7 = graph.GraphNode(
+            sid=7,
+            startTime=10,
+            duration=1,
+            parentSpanId=3,
+            opName="o7",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=False,
+        )
+        c8 = graph.GraphNode(
+            sid=8,
+            startTime=110,
+            duration=10,
+            parentSpanId=5,
+            opName="o6",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=True,
+        )
+        c9 = graph.GraphNode(
+            sid=9,
+            startTime=10,
+            duration=1,
+            parentSpanId=6,
+            opName="o9",
+            processID=1,
+            spanKind=graph.SpanKind.SERVER,
+            peerService="testService",
+            returnError=False,
+        )
+
+        c9.parent = c6
+        c6.addChild(c9)
+        c8.parent = c5
+        c5.addChild(c8)
+        c7.parent = c3
+        c3.addChild(c7)
+        c6.parent = c3
+        c3.addChild(c6)
+        c5.parent = c2
+        c2.addChild(c5)
+        c4.parent = c1
+        c1.addChild(c4)
+        c3.parent = c1
+        c1.addChild(c3)
+        c2.parent = root
+        root.addChild(c2)
+        c1.parent = root
+        root.addChild(c1)
+
+        g.rootNode = root
+        propToRootHisto = {}
+        notPropToRootHisto = {}
+        notPropToRootHistoExpected = {1: 1, 3: 2}
+        depth = 0
+        g.computeErrDepthHisto(
+            g.rootNode,
+            depth,
+            propToRootHisto,
+            notPropToRootHisto,
+            True,
+            lambda x: True,  # noqa: ARG005
+        )
+        self.assertDictEqual({}, propToRootHisto)
+        self.assertDictEqual(notPropToRootHistoExpected, notPropToRootHisto)
+
+        supressHisto = {}
+        supressHistotExpected = {0: 1, 1: 1, 2: 1}
+        g.computeSupressErrDepthHisto(g.rootNode, depth, supressHisto, lambda x: True)  # noqa: ARG005
+        self.assertDictEqual(supressHistotExpected, supressHisto)
+
+        # Now fail the root
+        root.returnError = True
+        propToRootHisto = {}
+        notPropToRootHisto = {}
+        propToRootHistoExpected = {1: 1}
+        notPropToRootHistoExpected = {3: 2}
+        depth = 0
+        g.computeErrDepthHisto(
+            g.rootNode,
+            depth,
+            propToRootHisto,
+            notPropToRootHisto,
+            True,
+            lambda x: True,  # noqa: ARG005
+        )
+        self.assertDictEqual(propToRootHistoExpected, propToRootHisto)
+        self.assertDictEqual(notPropToRootHistoExpected, notPropToRootHisto)
+
+        supressHisto = {}
+        supressHistotExpected = {1: 1, 2: 1}
+        g.computeSupressErrDepthHisto(g.rootNode, depth, supressHisto, lambda x: True)  # noqa: ARG005
+        self.assertDictEqual(supressHistotExpected, supressHisto)
+
+    def test_getOutboundCount_root_matches(self):
+        # Create a simple graph where the root node matches the service name
+        jsonData = {
+            "data": [
+                {
+                    "processes": {
+                        "P1": {"serviceName": "S1", "tags": []},
+                        "P2": {"serviceName": "S2", "tags": []},
+                        "P3": {"serviceName": "S3", "tags": []},
+                    },
+                    "traceID": "0x1234abcd",
+                    "spans": [
+                        {
+                            "traceID": "0x1234abcd",
+                            "spanID": "A",
+                            "operationName": "O1",
+                            "references": [],
+                            "startTime": 0,
+                            "duration": 100,
+                            "processID": "P1",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0x1234abcd",
+                            "spanID": "B",
+                            "operationName": "O2",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0x1234abcd", "spanID": "A"}],
+                            "startTime": 10,
+                            "duration": 60,
+                            "processID": "P2",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0x1234abcd",
+                            "spanID": "C",
+                            "operationName": "O3",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0x1234abcd", "spanID": "A"}],
+                            "startTime": 20,
+                            "duration": 40,
+                            "processID": "P3",
+                            "warnings": None,
+                        },
+                    ],
+                }
+            ]
+        }
+
+        g = Graph(jsonData, "S1", "O1", filename="test.json", rootTrace=True)
+        self.assertEqual(g.getOutboundCount("S1"), [2])  # Root has 2 children
+
+    def test_getOutboundCount_child_matches(self):
+        # Create a graph where a child node matches the service name
+        jsonData = {
+            "data": [
+                {
+                    "processes": {
+                        "P1": {"serviceName": "S1", "tags": []},
+                        "P2": {"serviceName": "S2", "tags": []},
+                        "P3": {"serviceName": "S3", "tags": []},
+                        "P4": {"serviceName": "S4", "tags": []},
+                    },
+                    "traceID": "0x5678def0",
+                    "spans": [
+                        {
+                            "traceID": "0x5678def0",
+                            "spanID": "A",
+                            "operationName": "O1",
+                            "references": [],
+                            "startTime": 0,
+                            "duration": 100,
+                            "processID": "P1",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0x5678def0",
+                            "spanID": "B",
+                            "operationName": "O2",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0x5678def0", "spanID": "A"}],
+                            "startTime": 10,
+                            "duration": 60,
+                            "processID": "P2",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0x5678def0",
+                            "spanID": "C",
+                            "operationName": "O3",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0x5678def0", "spanID": "B"}],
+                            "startTime": 20,
+                            "duration": 40,
+                            "processID": "P3",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0x5678def0",
+                            "spanID": "D",
+                            "operationName": "O4",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0x5678def0", "spanID": "B"}],
+                            "startTime": 25,
+                            "duration": 35,
+                            "processID": "P4",
+                            "warnings": None,
+                        },
+                    ],
+                }
+            ]
+        }
+
+        g = Graph(jsonData, "S1", "O1", filename="test.json", rootTrace=True)
+        self.assertEqual(g.getOutboundCount("S2"), [2])  # S2 has 2 children
+
+    def test_getOutboundCount_no_match(self):
+        # Create a graph where no node matches the service name
+        jsonData = {
+            "data": [
+                {
+                    "processes": {
+                        "P1": {"serviceName": "S1", "tags": []},
+                        "P2": {"serviceName": "S2", "tags": []},
+                        "P3": {"serviceName": "S3", "tags": []},
+                    },
+                    "traceID": "0x9abc1234",
+                    "spans": [
+                        {
+                            "traceID": "0x9abc1234",
+                            "spanID": "A",
+                            "operationName": "O1",
+                            "references": [],
+                            "startTime": 0,
+                            "duration": 100,
+                            "processID": "P1",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0x9abc1234",
+                            "spanID": "B",
+                            "operationName": "O2",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0x9abc1234", "spanID": "A"}],
+                            "startTime": 10,
+                            "duration": 60,
+                            "processID": "P2",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0x9abc1234",
+                            "spanID": "C",
+                            "operationName": "O3",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0x9abc1234", "spanID": "B"}],
+                            "startTime": 20,
+                            "duration": 40,
+                            "processID": "P3",
+                            "warnings": None,
+                        },
+                    ],
+                }
+            ]
+        }
+
+        g = Graph(jsonData, "S1", "O1", filename="test.json", rootTrace=True)
+        self.assertEqual(g.getOutboundCount("S4"), [])  # No node with service name S4
+
+    def test_getOutboundCount_empty_graph(self):
+        # Test with an empty graph
+        g = Graph({"data": []}, "S1", "O1", filename="test.json", rootTrace=True)
+        self.assertEqual(g.getOutboundCount("S1"), [])  # Empty graph has no nodes
+
+    def test_getOutboundCount_deep_match(self):
+        # Create a graph where a deep node matches the service name
+        jsonData = {
+            "data": [
+                {
+                    "processes": {
+                        "P1": {"serviceName": "S1", "tags": []},
+                        "P2": {"serviceName": "S2", "tags": []},
+                        "P3": {"serviceName": "S3", "tags": []},
+                        "P4": {"serviceName": "S4", "tags": []},
+                    },
+                    "traceID": "0xdef05678",
+                    "spans": [
+                        {
+                            "traceID": "0xdef05678",
+                            "spanID": "A",
+                            "operationName": "O1",
+                            "references": [],
+                            "startTime": 0,
+                            "duration": 100,
+                            "processID": "P1",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0xdef05678",
+                            "spanID": "B",
+                            "operationName": "O2",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0xdef05678", "spanID": "A"}],
+                            "startTime": 10,
+                            "duration": 60,
+                            "processID": "P2",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0xdef05678",
+                            "spanID": "C",
+                            "operationName": "O3",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0xdef05678", "spanID": "B"}],
+                            "startTime": 20,
+                            "duration": 40,
+                            "processID": "P3",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0xdef05678",
+                            "spanID": "D",
+                            "operationName": "O4",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0xdef05678", "spanID": "C"}],
+                            "startTime": 25,
+                            "duration": 35,
+                            "processID": "P4",
+                            "warnings": None,
+                        },
+                    ],
+                }
+            ]
+        }
+
+        g = Graph(jsonData, "S1", "O1", filename="test.json", rootTrace=True)
+        self.assertEqual(g.getOutboundCount("S3"), [1])  # S3 has 1 child
+
+    def test_getAllOutboundCounts(self):
+        # Test getAllOutboundCounts function with a multi-service graph
+        jsonData = {
+            "data": [
+                {
+                    "processes": {
+                        "P1": {"serviceName": "S1", "tags": []},
+                        "P2": {"serviceName": "S2", "tags": []},
+                        "P3": {"serviceName": "S3", "tags": []},
+                        "P4": {"serviceName": "S2", "tags": []},  # Another S2 span
+                    },
+                    "traceID": "0xtest1234",
+                    "spans": [
+                        {
+                            "traceID": "0xtest1234",
+                            "spanID": "A",
+                            "operationName": "O1",
+                            "references": [],
+                            "startTime": 0,
+                            "duration": 100,
+                            "processID": "P1",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0xtest1234",
+                            "spanID": "B",
+                            "operationName": "O2",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0xtest1234", "spanID": "A"}],
+                            "startTime": 10,
+                            "duration": 60,
+                            "processID": "P2",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0xtest1234",
+                            "spanID": "C",
+                            "operationName": "O3",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0xtest1234", "spanID": "A"}],
+                            "startTime": 20,
+                            "duration": 40,
+                            "processID": "P3",
+                            "warnings": None,
+                        },
+                        {
+                            "traceID": "0xtest1234",
+                            "spanID": "D",
+                            "operationName": "O4",
+                            "references": [{"refType": "CHILD_OF", "traceID": "0xtest1234", "spanID": "B"}],
+                            "startTime": 30,
+                            "duration": 20,
+                            "processID": "P4",
+                            "warnings": None,
+                        },
+                    ],
+                }
+            ]
+        }
+
+        g = Graph(jsonData, "S1", "O1", filename="test.json", rootTrace=True)
+        all_counts = g.getAllOutboundCounts()
+
+        # S1 has 2 children, S2 has 1 child (first S2 span) and 0 children (second S2 span), S3 has 0 children
+        expected = {"S1": [2], "S2": [1, 0], "S3": [0]}
+        self.assertEqual(all_counts, expected)
+
+    def test_getCycles(self):
+        # Test case 1: Simple cycle with two nodes
+        jsonData = {
+            "data": [
+                {
+                    "processes": {
+                        "pid1": {
+                            "serviceName": "serviceA",
+                            "tags": [],
+                        },
+                    },
+                    "traceID": "A",
+                    "spans": [],
+                },
+            ],
+        }
+        g = Graph(jsonData, "serviceA", "opA", filename="test.json")
+        node1 = GraphNode(
+            sid="1",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="opA",
+            processID="pid1",
+            spanKind=SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        node2 = GraphNode(
+            sid="2",
+            startTime=10,
+            duration=80,
+            parentSpanId="1",
+            opName="opB",
+            processID="pid1",
+            spanKind=SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        node3 = GraphNode(
+            sid="3",
+            startTime=20,
+            duration=60,
+            parentSpanId="2",
+            opName="opA",
+            processID="pid1",
+            spanKind=SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        node4 = GraphNode(
+            sid="4",
+            startTime=40,
+            duration=20,
+            parentSpanId="3",
+            opName="opA",
+            processID="pid1",
+            spanKind=SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        node1.addChild(node2)
+        node2.addChild(node3)
+        node3.addChild(node4)
+        g.rootNode = node1
+
+        cycles = {}
+        g.getCycles(node1, [], [], cycles)
+        self.assertEqual(len(cycles), 2)
+        self.assertIn("3", cycles)
+        self.assertIn("4", cycles)
+        self.assertEqual(cycles["3"], ["[serviceA] opA", "[serviceA] opB", "[serviceA] opA"])
+        self.assertEqual(cycles["4"], ["[serviceA] opA", "[serviceA] opA"])
+        # Test case 2: No cycle
+        jsonData = {
+            "data": [
+                {
+                    "processes": {
+                        "pid1": {
+                            "serviceName": "serviceA",
+                            "tags": [],
+                        },
+                    },
+                    "traceID": "A",
+                    "spans": [],
+                },
+            ],
+        }
+        g = Graph(jsonData, "serviceA", "opA", filename="test.json")
+        node1 = GraphNode(
+            sid="1",
+            startTime=0,
+            duration=100,
+            parentSpanId="",
+            opName="opA",
+            processID="pid1",
+            spanKind=SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        node2 = GraphNode(
+            sid="2",
+            startTime=10,
+            duration=80,
+            parentSpanId="1",
+            opName="opB",
+            processID="pid1",
+            spanKind=SpanKind.CLIENT,
+            peerService=None,
+            returnError=False,
+        )
+        node1.addChild(node2)
+        g.rootNode = node1
+
+        cycles = {}
+        g.getCycles(node1, [], [], cycles)
+        self.assertEqual(len(cycles), 0)
+
+
+class TestCrossRegionDetection(TestCase):
+    """Test cases for cross-region call detection functionality"""
+
+    def test_region_map_parsing(self):
+        """Test that region information is correctly parsed from process tags"""
+        g = crossRegionSampleGraph()
+
+        # Verify region map is populated correctly
+        self.assertEqual(g.regionMap["P1"], "us-west-1")
+        self.assertEqual(g.regionMap["P2"], "us-east-1")
+        self.assertEqual(g.regionMap["P3"], "eu-west-1a")  # Zone fallback
+        self.assertEqual(g.regionMap["P4"], "us-west-1")
+        self.assertNotIn("P5", g.regionMap)  # No region/zone data
+
+    def test_zone_fallback_logic(self):
+        """Test that zone information is used when region is not available"""
+        jsonData = {
+            "data": [
+                {
+                    "processes": {
+                        "P1": {
+                            "serviceName": "ServiceA",
+                            "tags": [
+                                {"key": "zone", "value": "us-west-1a"},
+                            ],
+                        },
+                        "P2": {
+                            "serviceName": "ServiceB",
+                            "tags": [
+                                {"key": "region", "value": "us-east-1"},
+                                {"key": "zone", "value": "us-east-1b"},
+                            ],
+                        },
+                    },
+                    "traceID": "T1",
+                    "spans": [
+                        {
+                            "traceID": "T1",
+                            "spanID": "S1",
+                            "operationName": "TestOp",
+                            "startTime": 0,
+                            "duration": 100,
+                            "references": [],
+                            "processID": "P1",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        g = Graph(jsonData, "ServiceA", "TestOp", "", "")
+
+        # Zone should be used for P1 since no region tag
+        self.assertEqual(g.regionMap["P1"], "us-west-1a")
+        # Region should be used for P2, zone ignored
+        self.assertEqual(g.regionMap["P2"], "us-east-1")
+
+    def test_cross_region_detection_same_operation(self):
+        """Test detection of cross-region calls with same operation name"""
+        g = crossRegionSampleGraph()
+        crossRegionCalls = {}
+        g.getCrossRegionCalls(g.rootNode, crossRegionCalls)
+
+        # Should detect cross-region calls
+        self.assertGreater(len(crossRegionCalls), 0)
+
+        # Check that we have the expected cross-region calls
+        s2_found = False
+        s3_found = False
+
+        for callData in crossRegionCalls.values():
+            if callData['operationName'] == 'GetUser':
+                if callData['parentRegion'] == 'uswest' and callData['childRegion'] == 'useast':
+                    s2_found = True
+                    self.assertEqual(callData['parentService'], 'ServiceA')
+                    self.assertEqual(callData['childService'], 'ServiceB')
+                    self.assertEqual(callData['parentDuration'], 1000)
+                    self.assertEqual(callData['childDuration'], 200)
+                elif callData['parentRegion'] == 'useast' and callData['childRegion'] == 'euwesta':
+                    s3_found = True
+                    self.assertEqual(callData['parentService'], 'ServiceB')
+                    self.assertEqual(callData['childService'], 'ServiceC')
+
+        self.assertTrue(s2_found, "Cross-region call S2 not detected")
+        self.assertTrue(s3_found, "Cross-region call S3 not detected")
+
+    def test_same_region_calls_ignored(self):
+        """Test that same-region calls are not detected as cross-region"""
+        g = crossRegionSampleGraph()
+        crossRegionCalls = {}
+        g.getCrossRegionCalls(g.rootNode, crossRegionCalls)
+
+        # Should not detect S4 (uswest -> uswest)
+        for callData in crossRegionCalls.values():
+            if callData['operationName'] == 'GetUser':
+                self.assertFalse(
+                    callData['parentRegion'] == 'uswest' and callData['childRegion'] == 'uswest',
+                    "Same-region call incorrectly detected as cross-region"
+                )
+
+    def test_different_operation_ignored(self):
+        """Test that calls with different operation names are ignored"""
+        g = crossRegionSampleGraph()
+        crossRegionCalls = {}
+        g.getCrossRegionCalls(g.rootNode, crossRegionCalls)
+
+        # Should not detect S5 (GetData operation, different from parent GetUser)
+        for callData in crossRegionCalls.values():
+            self.assertNotEqual(callData['operationName'], 'GetData',
+                              "Different operation incorrectly detected as cross-region")
+
+    def test_missing_region_data_ignored(self):
+        """Test that spans without region data are ignored"""
+        g = crossRegionSampleGraph()
+        crossRegionCalls = {}
+        g.getCrossRegionCalls(g.rootNode, crossRegionCalls)
+
+        # Should not detect S6 (no region data for P5)
+        for callData in crossRegionCalls.values():
+            self.assertNotEqual(callData['childService'], 'ServiceE',
+                              "Span without region data incorrectly detected")
+
+    def test_duration_ratio_calculation(self):
+        """Test that duration ratios are calculated correctly"""
+        g = crossRegionSampleGraph()
+        crossRegionCalls = {}
+        g.getCrossRegionCalls(g.rootNode, crossRegionCalls)
+
+        for callData in crossRegionCalls.values():
+            expected_ratio = callData['parentDuration'] / callData['childDuration']
+            self.assertEqual(callData['durationRatio'], expected_ratio)
+            self.assertGreater(callData['durationRatio'], 0)
+
+    def test_call_path_tracking(self):
+        """Test that call paths are correctly tracked"""
+        g = crossRegionSampleGraph()
+        crossRegionCalls = {}
+        g.getCrossRegionCalls(g.rootNode, crossRegionCalls)
+
+        for callData in crossRegionCalls.values():
+            self.assertIsInstance(callData['callPath'], str)
+            self.assertGreater(len(callData['callPath']), 0)
+            # Call path should contain the operation name
+            self.assertIn(callData['operationName'], callData['callPath'])
+
+    def test_empty_trace_handling(self):
+        """Test handling of empty trace data"""
+        jsonData = {"data": [{"processes": {}, "traceID": "T1", "spans": []}]}
+        g = Graph(jsonData, "NonExistentService", "NonExistentOp", "", "")
+
+        # Should handle gracefully without errors
+        crossRegionCalls = {}
+        if g.rootNode:
+            g.getCrossRegionCalls(g.rootNode, crossRegionCalls)
+
+        self.assertEqual(len(crossRegionCalls), 0)
+
+    def test_single_span_trace(self):
+        """Test handling of single span traces"""
+        jsonData = {
+            "data": [
+                {
+                    "processes": {
+                        "P1": {
+                            "serviceName": "ServiceA",
+                            "tags": [{"key": "region", "value": "us-west-1"}],
+                        },
+                    },
+                    "traceID": "T1",
+                    "spans": [
+                        {
+                            "traceID": "T1",
+                            "spanID": "S1",
+                            "operationName": "GetUser",
+                            "startTime": 0,
+                            "duration": 100,
+                            "references": [],
+                            "processID": "P1",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        g = Graph(jsonData, "ServiceA", "GetUser", "", "")
+        crossRegionCalls = {}
+        g.getCrossRegionCalls(g.rootNode, crossRegionCalls)
+
+        # No cross-region calls possible with single span
+        self.assertEqual(len(crossRegionCalls), 0)


### PR DESCRIPTION
## Summary

Completes the `Graph` class by porting the remaining ~730 lines of `graph.py`
(25 methods from `_get_root_node` through `getSplitChildTraceIds`) and unblocks
all 14 tests that were deferred across PRs 9b and 9c. No logic changes; imports
rewritten from `uber.tooling.program_analysis.critical_path.*` → `crisp.*`.

### Methods added (`crisp/graph.py`)

| Group | Methods |
|---|---|
| Critical path traversal | `_get_root_node`, `findCriticalPath`, `findErrorsOnCriticalPath` |
| Time change / projection | `computeTimeChange`, `_findMatchingNodes`, `computeProjectedCPMetrics`, `computeTimeSaved` |
| Metrics accumulation | `accumeCPMetrics`, `handleFullErrCPMetrics`, `accumeErrorCPMetrics`, `getMetrics` |
| Call path helpers | `canonicalOpName`, `appendCallPath`, `getCallPath`, `sanitizeExclusiveTime` |
| Error depth histograms | `computeErrDepthHisto`, `computeSupressErrDepthHisto`, `computeMaxErrDepthPropagatedToRoot`, `getErrDepthHisto`, `getSupressErrDepthHisto` |
| Outbound / structural | `getAllOutboundCounts`, `getOutboundCount`, `getCycles`, `getCrossRegionCalls`, `getSplitChildTraceIds` |

### Tests unblocked (`tests/test_graph.py`)

54 → **69 passed**.

**Helper factories added:**
`root_error_graph`, `excludeGraph`, `crossRegionSampleGraph`, `sampleGraph2`,
`sampleGraph3`, `timeskew_graph`, `mild_overlap_graph`

**New test classes:**

| Class | Tests |
|---|---|
| `GraphTestCaseDeferred` (14) | `test_findCriticalPath`, `test_findErrorsOnCriticalPath`, `test_computeTimeSaved`, `test_rootReturnError`, `test_metrics1`, `test_metrics2`, `test_timeskewMetrics`, `test_overlapedSerialCalls`, `test_exclusion`, `test_computeErrDepthHisto`, `test_getOutboundCount_*` (×5), `test_getAllOutboundCounts`, `test_getCycles` |
| `TestCrossRegionDetection` (9) | region-map parsing, zone fallback, same-op cross-region detection, different-op cross-region, no-region-data, same-region no-flag, graph-level aggregation, call-path labeling |

### `crisp/LAYERS.md`

All 14 PR-9d deferred-test rows removed.

## Test plan

- [x] `bazel test //...` — all 5 targets pass (69 tests, no regressions)
- [x] `grep -n "uber\." crisp/graph.py tests/test_graph.py` — empty
