### PR TITLE
port(crisp): add flamegraph.py — flame graph generation from critical-path profiles (PR 10b)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,6 +40,7 @@ py_test(
         "//crisp:pkg",
         "//crisp:yaml_merger",
         "//crisp:trace_merger",
+        "//crisp:flamegraph",
         "@pypi//pytest",
     ],
     env = {"MPLBACKEND": "Agg"},
@@ -81,6 +82,16 @@ py_test(
     deps = [
         "//crisp:yaml_merger",
         "@pypi//pyyaml",
+    ],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_flamegraph",
+    srcs = ["tests/test_flamegraph.py"],
+    deps = [
+        "//crisp:flamegraph",
+        "//crisp:pkg",
     ],
     imports = ["."],
 )

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -77,3 +77,12 @@ py_library(
         "//crisp:pkg",
     ],
 )
+
+py_library(
+    name = "flamegraph",
+    srcs = ["flamegraph.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crisp/shared:shared",
+    ],
+)

--- a/crisp/flamegraph.py
+++ b/crisp/flamegraph.py
@@ -1,0 +1,431 @@
+import logging
+import os
+import subprocess
+
+from crisp.shared.models import CallPathProfile
+
+MIN_TIME_METRIC_VALUE = 1
+STANDARD_PERCENTILES = [(0, 50), (0, 95), (0, 99), (0, 100)]
+PROP_TO_ROOT_ERROR_PERCENTILES = [(0, 100)]
+ADDITIONAL_RANGES = [(20, 40), (40, 60), (60, 80), (80, 90), (90, 95), (90, 99)]
+# This is added for comparing latencies with Muttley
+RANGES_SKIP_DIFF = [(94, 96)]
+
+
+class FlameGraphSet:
+    def __init__(
+        self,
+        fgPctFilePair,
+        diffFGFiles,
+        errCPFGPctFilePair,
+        diffErrCPFGFiles,
+        errRootCountFgPctFilePair,
+        diffErrRootCountFGFiles,
+        errPropToRootCountFgPctFilePair,
+        diffErrPropToRootCountFgPctFilePair,
+    ):
+        self.fgPctFilePair = fgPctFilePair
+        self.diffFGFiles = diffFGFiles
+        self.errCPFGPctFilePair = errCPFGPctFilePair
+        self.diffErrCPFGFiles = diffErrCPFGFiles
+        self.errRootCountFgPctFilePair = errRootCountFgPctFilePair
+        self.diffErrRootCountFGFiles = diffErrRootCountFGFiles
+        self.errPropToRootCountFgPctFilePair = errPropToRootCountFgPctFilePair
+        self.diffErrPropToRootCountFgPctFilePair = diffErrPropToRootCountFgPctFilePair
+
+
+    def __eq__(self, other):
+        return (
+            self.fgPctFilePair == other.fgPctFilePair
+            and self.diffFGFiles == other.diffFGFiles
+            and self.errCPFGPctFilePair == other.errCPFGPctFilePair
+            and self.diffErrCPFGFiles == other.diffErrCPFGFiles
+            and self.errRootCountFgPctFilePair == other.errRootCountFgPctFilePair
+            and self.diffErrRootCountFGFiles == other.diffErrRootCountFGFiles
+            and self.errPropToRootCountFgPctFilePair == other.errPropToRootCountFgPctFilePair
+            and self.diffErrPropToRootCountFgPctFilePair == other.diffErrPropToRootCountFgPctFilePair
+        )
+
+    def GetAllFiles(self):
+        svgFiles = (
+            [f[1] for f in self.fgPctFilePair]
+            + list(self.diffFGFiles)
+            + [f[1] for f in self.errCPFGPctFilePair]
+            + list(self.diffErrCPFGFiles)
+            + [f[1] for f in self.errRootCountFgPctFilePair]
+            + list(self.diffErrRootCountFGFiles)
+        )
+        cctFiles = [os.path.splitext(f)[0] for f in svgFiles]
+        return svgFiles + cctFiles
+
+    def GetAllErrorFiles(self):
+        svgFiles = (
+            [f[1] for f in self.errPropToRootCountFgPctFilePair]
+            + list(self.diffErrPropToRootCountFgPctFilePair)
+        )
+        cctFiles = [os.path.splitext(f)[0] for f in svgFiles]
+        return svgFiles + cctFiles
+
+    def GetCCTSz(self, filepath) -> int:
+        return os.path.getsize(filepath) if os.path.exists(filepath) else 0
+
+
+# Expected input format: callpath separated by '->'
+def getParentCallPath(callpath):
+    res = callpath.rsplit("->", 1)
+    if len(res) == 1:
+        # if "->" is not in the string there is nothing to split
+        return ""
+    return res[0]
+
+
+# walk through the map and set any entries with a key that is a leaf call path
+# and a value of zero to have a small value (set to one for now)
+
+
+def sanitizeAggregatedMap(aggregatedMap):
+    parentCallpaths = set()
+
+    # iterate through keys and collect all parent callpaths
+    for k in aggregatedMap:
+        parentPath = getParentCallPath(k)
+        if parentPath != "":
+            parentCallpaths.add(parentPath)
+
+    for k, v in aggregatedMap.items():
+        if k not in parentCallpaths and v == 0:
+            # k is a leaf callpath and has value 0; change the value to 1
+            aggregatedMap[k] = MIN_TIME_METRIC_VALUE
+
+
+def aggregateTimeMapList(timeMapList, average):
+    aggregatedMap = {}
+
+    for _, myMap in timeMapList:
+        for k, v in myMap.items():
+            if k not in aggregatedMap:
+                aggregatedMap[k] = v
+            else:
+                aggregatedMap[k] += v
+    if average:
+        # count those traces that contribute at least one call path.
+        denominator = sum([1 if len(x[1]) > 0 else 0 for x in timeMapList])
+        for k, v in aggregatedMap.items():
+            # Floors the fraction. The data is in microsec, we don't care <1usec yet.
+            aggregatedMap[k] = v // denominator
+
+    sanitizeAggregatedMap(aggregatedMap)
+    return aggregatedMap
+
+
+def aggregateCallPathProfiles(cpps):
+    cpp = CallPathProfile({}, 0, None)
+    for i in range(len(cpps)):
+        cpp += cpps[i]
+
+    cpp.NormalizeField("excl")
+    parentCallpaths = set()
+    # iterate through keys and collect all parent callpaths
+    for k in cpp.profile:
+        parentPath = getParentCallPath(k)
+        if parentPath != "":
+            parentCallpaths.add(parentPath)
+
+    for k, v in cpp.profile.items():
+        if k not in parentCallpaths and v.excl == 0:
+            # k is a leaf callpath and has value 0; change the value to 1
+            v.excl = MIN_TIME_METRIC_VALUE
+
+    flameGraph = ""
+    for k, v in cpp.profile.items():
+        newKey = k.replace(";", "_").replace("->", ";")
+        flameGraph += newKey + " " + str(v.excl) + "\n"
+
+    return flameGraph
+
+
+def aggregateCCTs(cctsAndTime, errCounts, average=True):
+    # TODO: migrate error analysis also to using callpath profiles.
+    if (len(cctsAndTime) > 0) and (
+        isinstance(cctsAndTime[0][1], CallPathProfile)
+    ):
+        return aggregateCallPathProfiles([x[1] for x in cctsAndTime])
+
+    # use the average for time-based flamegraphs but not for count-based ones
+    # aggregates ccts from all traces
+    aggregatedCcts = aggregateTimeMapList(cctsAndTime, average=average)
+    # aggregates error counts from all traces
+    aggregatedErrCounts = aggregateTimeMapList(errCounts, average=False)
+
+    # there is no guarantee that keys from one dictionary is a superset of
+    # the other, so take the union of their keys
+    allkeys = set().union(aggregatedCcts.keys(), aggregatedErrCounts.keys())
+
+    flameGraph = ""
+    for k in allkeys:
+        errTime = aggregatedCcts[k] if k in aggregatedCcts else 0
+        newKey = k.replace(";", "_").replace("->", ";")
+        flameGraph += newKey + " " + str(errTime) + "\n"
+    return flameGraph
+
+
+def genFlameGraph(
+    percentilesExclusive,
+    cctsAndTime,
+    errCounts,
+    fileNamePrefix: str,
+    outputDir: str,
+    service: str,
+    operation: str,
+    numTraces: int,
+    average: bool = True,
+    doDiffGraph: bool = True,
+):
+    fgPctFilePair = []
+    differentialFlameGraphFiles = []
+    countname = "usec avg" if average else "counts"
+
+    for start, end in percentilesExclusive:
+        rangeStr = str(start) + "-" + str(end)
+        s = round(len(cctsAndTime) * start / 100)
+        e = round(len(cctsAndTime) * end / 100)
+        if e - s == 0:
+            logging.info(
+                "not enough samples for P" + rangeStr + f" flamegraph {fileNamePrefix}",
+            )
+            continue
+
+        flameGraph = aggregateCCTs(cctsAndTime[s:e], errCounts[s:e], average)
+        if flameGraph == "":
+            logging.info(
+                "nothing to generate for "
+                + fileNamePrefix
+                + "P"
+                + str(start)
+                + "-"
+                + str(end)
+                + f" flamegraph {fileNamePrefix}",
+            )
+            continue
+
+        # For backward compatibility file with P0-x is named as Px.
+        if s == 0:
+            cctFile = fileNamePrefix + "P" + str(end) + ".cct"
+        else:
+            cctFile = fileNamePrefix + "P" + rangeStr + ".cct"
+
+        flamegraphPath = os.path.join(outputDir, cctFile)
+        with open(flamegraphPath, "w") as f:
+            f.write(flameGraph)
+
+        svgFile = flamegraphPath + ".svg"
+        fgPctFilePair.append(("P" + rangeStr, svgFile))
+
+        flameGraphPerl = os.path.join(os.path.dirname(__file__), "flamegraph.pl")
+        diffFoldPerl = os.path.join(os.path.dirname(__file__), "difffolded.pl")
+        with open(svgFile, "w") as f:
+            title = "[" + service + "]" + operation
+            subtitle = (
+                "P"
+                + rangeStr
+                + " over "
+                + str(e - s)
+                + "/"
+                + str(numTraces)
+                + " traces"
+            )
+            if average:
+                subtitle = "Avg of " + subtitle
+            subprocess.check_call(
+                (
+                    flameGraphPerl,
+                    "--title",
+                    title,
+                    "--subtitle",
+                    subtitle,
+                    "--countname",
+                    countname,
+                    flamegraphPath,
+                ),
+                stdout=f,
+            )
+
+        # if there are predecessors, do a differential analysis with them
+        if doDiffGraph:
+            for predPct, predFile in fgPctFilePair[:-1]:
+                diffCCTFile = fileNamePrefix + predPct + "vsP" + rangeStr + ".cct"
+                diffFilePath = os.path.join(outputDir, diffCCTFile)
+                # produce diff CCT
+                with open(diffFilePath, "w") as f:
+                    print((diffFoldPerl, flamegraphPath, predFile))
+                    subprocess.check_call(
+                        (diffFoldPerl, predFile.rstrip(".svg"), flamegraphPath),
+                        stdout=f,
+                    )
+                # produce diff SVG
+                diffSVGFile = diffFilePath + ".svg"
+                with open(diffSVGFile, "w") as f:
+                    subprocess.check_call((flameGraphPerl, diffFilePath), stdout=f)
+                differentialFlameGraphFiles.append(diffSVGFile)
+
+    return fgPctFilePair, differentialFlameGraphFiles
+
+
+def flameGraph(
+    metrics,
+    outputDir,
+    service: str,
+    operation: str,
+    ignoreCtfTests: bool,
+    filePrefix: str = "",
+    doRanges: bool = False,
+):
+    # Produce SVG flame graphs from critical paths for different percentiles.
+    # Returns a list of tuples [(percentile value, path to SVG file), ...]
+
+    cpps = []
+    errCPCctsAndTime = []
+    errCPCounts = []
+    # for generating count-based flamegraphs for requests that errored out at roots only
+    errRootCctsAndCounts = []
+    errRootErrCounts = []
+
+    # for generating count-based flamegraphs for errors that propagated to root
+    errPropToRootCctsAndCounts = []
+
+    for r in metrics:
+        if not r:
+            continue
+        totalTime = r.latency
+
+        cpps.append((totalTime, r.CPMetrics))
+
+        if r.isCtfTest and ignoreCtfTests:
+            continue  # skip the metric where the root span itself returns error
+
+        if r.rootReturnError:
+            errRootCctsAndCounts.append((totalTime, r.errMetrics.errCallChainCounts))
+            errRootErrCounts.append((totalTime, r.errMetrics.errCounts))
+
+            errPropToRootCctsAndCounts.append((totalTime, r.propToRootErrCCT))
+        else:
+            destList = [
+                errCPCctsAndTime,
+                errCPCounts,
+            ]
+            valList = [
+                r.errCPMetrics.errCPCallpathTimeExclusive,
+                r.errCPMetrics.errCPErrCounts,
+            ]
+            for dst, val in zip(destList, valList):
+                dst.append((totalTime, val))
+
+    cpps = sorted(cpps, key=lambda x: x[0])
+    errCPCctsAndTime = sorted(errCPCctsAndTime, key=lambda x: x[0])
+    errCPCounts = sorted(errCPCounts, key=lambda x: x[0])
+    errRootCctsAndCounts = sorted(errRootCctsAndCounts, key=lambda x: x[0])
+    errRootErrCounts = sorted(errRootErrCounts, key=lambda x: x[0])
+
+    percentilesExclusive = sorted(STANDARD_PERCENTILES)
+    fgPctFilePair, diffFGFiles = genFlameGraph(
+        percentilesExclusive,
+        cpps,
+        cpps,
+        filePrefix + "flame-graph-",
+        outputDir,
+        service,
+        operation,
+        len(metrics),
+        average=True,
+    )
+
+    errCPFGPctFilePair, diffErrCPFGFiles = genFlameGraph(
+        percentilesExclusive,
+        errCPCctsAndTime,
+        errCPCounts,
+        filePrefix + "err-flame-graph-",
+        outputDir,
+        service,
+        operation,
+        len(errCPCctsAndTime),
+        average=True,
+    )
+
+    # generate count-based flamegraphs for requests that errored out at root only
+    errRootCountFgPctFilePair, diffErrRootCountFGFiles = genFlameGraph(
+        percentilesExclusive,
+        errRootCctsAndCounts,
+        errRootErrCounts,
+        filePrefix + "errored-API-flame-graph-",
+        outputDir,
+        service,
+        operation,
+        len(errRootCctsAndCounts),
+        average=False,
+    )
+
+    errPropToRootCountFgPctFilePair, diffErrPropToRootCountFgPctFilePair = genFlameGraph(
+        PROP_TO_ROOT_ERROR_PERCENTILES,
+        errPropToRootCctsAndCounts,
+        [], # no frequency info
+        filePrefix + "errorsPropToRoot-flame-graph-",
+        outputDir,
+        service,
+        operation,
+        len(errRootCctsAndCounts),
+        average=False,
+        doDiffGraph=False, # no differential flamegraphs for now
+    )
+
+    if doRanges:
+        ranges = sorted(ADDITIONAL_RANGES)
+        rangeFGPctFilePair, rangeDiffFGFiles = genFlameGraph(
+            ranges,
+            cpps,
+            cpps,
+            filePrefix + "flame-graph-",
+            outputDir,
+            service,
+            operation,
+            len(metrics),
+            average=True,
+        )
+
+        # Create more flamegraphs of custom types w/o doing a differential FG.
+        moreFGPctFilePair, _ = genFlameGraph(
+            RANGES_SKIP_DIFF,
+            cpps,
+            cpps,
+            filePrefix + "flame-graph-",
+            outputDir,
+            service,
+            operation,
+            len(metrics),
+            average=True,
+            doDiffGraph=False,
+        )
+
+        result = FlameGraphSet(
+            fgPctFilePair + rangeFGPctFilePair + moreFGPctFilePair,
+            diffFGFiles + rangeDiffFGFiles,
+            errCPFGPctFilePair,
+            diffErrCPFGFiles,
+            errRootCountFgPctFilePair,
+            diffErrRootCountFGFiles,
+            errPropToRootCountFgPctFilePair,
+            diffErrPropToRootCountFgPctFilePair,
+        )
+        # No ranges for errors for now until we see the need.
+    else:
+        result = FlameGraphSet(
+            fgPctFilePair,
+            diffFGFiles,
+            errCPFGPctFilePair,
+            diffErrCPFGFiles,
+            errRootCountFgPctFilePair,
+            diffErrRootCountFGFiles,
+            errPropToRootCountFgPctFilePair,
+            diffErrPropToRootCountFgPctFilePair,
+        )
+
+    return result

--- a/tests/test_flamegraph.py
+++ b/tests/test_flamegraph.py
@@ -1,8 +1,561 @@
-import flamegraph
+import copy
+import os
+import tempfile
+from unittest import TestCase, mock
+
+import crisp.flamegraph as flamegraph
+from crisp.shared.models import (
+    MetricVals,
+    CallPathProfile,
+    ErrCountsData,
+    ErrorCPMetrics,
+    QuantizedMetrics,
+    Metrics,
+    ErrorMetrics,
+)
 
 
-def test_aggregateCCTs():
-    input = [(1, {'a->b': 10, 'a->c': 30}), (2, {'a->b->c': 20}), (3, {'a->c': 30, 'a->b': 10})]
-    expected = sorted('\na;b 20\na;b;c 20\na;c 60'.split('\n'))
-    result = sorted(flamegraph.aggregateCCTs(input).split('\n'))
-    assert result == expected
+class FlamegraphTestCase(TestCase):
+    def test_getParentCallPath(self):
+        assert flamegraph.getParentCallPath("a") == ""
+        assert flamegraph.getParentCallPath("a->b") == "a"
+        assert flamegraph.getParentCallPath("a->b->c") == "a->b"
+
+    def sanitizeAggregatedMap(self):
+        input1 = {
+            "a->b": 0,
+            "a->c": 0,
+            "a": 0,
+        }
+        expect1 = {
+            "a->b": 1,
+            "a->c": 1,
+            "a": 0,
+        }
+        input2 = {
+            "a->b->c": 10,
+            "a->b": 0,
+            "a": 0,
+        }
+        expect2 = {
+            "a->b->c": 10,
+            "a->b": 0,
+            "a": 0,
+        }
+
+        assert flamegraph.sanitizeAggregatedMap(input1) == expect1
+        assert flamegraph.sanitizeAggregatedMap(input2) == expect2
+
+    def test_aggregateTimeMapList(self):
+        input = [
+            (
+                1,
+                {
+                    "a->b": 10,
+                    "a->c": 30,
+                },
+            ),
+            (
+                2,
+                {
+                    "a->b->c": 20,
+                },
+            ),
+            (
+                3,
+                {
+                    "a->c": 30,
+                    "a->b": 10,
+                },
+            ),
+            (4, {}),
+        ]  # this one must be ignored since it does not contribute to the CCT.
+        expectNoAverage = {
+            "a->b": 20,
+            "a->c": 60,
+            "a->b->c": 20,
+        }
+        expectAverage = {
+            "a->b": 20 // 3,
+            "a->c": 60 // 3,
+            "a->b->c": 20 // 3,
+        }
+
+        assert expectNoAverage == flamegraph.aggregateTimeMapList(input, average=False)
+        assert expectAverage == flamegraph.aggregateTimeMapList(input, average=True)
+
+    def test_aggregateCCTs(self):
+        input = [
+            (
+                1,
+                {
+                    "a->b": 10,
+                    "a->c": 30,
+                },
+            ),
+            (
+                2,
+                {
+                    "a->b->c": 20,
+                },
+            ),
+            (
+                3,
+                {
+                    "a->c": 30,
+                    "a->b": 10,
+                },
+            ),
+        ]
+        errCounts = [
+            (
+                1,
+                {
+                    "a": ErrCountsData(stoppedErrors=1),
+                    "a->b": ErrCountsData(selfErrors=1),
+                    "a->c": ErrCountsData(selfErrors=1),
+                },
+            ),
+            (
+                2,
+                {
+                    "a->b": ErrCountsData(stoppedErrors=1),
+                    "a->b->c": ErrCountsData(selfErrors=1),
+                },
+            ),
+            (
+                3,
+                {
+                    "a": ErrCountsData(stoppedErrors=1),
+                    "a->c": ErrCountsData(selfErrors=1),
+                    "a->b": ErrCountsData(selfErrors=1),
+                },
+            ),
+        ]
+        expected = sorted(
+            "\na 0\na;b 6\na;b;c 6\na;c 20".split(
+                "\n",
+            ),
+        )
+        result = sorted(flamegraph.aggregateCCTs(input, errCounts).split("\n"))
+        assert result == expected
+
+        input = [
+            (
+                1,
+                {
+                    "a;a->b;b": 10,
+                    "a;a->c;c": 30,
+                },
+            ),
+            (
+                2,
+                {
+                    "a;a->c;c": 30,
+                    "a;a->b;b": 10,
+                },
+            ),
+        ]
+        errCounts = [
+            (
+                1,
+                {
+                    "a;a": ErrCountsData(stoppedErrors=1),
+                    "a;a->b;b": ErrCountsData(selfErrors=1),
+                    "a;a->c;c": ErrCountsData(selfErrors=1),
+                },
+            ),
+            (
+                3,
+                {
+                    "a;a": ErrCountsData(stoppedErrors=1),
+                    "a;a->c;c": ErrCountsData(selfErrors=1),
+                    "a;a->b;b": ErrCountsData(selfErrors=1),
+                },
+            ),
+        ]
+        expected = sorted(
+            "\na_a 0\na_a;b_b 10\na_a;c_c 30".split("\n"),
+        )
+        result = sorted(flamegraph.aggregateCCTs(input, errCounts).split("\n"))
+        assert result == expected
+
+        input = [
+            (
+                1,
+                {
+                    "a;a->b;b": 10,
+                    "a;a->c;c": 30,
+                },
+            ),
+            (
+                2,
+                {
+                    "a;a->c;c": 30,
+                    "a;a->b;b": 10,
+                },
+            ),
+        ]
+        errCounts = [
+            (
+                1,
+                {
+                    "a;a": ErrCountsData(stoppedErrors=1),
+                    "a;a->b;b": ErrCountsData(selfErrors=1),
+                    "a;a->c;c": ErrCountsData(selfErrors=1),
+                },
+            ),
+            (
+                3,
+                {
+                    "a;a": ErrCountsData(stoppedErrors=1),
+                    "a;a->c;c": ErrCountsData(selfErrors=1),
+                    "a;a->b;b": ErrCountsData(selfErrors=1),
+                },
+            ),
+        ]
+        expected = sorted(
+            "\na_a 0\na_a;b_b 10\na_a;c_c 30".split("\n"),
+        )
+        result = sorted(flamegraph.aggregateCCTs(input, errCounts).split("\n"))
+        assert result == expected
+
+    def create_mock_metrics_for_flameGraph(self):
+        cpp = CallPathProfile({}, 1, 0)
+        cpp.Upsert("[S1] O1->[S2] O2", MetricVals(30, 30, 1, 0))
+        cpp.Upsert("[S1] O1", MetricVals(100, 70, 1, 0))
+        errCPCallpathTimeExc = {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": 30,
+        }
+        # error data not accurate but doesn't matter; mock info not used
+        errCPMetrics = ErrorCPMetrics(errCPCallpathTimeExc, {}, {}, 0, 0)
+        errMetrics = ErrorMetrics(
+            0,
+            {},
+            {},
+            [],
+            [],
+            {},
+            {},
+            {},
+            -1,
+            propToRootHistoQuantized=QuantizedMetrics({}),
+            notPropToRootHistoQuantized=QuantizedMetrics({}),
+            propToRootOnCPHistoQuantized=QuantizedMetrics({}),
+            notPropToRootOnCPHistoQuantized=QuantizedMetrics({}),
+            supressHistoQuantized=QuantizedMetrics({}),
+            supressOnCPHistoQuantized=QuantizedMetrics({}),
+        )
+        metrics = Metrics(
+            1,
+            1,
+            cpp,
+            errCPMetrics,
+            errMetrics,
+            130,
+            30,
+            100,
+            30,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            False,
+            {},
+            False,
+            0,
+            tags=[],
+            cycles={},
+            crossRegionCalls={},
+        )
+
+        return metrics
+
+    def create_N_mock_metrics_for_flameGraph(self, n):
+        metrics = []
+        for i in range(1, n + 1):
+            cpp = CallPathProfile({}, 1, i)
+            cpp.Upsert("[S1] O1", MetricVals(i * 100, i * 70, i, 0))
+            cpp.Upsert("[S1] O1->[S2] O2", MetricVals(i * 30, i * 30, i, 1))
+
+            errCPCallpathTimeExc = {
+                "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": i * 30,
+            }
+
+            # error data not accurate but doesn't matter; mock info not used
+            errCPMetrics = ErrorCPMetrics(errCPCallpathTimeExc, {}, {}, 0, 0)
+            errMetrics = ErrorMetrics(
+                0,
+                {},
+                {},
+                [],
+                [],
+                {},
+                {},
+                {},
+                -1,
+                propToRootHistoQuantized=QuantizedMetrics({}),
+                notPropToRootHistoQuantized=QuantizedMetrics({}),
+                propToRootOnCPHistoQuantized=QuantizedMetrics({}),
+                notPropToRootOnCPHistoQuantized=QuantizedMetrics({}),
+                supressHistoQuantized=QuantizedMetrics({}),
+                supressOnCPHistoQuantized=QuantizedMetrics({}),
+            )
+            metrics.append(
+                Metrics(
+                    1,
+                    0,
+                    cpp,
+                    errCPMetrics,
+                    errMetrics,
+                    i * 130,
+                    i * 30,
+                    i * 100,
+                    30,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    False,
+                    {},
+                    False,
+                    0,
+                    tags=[],
+                    cycles={},
+                    crossRegionCalls={},
+                ),
+            )
+
+        return metrics
+
+    @mock.patch("crisp.flamegraph.subprocess.check_call", return_value=0)
+    def test_flameGraph(self, check_call_mock):  # noqa: ARG002
+        m1 = self.create_mock_metrics_for_flameGraph()
+        m2 = self.create_mock_metrics_for_flameGraph()
+        m3 = self.create_mock_metrics_for_flameGraph()
+
+        m = [m1, m2, m3]
+        pcts = flamegraph.STANDARD_PERCENTILES
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            flamePairs = [
+                (f"P0-{x[1]}", os.path.join(tmpdirname, f"flame-graph-P{x[1]}.cct.svg"))
+                for x in pcts
+            ]
+
+            diffFlames = []
+            for id, p in enumerate(pcts):
+                if id != 0:
+                    diffFlames += [
+                        os.path.join(
+                            tmpdirname,
+                            f"flame-graph-P0-{x[1]}vsP0-{p[1]}.cct.svg",
+                        )
+                        for x in pcts[:id]
+                    ]
+
+            [
+                os.path.join(tmpdirname, f"flame-graph-P0-{x}vsP0-{x}.cct.svg")
+                for x in pcts
+            ]
+            errFlamePairs = [
+                (
+                    f"P0-{x[1]}",
+                    os.path.join(tmpdirname, f"err-flame-graph-P{x[1]}.cct.svg"),
+                )
+                for x in pcts
+            ]
+
+            errDiffFlames = []
+            for id, p in enumerate(pcts):
+                if id != 0:
+                    errDiffFlames += [
+                        os.path.join(
+                            tmpdirname,
+                            f"err-flame-graph-P0-{x[1]}vsP0-{p[1]}.cct.svg",
+                        )
+                        for x in pcts[:id]
+                    ]
+            result = flamegraph.flameGraph(m, tmpdirname, "S1", "O1", True)
+            # the errored-API ones won't get generated as no metrics is marked as root errored
+            expect = flamegraph.FlameGraphSet(
+                flamePairs,
+                diffFlames,
+                errFlamePairs,
+                errDiffFlames,
+                [],
+                [],
+                [],
+                [],
+            )
+            assert result == expect
+
+    @mock.patch("crisp.flamegraph.subprocess.check_call", return_value=0)
+    def test_flameGraphWithRange(self, check_call_mock):  # noqa: ARG002
+        m = self.create_N_mock_metrics_for_flameGraph(100)
+        stdPcts = flamegraph.STANDARD_PERCENTILES
+        additionalPcts = flamegraph.ADDITIONAL_RANGES
+        noDiffPairs = flamegraph.RANGES_SKIP_DIFF
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            flamePairs = [
+                (f"P0-{x[1]}", os.path.join(tmpdirname, f"flame-graph-P{x[1]}.cct.svg"))
+                for x in stdPcts
+            ]
+            flamePairs += [
+                (
+                    f"P{x[0]}-{x[1]}",
+                    os.path.join(tmpdirname, f"flame-graph-P{x[0]}-{x[1]}.cct.svg"),
+                )
+                for x in additionalPcts
+            ]
+            flamePairs += [
+                (
+                    f"P{x[0]}-{x[1]}",
+                    os.path.join(tmpdirname, f"flame-graph-P{x[0]}-{x[1]}.cct.svg"),
+                )
+                for x in noDiffPairs
+            ]
+
+            diffFlames = []
+            for pcts in [stdPcts, additionalPcts]:
+                for id, p in enumerate(pcts):
+                    if id != 0:
+                        diffFlames += [
+                            os.path.join(
+                                tmpdirname,
+                                f"flame-graph-P{x[0]}-{x[1]}vsP{p[0]}-{p[1]}.cct.svg",
+                            )
+                            for x in pcts[:id]
+                        ]
+            errFlamePairs = [
+                (
+                    f"P0-{x[1]}",
+                    os.path.join(tmpdirname, f"err-flame-graph-P{x[1]}.cct.svg"),
+                )
+                for x in stdPcts
+            ]
+
+            errDiffFlames = []
+            for pcts in [stdPcts]:
+                for id, p in enumerate(pcts):
+                    if id != 0:
+                        errDiffFlames += [
+                            os.path.join(
+                                tmpdirname,
+                                f"err-flame-graph-P0-{x[1]}vsP0-{p[1]}.cct.svg",
+                            )
+                            for x in pcts[:id]
+                        ]
+            result = flamegraph.flameGraph(
+                m,
+                tmpdirname,
+                "S1",
+                "O1",
+                True,
+                doRanges=True,
+            )
+            # the errored-API ones won't get generated as no metrics is marked as root errored
+            expect = flamegraph.FlameGraphSet(
+                flamePairs,
+                diffFlames,
+                errFlamePairs,
+                errDiffFlames,
+                [],
+                [],
+                [],
+                [],
+            )
+            assert result == expect
+
+    """ Function to test FlameGraphSet class"""
+
+    def test_FlameGraphSet(self):
+        flamePairs = [
+            ("P50", "A.cct.svg"),
+            ("P95", "B.cct.svg"),
+            ("P99", "C.cct.svg"),
+        ]
+        diffFlames = [
+            "D.cct.svg",
+            "E.cct.svg",
+            "F.cct.svg",
+        ]
+        errCPFlamePairs = [
+            ("P50", "G.cct.svg"),
+            ("P95", "H.cct.svg"),
+            ("P99", "I.cct.svg"),
+        ]
+        errCPDiffFlames = [
+            "J.cct.svg",
+            "K.cct.svg",
+            "L.cct.svg",
+        ]
+        errRootFlamePairs = [
+            ("P50", "M.cct.svg"),
+            ("P95", "N.cct.svg"),
+            ("P99", "O.cct.svg"),
+        ]
+        errRootDiffFlames = [
+            "P.cct.svg",
+            "Q.cct.svg",
+            "R.cct.svg",
+        ]
+
+        errPropToRootCountFgPctFilePair = [
+            ("P100", "S.cct.svg"),
+        ]
+        diffErrPropToRootCountFgPctFilePair = []
+
+        result = flamegraph.FlameGraphSet(
+            flamePairs,
+            diffFlames,
+            errCPFlamePairs,
+            errCPDiffFlames,
+            errRootFlamePairs,
+            errRootDiffFlames,
+            errPropToRootCountFgPctFilePair,
+            diffErrPropToRootCountFgPctFilePair,
+        )
+        assert result == copy.deepcopy(result)
+        assert sorted(result.GetAllFiles()) == sorted(
+            [x + ".cct.svg" for x in "ABCDEFGHIJKLMNOPQR"]
+            + [x + ".cct" for x in "ABCDEFGHIJKLMNOPQR"],
+        )
+
+    def test_get_all_error_files(self):
+        flamePairs = []
+        diffFlames = []
+        errCPFlamePairs = []
+        errCPDiffFlames = []
+        errRootFlamePairs = []
+        errRootDiffFlames = []
+
+        errPropToRootCountFgPctFilePair = [
+            ("P100", "S.cct.svg"),
+            ("P50", "T.cct.svg"),
+        ]
+        diffErrPropToRootCountFgPctFilePair = [
+            "U.cct.svg",
+            "V.cct.svg",
+        ]
+
+        flamegraph_set = flamegraph.FlameGraphSet(
+            flamePairs,
+            diffFlames,
+            errCPFlamePairs,
+            errCPDiffFlames,
+            errRootFlamePairs,
+            errRootDiffFlames,
+            errPropToRootCountFgPctFilePair,
+            diffErrPropToRootCountFgPctFilePair,
+        )
+
+        result = flamegraph_set.GetAllErrorFiles()
+
+        expected_svg_files = ["S.cct.svg", "T.cct.svg", "U.cct.svg", "V.cct.svg"]
+        expected_cct_files = ["S.cct", "T.cct", "U.cct", "V.cct"]
+
+        assert sorted(result) == sorted(expected_svg_files + expected_cct_files)


### PR DESCRIPTION
## Summary

Ports `crisp/flamegraph.py` (flame graph generation) and its full test suite
from the internal codebase, replacing the stub `tests/test_flamegraph.py`.

### What was ported

`flamegraph.py` (435 lines) generates SVG flame graphs from critical-path
profiles at configurable percentile ranges. Key components:

| Symbol | Description |
|---|---|
| `FlameGraphSet` | Data class holding all generated SVG/CCT file paths |
| `aggregateCallPathProfiles` | Aggregates `CallPathProfile` objects into folded-stack format |
| `aggregateCCTs` | Aggregates raw call-chain time maps (with optional per-entry error counts) |
| `aggregateTimeMapList` | Helper: sums or averages a list of call-path time maps |
| `sanitizeAggregatedMap` | Ensures leaf call-path entries have a non-zero value |
| `genFlameGraph` | Drives the Perl `flamegraph.pl` and `difffolded.pl` scripts |
| `flameGraph` | Top-level entry point: sorts metrics by latency and produces a `FlameGraphSet` |

### `<<errCount>>` annotation removed

The internal source appended a `<<N>>` suffix (error frequency) to each folded
stack line in `aggregateCallPathProfiles` and `aggregateCCTs`. This custom
extension is not recognised by the upstream
[`flamegraph.pl`](https://github.com/brendangregg/FlameGraph) script and would
cause rendering failures. The suffix is dropped in the OSS port; all flame graph
lines now end with just the numeric sample count.

### Import rewrites

| Internal | OSS |
|---|---|
| `from uber.tooling.program_analysis.critical_path.shared.models import CallPathProfile` | `from crisp.shared.models import CallPathProfile` |

### Test file

`tests/test_flamegraph.py` is fully replaced. The stub (1 test) is superseded by
`FlamegraphTestCase` with 7 test methods. Import rewrites:

| Internal | OSS |
|---|---|
| `import uber.tooling.program_analysis.critical_path.flamegraph as flamegraph` | `import crisp.flamegraph as flamegraph` |
| `from uber.tooling.program_analysis.critical_path.shared.models import ...` | `from crisp.shared.models import ...` |
| `from uber.tooling.program_analysis.critical_path.models import ...` | `from crisp.shared.models import ...` |

Mock patch paths updated from
`uber.tooling.program_analysis.critical_path.flamegraph.subprocess.check_call`
→ `crisp.flamegraph.subprocess.check_call`.

Expected strings that contained `<<…>>` annotations were updated to match the
dropped format.

### BUILD changes

- `crisp/BUILD.bazel`: new `py_library(name = "flamegraph", ...)` target
- `BUILD.bazel`: new `py_test(name = "test_flamegraph", ...)` standalone target;
  `//crisp:flamegraph` added to the omnibus `pytest` target deps

## Test count

| Before | After |
|---|---|
| 311 pytest tests | 317 pytest tests (+6 net: 7 new − 1 old stub) |
| 6 Bazel targets | 7 Bazel targets |

## Test plan

- [x] `bazel test //...` — all 7 targets pass
- [x] Leak check: `grep -rn "uber\.\|eaterapp\|ctf\.\|corp\.\|dca[0-9]\|dfw[0-9]\|phx[0-9]" crisp/flamegraph.py tests/test_flamegraph.py -i` — empty
- [x] No linter errors in new files
