### PR TITLE
port(crisp): add yaml_merger and trace_merger (PR 10a)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,6 +38,8 @@ py_test(
         "//crisp:constants",
         "//crisp:graph",
         "//crisp:pkg",
+        "//crisp:yaml_merger",
+        "//crisp:trace_merger",
         "@pypi//pytest",
     ],
     env = {"MPLBACKEND": "Agg"},
@@ -70,5 +72,15 @@ py_test(
     name = "test_graph",
     srcs = ["tests/test_graph.py"],
     deps = ["//crisp:graph"],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_merger",
+    srcs = ["tests/test_merger.py"],
+    deps = [
+        "//crisp:yaml_merger",
+        "@pypi//pyyaml",
+    ],
     imports = ["."],
 )

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -60,3 +60,20 @@ py_library(
         "//crisp/utils:utils",
     ],
 )
+
+py_library(
+    name = "yaml_merger",
+    srcs = ["yaml_merger.py"],
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+py_library(
+    name = "trace_merger",
+    srcs = ["trace_merger.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crisp:graph",
+        "//crisp:pkg",
+    ],
+)

--- a/crisp/yaml_merger.py
+++ b/crisp/yaml_merger.py
@@ -1,0 +1,84 @@
+import argparse
+import copy
+import yaml
+
+
+def read_yaml(file_name):
+    """Read a YAML file and return its content."""
+    with open(file_name) as file:
+        return yaml.safe_load(file)
+
+
+def merge_without_overwrite_or_duplication(dict1, dict2):
+    """
+    Merges two dictionaries without overwriting or duplicating entries,
+    specifically handling list and dict values.
+    """
+    merged = copy.deepcopy(dict1)
+
+    for key, val_list in dict2.items():
+        if key not in merged:
+            # If key doesn't exist in dict1, simply add it
+            merged[key] = val_list
+        else:
+            # Key exists in dict1, so we need to merge the values
+            if isinstance(merged[key], list) and isinstance(val_list, list):
+                for item in val_list:
+                    if item not in merged[key]:
+                        merged[key].append(item)
+    return merged
+
+
+def write_yaml(data, file_name):
+    """Write data to a YAML file."""
+    with open(file_name, "w") as file:
+        yaml.dump(data, file)
+
+
+def merge_yaml(file1_name, file2_name, merged_file_name):
+    """Merge two YAML files and write the result to a new file."""
+    # Read the content of both YAML files
+    file1_content = read_yaml(file1_name)
+    file2_content = read_yaml(file2_name)
+
+    # Merge the contents without overwriting or duplicating
+    merged_content = merge_without_overwrite_or_duplication(file1_content, file2_content)
+
+    # Write the merged content to the output YAML file
+    write_yaml(merged_content, merged_file_name)
+
+
+def parse_arguments():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Merge two YAML files into a single YAML file.",
+    )
+
+    # Add explicit arguments for input file names and output file name
+    parser.add_argument("--file1", required=True, help="First YAML file to merge")
+    parser.add_argument("--file2", required=True, help="Second YAML file to merge")
+    parser.add_argument(
+        "--merged",
+        required=True,
+        help="Output file name for the merged YAML",
+    )
+
+    # Parse the arguments
+    return parser.parse_args()
+
+
+def main():
+    """Main function to execute the script logic."""
+    args = parse_arguments()
+
+    # Get file names from parsed arguments
+    file1_name = args.file1
+    file2_name = args.file2
+    merged_file_name = args.merged
+
+    # Merge the YAML files
+    merge_yaml(file1_name, file2_name, merged_file_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -1,14 +1,10 @@
 import os
-import sys
 import tempfile
 import unittest
 from unittest.mock import patch
 import yaml
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-# Import all functions to be tested
-from yaml_merger import (
+from crisp.yaml_merger import (
     main,
     merge_yaml,
     merge_without_overwrite_or_duplication,


### PR DESCRIPTION
## Summary

- **`crisp/yaml_merger.py`** (85 lines): Ported verbatim from internal `yaml_merger.py`. Provides `read_yaml`, `write_yaml`, `merge_without_overwrite_or_duplication`, `merge_yaml`, `parse_arguments`, and `main()`. No internal references; removed `# ruff: noqa: I001` header comment.

- **`crisp/trace_merger.py`** (323 lines): Ported from internal `trace_merger.py`. Implements Jaeger split-trace stitching: finds `FOLLOWS_FROM` cross-trace links, reattaches child spans under the parent trace, converts reference types, and handles process-ID collisions. Key public API: `create_merged_graph()`, `load_and_merge_traces()`, `merge_trace_data()`, `merge_multiple_child_traces()`, `identify_split_traces()`.
  - Import rewritten: `from uber.tooling.program_analysis.critical_path.graph import Graph` → `from crisp.graph import Graph`
  - Module docstring sanitized: example process collision reference generalized.
  - All logic, class/method/variable names preserved exactly.

- **`tests/test_merger.py`** (16 test cases): Updated import from ad-hoc `sys.path` hack + `from yaml_merger import` to `from crisp.yaml_merger import`. All 16 `TestMergedYAML` test cases cover `merge_without_overwrite_or_duplication`, `merge_yaml`, `read_yaml`, `write_yaml`, `parse_arguments`, and `main()`.

- **`crisp/BUILD.bazel`**: Added `yaml_merger` and `trace_merger` `py_library` targets.

- **`BUILD.bazel`**: Added `test_merger` `py_test` target (with `pyyaml` dep); added `//crisp:yaml_merger` and `//crisp:trace_merger` to the `pytest` omnibus `deps`.

## Test counts

| | Count |
|---|---|
| Before (PR 9d baseline) | 69 tests (`//:pytest` omnibus: ~295) |
| After (PR 10a) | 6/6 Bazel targets pass; `//:pytest` omnibus: **311 passed** |

New tests added: **16** (`TestMergedYAML` in `tests/test_merger.py`)
