### PR TITLE
port(crisp): add cct_utils.py — CCT parsing, DOT rendering, and pure-Python tests (PR 10c)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,7 @@ py_test(
         "//crisp:yaml_merger",
         "//crisp:trace_merger",
         "//crisp:flamegraph",
+        "//crisp:cct_utils",
         "@pypi//pytest",
     ],
     env = {"MPLBACKEND": "Agg"},
@@ -92,6 +93,16 @@ py_test(
     deps = [
         "//crisp:flamegraph",
         "//crisp:pkg",
+    ],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_cct_utils",
+    srcs = ["tests/test_cct_utils.py"],
+    deps = [
+        "//crisp:cct_utils",
+        "@pypi//pytest",
     ],
     imports = ["."],
 )

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -86,3 +86,10 @@ py_library(
         "//crisp/shared:shared",
     ],
 )
+
+py_library(
+    name = "cct_utils",
+    srcs = ["cct_utils.py"],
+    visibility = ["//visibility:public"],
+    deps = [],
+)

--- a/crisp/LAYERS.md
+++ b/crisp/LAYERS.md
@@ -83,3 +83,6 @@ When porting, apply this decision in order:
 | `tests/test_common.py::TestDirExistsOnTB.*`                           | PR 11             | TBClient not yet ported.                                                                              |
 | `tests/test_common.py::TestBlobExistsOnTB.*`                          | PR 11             | TBClient not yet ported.                                                                              |
 | *(all PR 9d items unblocked — see port/pr-09d-graph-final commit)*      | —                 | —                                                                                                     |
+| `tests/test_cct_utils.py::TestCreateProtobufResponse`                  | PR 11             | Requires protobuf stub not yet available.                                                             |
+| `tests/test_cct_utils.py::TestCreateProtobufResponseWithExemplars`     | PR 11             | Requires protobuf stub not yet available.                                                             |
+| `tests/test_cct_utils.py::TestCCTUtilsIntegration`                     | PR 11             | Both test methods call `create_protobuf_response_with_exemplars`; requires protobuf stub.             |

--- a/crisp/cct_utils.py
+++ b/crisp/cct_utils.py
@@ -1,0 +1,170 @@
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+TIMING_PATTERN = re.compile(r'(\d+)\s*<<(\d+)>>$')
+
+
+def parse_call_path_part(part: str) -> dict[str, str]:
+    """Parse a single call path part into service and operation."""
+    if not (part.startswith('[') and ']' in part):
+        return {}
+    service_end = part.find(']')
+    service = part[1:service_end]
+    operation = part[service_end + 1:].strip()
+    return {'service': service, 'operation_name': operation}
+
+
+def parse_cct_line(line: str) -> dict[str, Any]:
+    """Parse a single line from the CCT file."""
+    line = line.strip()
+    if not line:
+        return {}
+    parts = line.split(';')
+    if not parts:
+        return {}
+
+    last_part = parts[-1]
+    timing_match = TIMING_PATTERN.search(last_part)
+    if not timing_match:
+        return {}
+
+    duration = int(timing_match.group(1))
+    frequency = int(timing_match.group(2))
+    last_part = last_part[: timing_match.start()].strip()
+
+    call_path: list[dict[str, str]] = []
+    for part in parts[:-1]:
+        p = parse_call_path_part(part)
+        if p:
+            call_path.append(p)
+    p_last = parse_call_path_part(last_part)
+    if p_last:
+        call_path.append(p_last)
+
+    if not call_path:
+        return {}
+
+    return {'call_path': call_path, 'duration': duration, 'frequency': frequency}
+
+
+def parse_cct_file(cct_path: str) -> list[dict[str, Any]]:
+    """Parse a CCT file and return call chain summaries."""
+    summaries: list[dict[str, Any]] = []
+    try:
+        with open(cct_path) as f:
+            for line in f:
+                summary = parse_cct_line(line)
+                if summary:
+                    summaries.append(summary)
+    except Exception as e:
+        logger.error("Error parsing CCT file %s: %s", cct_path, e)
+    return summaries
+
+
+def _escape_dot_label(s: str) -> str:
+    """Escape characters that are special inside DOT double-quoted strings."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _make_node_label(label: str, excl_time: int, incl_time: int, freq: int) -> str:
+    """Build a multi-line DOT node label with timing info."""
+    parts = [_escape_dot_label(label)]
+    if incl_time > 0:
+        parts.append(f"incl: {incl_time}\u00b5s")
+    if excl_time > 0:
+        parts.append(f"excl: {excl_time}\u00b5s")
+    if freq > 0:
+        parts.append(f"freq: {freq}")
+    return "\\n".join(parts)
+
+
+def cct_to_dot(summaries: list[dict[str, Any]]) -> str:
+    """Convert parsed CCT summaries into a Graphviz DOT digraph."""
+    if not summaries:
+        return "digraph CCT {\n}\n"
+
+    path_to_id: dict[tuple[str, ...], int] = {}
+    node_label: dict[int, str] = {}
+    node_excl: dict[int, int] = {}
+    node_freq: dict[int, int] = {}
+    children: dict[int, list[int]] = {}
+    edge_set: set[tuple[int, int]] = set()
+    next_id = 0
+
+    def _get_or_create(path_key: tuple[str, ...], label: str) -> int:
+        nonlocal next_id
+        if path_key in path_to_id:
+            return path_to_id[path_key]
+        nid = next_id
+        next_id += 1
+        path_to_id[path_key] = nid
+        node_label[nid] = label
+        node_excl[nid] = 0
+        node_freq[nid] = 0
+        children[nid] = []
+        return nid
+
+    for summary in summaries:
+        call_path = summary['call_path']
+        duration = summary['duration']
+        frequency = summary['frequency']
+
+        prev_id = None
+        for i, part in enumerate(call_path):
+            path_key = tuple(
+                f"[{p['service']}]{p['operation_name']}" for p in call_path[:i + 1]
+            )
+            label = f"[{part['service']}] {part['operation_name']}"
+            nid = _get_or_create(path_key, label)
+
+            if i == len(call_path) - 1:
+                node_excl[nid] += duration
+                node_freq[nid] += frequency
+
+            if prev_id is not None and (prev_id, nid) not in edge_set:
+                children[prev_id].append(nid)
+                edge_set.add((prev_id, nid))
+            prev_id = nid
+
+    # Compute inclusive times bottom-up via post-order traversal
+    node_incl: dict[int, int] = {}
+
+    def _compute_inclusive(nid: int) -> int:
+        total = node_excl[nid]
+        for cid in children[nid]:
+            total += _compute_inclusive(cid)
+        node_incl[nid] = total
+        return total
+
+    roots = {nid for nid in node_label if not any(nid in ch for ch in children.values())}
+    for root in roots:
+        _compute_inclusive(root)
+
+    lines = [
+        "digraph CCT {",
+        '    rankdir=TB;',
+        '    node [shape=box, style=filled, fillcolor=lightyellow, '
+        'fontname="Helvetica", fontsize=10];',
+        '    edge [fontname="Helvetica", fontsize=8];',
+        "",
+    ]
+
+    for nid in sorted(node_label):
+        label = _make_node_label(
+            node_label[nid], node_excl[nid], node_incl.get(nid, 0), node_freq[nid],
+        )
+        lines.append(f'    n{nid} [label="{label}"];')
+
+    lines.append("")
+
+    for parent_id, child_id in sorted(edge_set):
+        lines.append(f"    n{parent_id} -> n{child_id};")
+
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+# create_protobuf_response_with_exemplars and helpers deferred — requires protobuf stub (PR 11)

--- a/tests/test_cct_utils.py
+++ b/tests/test_cct_utils.py
@@ -1,0 +1,417 @@
+"""Unit tests for cct_utils.py module."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, mock_open
+
+import pytest
+
+from crisp import cct_utils
+
+
+class TestParseCallPathPart(unittest.TestCase):
+    """Test parse_call_path_part function."""
+
+    def test_valid_service_operation(self):
+        """Test parsing valid service and operation."""
+        result = cct_utils.parse_call_path_part("[feedservice]GetStreamingFeedByID")
+        expected = {
+            'service': 'feedservice',
+            'operation_name': 'GetStreamingFeedByID'
+        }
+        self.assertEqual(result, expected)
+
+    def test_service_only(self):
+        """Test parsing service without operation."""
+        result = cct_utils.parse_call_path_part("[feedservice]")
+        expected = {
+            'service': 'feedservice',
+            'operation_name': ''
+        }
+        self.assertEqual(result, expected)
+
+    def test_operation_with_spaces(self):
+        """Test parsing with whitespace around operation."""
+        result = cct_utils.parse_call_path_part("[service]  operation_name  ")
+        expected = {
+            'service': 'service',
+            'operation_name': 'operation_name'
+        }
+        self.assertEqual(result, expected)
+
+    def test_complex_service_name(self):
+        """Test parsing complex service names."""
+        result = cct_utils.parse_call_path_part("[com.example.feedservice.feedmaker]GetFeed")
+        expected = {
+            'service': 'com.example.feedservice.feedmaker',
+            'operation_name': 'GetFeed'
+        }
+        self.assertEqual(result, expected)
+
+    def test_invalid_format_no_brackets(self):
+        """Test invalid format without brackets."""
+        result = cct_utils.parse_call_path_part("feedservice GetStreamingFeedByID")
+        self.assertEqual(result, {})
+
+    def test_invalid_format_no_closing_bracket(self):
+        """Test invalid format without closing bracket."""
+        result = cct_utils.parse_call_path_part("[feedservice GetStreamingFeedByID")
+        self.assertEqual(result, {})
+
+    def test_empty_string(self):
+        """Test parsing empty string."""
+        result = cct_utils.parse_call_path_part("")
+        self.assertEqual(result, {})
+
+    def test_only_brackets(self):
+        """Test parsing only brackets."""
+        result = cct_utils.parse_call_path_part("[]")
+        expected = {
+            'service': '',
+            'operation_name': ''
+        }
+        self.assertEqual(result, expected)
+
+
+class TestParseCCTLine(unittest.TestCase):
+    """Test parse_cct_line function."""
+
+    def test_valid_single_service_line(self):
+        """Test parsing valid line with single service."""
+        line = "[feedservice]GetStreamingFeedByID 1500 <<100>>"
+        result = cct_utils.parse_cct_line(line)
+        expected = {
+            'call_path': [{'service': 'feedservice', 'operation_name': 'GetStreamingFeedByID'}],
+            'duration': 1500,
+            'frequency': 100
+        }
+        self.assertEqual(result, expected)
+
+    def test_valid_multi_service_line(self):
+        """Test parsing valid line with multiple services."""
+        line = "[service1]operation1;[service2]operation2;[service3]operation3 2000 <<50>>"
+        result = cct_utils.parse_cct_line(line)
+        expected = {
+            'call_path': [
+                {'service': 'service1', 'operation_name': 'operation1'},
+                {'service': 'service2', 'operation_name': 'operation2'},
+                {'service': 'service3', 'operation_name': 'operation3'}
+            ],
+            'duration': 2000,
+            'frequency': 50
+        }
+        self.assertEqual(result, expected)
+
+    def test_complex_real_world_line(self):
+        """Test parsing complex real-world CCT line."""
+        line = "[com.example.feedservice.feedmaker]FeedService::GetStreamingFeedByID;[cache]GetFromCache;[db]QueryDatabase 750 <<25>>"
+        result = cct_utils.parse_cct_line(line)
+        expected = {
+            'call_path': [
+                {'service': 'com.example.feedservice.feedmaker', 'operation_name': 'FeedService::GetStreamingFeedByID'},
+                {'service': 'cache', 'operation_name': 'GetFromCache'},
+                {'service': 'db', 'operation_name': 'QueryDatabase'}
+            ],
+            'duration': 750,
+            'frequency': 25
+        }
+        self.assertEqual(result, expected)
+
+    def test_line_with_whitespace(self):
+        """Test parsing line with extra whitespace."""
+        line = "  [service]operation  3000 <<10>>  "
+        result = cct_utils.parse_cct_line(line)
+        expected = {
+            'call_path': [{'service': 'service', 'operation_name': 'operation'}],
+            'duration': 3000,
+            'frequency': 10
+        }
+        self.assertEqual(result, expected)
+
+    def test_invalid_timing_format(self):
+        """Test invalid timing format."""
+        line = "[service]operation invalid_timing"
+        result = cct_utils.parse_cct_line(line)
+        self.assertEqual(result, {})
+
+    def test_missing_frequency(self):
+        """Test missing frequency in timing."""
+        line = "[service]operation 1500"
+        result = cct_utils.parse_cct_line(line)
+        self.assertEqual(result, {})
+
+    def test_malformed_frequency(self):
+        """Test malformed frequency brackets."""
+        line = "[service]operation 1500 <100>"
+        result = cct_utils.parse_cct_line(line)
+        self.assertEqual(result, {})
+
+    def test_empty_line(self):
+        """Test parsing empty line."""
+        result = cct_utils.parse_cct_line("")
+        self.assertEqual(result, {})
+
+    def test_line_with_invalid_service_parts(self):
+        """Test line with some invalid service parts."""
+        line = "[valid]op1;invalid_part;[valid2]op2 1000 <<5>>"
+        result = cct_utils.parse_cct_line(line)
+        expected = {
+            'call_path': [
+                {'service': 'valid', 'operation_name': 'op1'},
+                {'service': 'valid2', 'operation_name': 'op2'}
+            ],
+            'duration': 1000,
+            'frequency': 5
+        }
+        self.assertEqual(result, expected)
+
+    def test_no_valid_call_path_parts(self):
+        """Test line with no valid call path parts."""
+        line = "invalid;invalid2;invalid3 1000 <<5>>"
+        result = cct_utils.parse_cct_line(line)
+        self.assertEqual(result, {})
+
+
+class TestParseCCTFile(unittest.TestCase):
+    """Test parse_cct_file function."""
+
+    def test_valid_file_parsing(self):
+        """Test parsing valid CCT file."""
+        file_content = """[service1]operation1 1000 <<10>>
+[service2]operation2;[service3]operation3 2000 <<20>>
+
+[service4]operation4 500 <<5>>"""
+
+        with patch("builtins.open", mock_open(read_data=file_content)):
+            result = cct_utils.parse_cct_file("test.cct")
+
+        expected = [
+            {
+                'call_path': [{'service': 'service1', 'operation_name': 'operation1'}],
+                'duration': 1000,
+                'frequency': 10
+            },
+            {
+                'call_path': [
+                    {'service': 'service2', 'operation_name': 'operation2'},
+                    {'service': 'service3', 'operation_name': 'operation3'}
+                ],
+                'duration': 2000,
+                'frequency': 20
+            },
+            {
+                'call_path': [{'service': 'service4', 'operation_name': 'operation4'}],
+                'duration': 500,
+                'frequency': 5
+            }
+        ]
+        self.assertEqual(result, expected)
+
+    def test_file_with_invalid_lines(self):
+        """Test parsing file with some invalid lines."""
+        file_content = """[valid]operation 1000 <<10>>
+invalid line
+[another_valid]op2 500 <<5>>
+"""
+
+        with patch("builtins.open", mock_open(read_data=file_content)):
+            result = cct_utils.parse_cct_file("test.cct")
+
+        expected = [
+            {
+                'call_path': [{'service': 'valid', 'operation_name': 'operation'}],
+                'duration': 1000,
+                'frequency': 10
+            },
+            {
+                'call_path': [{'service': 'another_valid', 'operation_name': 'op2'}],
+                'duration': 500,
+                'frequency': 5
+            }
+        ]
+        self.assertEqual(result, expected)
+
+    def test_empty_file(self):
+        """Test parsing empty file."""
+        with patch("builtins.open", mock_open(read_data="")):
+            result = cct_utils.parse_cct_file("empty.cct")
+        self.assertEqual(result, [])
+
+    def test_file_read_error(self):
+        """Test file read error handling."""
+        with patch("builtins.open", side_effect=FileNotFoundError("File not found")):
+            with patch("crisp.cct_utils.logger") as mock_logger:
+                result = cct_utils.parse_cct_file("nonexistent.cct")
+                mock_logger.error.assert_called_once()
+                self.assertEqual(result, [])
+
+
+@pytest.mark.parametrize("label,excl,incl,freq,expected", [
+    ("svc op", 100, 500, 10, "svc op\\nincl: 500\u00b5s\\nexcl: 100\u00b5s\\nfreq: 10"),
+    ("svc op", 0, 500, 10, "svc op\\nincl: 500\u00b5s\\nfreq: 10"),
+    ("svc op", 100, 0, 10, "svc op\\nexcl: 100\u00b5s\\nfreq: 10"),
+    ("svc op", 100, 500, 0, "svc op\\nincl: 500\u00b5s\\nexcl: 100\u00b5s"),
+    ("svc op", 0, 0, 0, "svc op"),
+    ('has"quote', 1, 1, 1, 'has\\"quote\\nincl: 1\u00b5s\\nexcl: 1\u00b5s\\nfreq: 1'),
+    ("has\\back", 1, 1, 1, "has\\\\back\\nincl: 1\u00b5s\\nexcl: 1\u00b5s\\nfreq: 1"),
+])
+def test_make_node_label(label, excl, incl, freq, expected):
+    result = cct_utils._make_node_label(label, excl, incl, freq)
+    assert result == expected
+
+
+def test_cct_to_dot_empty_summaries():
+    result = cct_utils.cct_to_dot([])
+    assert result == "digraph CCT {\n}\n"
+
+
+def test_cct_to_dot_single_leaf():
+    summaries = [
+        {
+            'call_path': [{'service': 'svcA', 'operation_name': 'opA'}],
+            'duration': 1000,
+            'frequency': 5,
+        }
+    ]
+    dot = cct_utils.cct_to_dot(summaries)
+    assert dot.startswith("digraph CCT {")
+    assert "[svcA] opA" in dot
+    assert "incl: 1000" in dot
+    assert "excl: 1000" in dot
+    assert "freq: 5" in dot
+    assert "->" not in dot
+
+
+def test_cct_to_dot_simple_chain():
+    summaries = [
+        {
+            'call_path': [
+                {'service': 'svcA', 'operation_name': 'opA'},
+                {'service': 'svcB', 'operation_name': 'opB'},
+            ],
+            'duration': 200,
+            'frequency': 3,
+        }
+    ]
+    dot = cct_utils.cct_to_dot(summaries)
+    assert "n0 -> n1;" in dot
+    assert "[svcA] opA" in dot
+    assert "[svcB] opB" in dot
+
+
+def test_cct_to_dot_branching_tree():
+    summaries = [
+        {
+            'call_path': [
+                {'service': 'root', 'operation_name': 'main'},
+                {'service': 'svcA', 'operation_name': 'opA'},
+            ],
+            'duration': 100,
+            'frequency': 1,
+        },
+        {
+            'call_path': [
+                {'service': 'root', 'operation_name': 'main'},
+                {'service': 'svcB', 'operation_name': 'opB'},
+            ],
+            'duration': 200,
+            'frequency': 2,
+        },
+    ]
+    dot = cct_utils.cct_to_dot(summaries)
+
+    assert dot.count("->") == 2
+    assert "[root] main" in dot
+    assert "[svcA] opA" in dot
+    assert "[svcB] opB" in dot
+
+
+def test_cct_to_dot_inclusive_time_propagation():
+    """Inclusive time of a parent equals the sum of exclusive times in its subtree."""
+    summaries = [
+        {
+            'call_path': [
+                {'service': 'root', 'operation_name': 'main'},
+                {'service': 'child', 'operation_name': 'work'},
+            ],
+            'duration': 300,
+            'frequency': 1,
+        },
+        {
+            'call_path': [
+                {'service': 'root', 'operation_name': 'main'},
+                {'service': 'child2', 'operation_name': 'io'},
+            ],
+            'duration': 700,
+            'frequency': 1,
+        },
+    ]
+    dot = cct_utils.cct_to_dot(summaries)
+
+    assert "incl: 1000" in dot
+    assert "incl: 300" in dot
+    assert "incl: 700" in dot
+
+
+def test_cct_to_dot_shared_prefix():
+    """Two chains sharing a prefix should share the same intermediate node."""
+    summaries = [
+        {
+            'call_path': [
+                {'service': 'A', 'operation_name': 'a'},
+                {'service': 'B', 'operation_name': 'b'},
+                {'service': 'C', 'operation_name': 'c'},
+            ],
+            'duration': 50,
+            'frequency': 1,
+        },
+        {
+            'call_path': [
+                {'service': 'A', 'operation_name': 'a'},
+                {'service': 'B', 'operation_name': 'b'},
+                {'service': 'D', 'operation_name': 'd'},
+            ],
+            'duration': 150,
+            'frequency': 2,
+        },
+    ]
+    dot = cct_utils.cct_to_dot(summaries)
+
+    assert dot.count("[A] a") == 1
+    assert dot.count("[B] b") == 1
+
+    assert dot.count("->") == 3
+
+
+def test_cct_to_dot_full_pipeline_with_file():
+    """Integration: parse a CCT file then produce DOT output."""
+    cct_content = (
+        "[gateway]handleRequest;[auth]validate;[db]lookup 500 <<10>>\n"
+        "[gateway]handleRequest;[auth]validate 100 <<10>>\n"
+        "[gateway]handleRequest;[cache]get 300 <<8>>\n"
+    )
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.cct', delete=False) as f:
+        f.write(cct_content)
+        temp_file = f.name
+
+    try:
+        summaries = cct_utils.parse_cct_file(temp_file)
+        dot = cct_utils.cct_to_dot(summaries)
+
+        assert dot.startswith("digraph CCT {")
+        assert dot.strip().endswith("}")
+        assert "[gateway] handleRequest" in dot
+        assert "[auth] validate" in dot
+        assert "[db] lookup" in dot
+        assert "[cache] get" in dot
+
+        assert "incl: 900" in dot
+        assert "incl: 600" in dot
+    finally:
+        os.unlink(temp_file)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `crisp/cct_utils.py` with the pure-Python subset of the Call Chain Tree
(CCT) utilities module. Functions for parsing CCT text files and rendering them
as Graphviz DOT diagrams are fully ported. The protobuf-dependent function
(`create_protobuf_response_with_exemplars`) and its two helpers are deferred to
PR 11, replaced by a single placeholder comment in the module.

### Functions ported

| Function | Description |
|---|---|
| `parse_call_path_part` | Parse a `[service]operation` token into a dict |
| `parse_cct_line` | Parse one semicolon-separated CCT line with timing |
| `parse_cct_file` | Read a CCT file and return all parsed summaries |
| `_escape_dot_label` | Escape special characters for DOT double-quoted strings |
| `_make_node_label` | Build a multi-line DOT node label with timing info |
| `cct_to_dot` | Convert parsed CCT summaries into a Graphviz DOT digraph |

### Deferred to PR 11 (requires protobuf stub)

- `_build_exemplar_lookup` — maps call-path keys to exemplar lists from a
  `CallPathProfile`; depends on the protobuf-backed profile type.
- `_cct_key_to_profile_key` — converts a parsed call-path list to the
  `->` -separated key format used by `CallPathProfile`.
- `create_protobuf_response_with_exemplars` — assembles a typed protobuf
  `AnalyzeResponse` from CCT summaries; cannot be ported until the protobuf
  stub is available in OSS.

A placeholder comment at the bottom of `crisp/cct_utils.py` marks the
deferral point and references PR 11.

### Tests ported

36 new pytest tests added across three test classes and eight standalone
parametrized/integration functions:

| Class / function | Count |
|---|---|
| `TestParseCallPathPart` | 8 |
| `TestParseCCTLine` | 10 |
| `TestParseCCTFile` | 4 |
| `test_make_node_label` (parametrized) | 7 |
| `test_cct_to_dot_*` standalone functions | 7 |

### Tests deferred to PR 11

| Test | Reason |
|---|---|
| `TestCreateProtobufResponse` | Calls `create_protobuf_response_with_exemplars` |
| `TestCreateProtobufResponseWithExemplars` | Same |
| `TestCCTUtilsIntegration` | Both test methods call `create_protobuf_response_with_exemplars` |

Entries added to `crisp/LAYERS.md`.

### Service name genericization

Internal service name strings appearing in test assertions were replaced with
generic equivalents:

| Internal string | Replacement |
|---|---|
| `uber.everything.eatsfeed.feedmaker` | `com.example.feedservice.feedmaker` |
| `Feedmaker::GetStreamingFeedByID` | `FeedService::GetStreamingFeedByID` |
| `eatsfeed` (standalone) | `feedservice` |

## Test count

| | Tests |
|---|---|
| Before PR 10c | 317 |
| After PR 10c | **353** |
| New tests | +36 |

## Test plan

- [x] `bazel test //...` — all 8 targets pass, 353 pytest tests
- [x] `grep -rn "uber\.\|eatsfeed\|feedmaker\|galileo" crisp/cct_utils.py tests/test_cct_utils.py` — only hits are in `com.example.feedservice.feedmaker` (generic replacement)
- [x] New `//crisp:cct_utils` Bazel target builds cleanly with no external deps
- [x] New `//:test_cct_utils` Bazel target passes independently
- [x] `//crisp:cct_utils` added to omnibus `//:pytest` deps
