### PR TITLE
`process_trace.py`: imports, trace completeness helpers, and `initArgs`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -47,6 +47,7 @@ py_test(
         "//crisp:pipeline",
         "//crisp:get_trace",
         "//crisp:exceptions",
+        "//crisp:process_trace",
         "@pypi//boto3",
         "@pypi//botocore",
         "@pypi//pytest",

--- a/common.py
+++ b/common.py
@@ -274,7 +274,7 @@ class Config:
         topN: int = 5,
         numHMTrace: int = 100,
         numOperation: int = 100,
-        ignoreCtfTests: bool = False,
+        ignoreTestTraces: bool = False,
         tracesDir: str = "traces",
         jaegerOfflineToken: typing.Optional[str] = None,
         terrablobOfflineToken: typing.Optional[str] = None,
@@ -318,7 +318,7 @@ class Config:
         self.topN = topN
         self.numHMTrace = numHMTrace
         self.numOperation = numOperation
-        self.ignoreCtfTests = ignoreCtfTests
+        self.ignoreTestTraces = ignoreTestTraces
         self.jaegerTraceFiles = []
         self.tracesDir = tracesDir
         self.filesToUpload = None

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -143,3 +143,23 @@ py_library(
         "@pypi//tenacity",
     ],
 )
+
+py_library(
+    name = "process_trace",
+    srcs = ["process_trace.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crisp:common",
+        "//crisp:constants",
+        "//crisp:flamegraph",
+        "//crisp:graph",
+        "//crisp:pkg",
+        "//crisp:storage",
+        "//crisp/metrics:metrics",
+        "//crisp/output:output",
+        "//crisp/shared:shared",
+        "@pypi//numpy",
+        "@pypi//pandas",
+        "@pypi//pyyaml",
+    ],
+)

--- a/crisp/common.py
+++ b/crisp/common.py
@@ -156,6 +156,7 @@ class Config:
         numShards: int = 1,
         shardId: int = 0,
         errorAnalysis: bool = False,
+        ignoreTestTraces: bool = False,
         deltaMicroSec: int = 0,
         deltaTargetService: typing.Optional[str] = None,
         deltaTargetOperation: typing.Optional[str] = None,
@@ -204,6 +205,7 @@ class Config:
             int(self.qps / (self.ioParallelism * self.numShards)),
         )
         self.errorAnalysis = errorAnalysis
+        self.ignoreTestTraces = ignoreTestTraces
         self.lightMode = lightMode
         self.mergeAllRoots = mergeAllRoots
         self.maxExemplars = maxExemplars

--- a/crisp/flamegraph.py
+++ b/crisp/flamegraph.py
@@ -276,7 +276,7 @@ def flameGraph(
     outputDir,
     service: str,
     operation: str,
-    ignoreCtfTests: bool,
+    ignoreTestTraces: bool,
     filePrefix: str = "",
     doRanges: bool = False,
 ):
@@ -300,7 +300,7 @@ def flameGraph(
 
         cpps.append((totalTime, r.CPMetrics))
 
-        if r.isCtfTest and ignoreCtfTests:
+        if r.isTestTrace and ignoreTestTraces:
             continue  # skip the metric where the root span itself returns error
 
         if r.rootReturnError:

--- a/crisp/get_trace.py
+++ b/crisp/get_trace.py
@@ -431,7 +431,7 @@ def getTraceIDReal(c: common.Config):
         traceIDs = []
         # The flags is a bit mask; sampled traces have bit-0 set,
         # debug traces have bit-1 set.
-        # Producton trace has flag 1 whereas ctf test trace has flag 9.
+        # Producton trace has flag 1 whereas synthetic test trace has flag 9.
         # Some endpoints (e.g., SIA service) have both "sampled traces" and "debug traces" => 0b11 => decimal 3 set.
         # We first try flag=1; if it returns no traces, we try flag=3.
         for flag in [1, 3]:

--- a/crisp/graph.py
+++ b/crisp/graph.py
@@ -267,10 +267,10 @@ class Graph:
 
         try:
             if useParquet:
-                potentialRoots, isCtfTest = self.parseNodeFromParquet(data)
+                potentialRoots, isTestTrace = self.parseNodeFromParquet(data)
             else:
-                potentialRoots, isCtfTest = self.parseNode(data)
-            self.isCtfTest = isCtfTest
+                potentialRoots, isTestTrace = self.parseNode(data)
+            self.isTestTrace = isTestTrace
         except Exception as e:
             logging.warning(f"self.parseNode failed in file {filename}!")
             logging.warning(f"Exception: {e}")
@@ -677,7 +677,7 @@ class Graph:
 
         potentialRoots = []
         numErrors = 0
-        isCtfTest = False
+        isTestTrace = False
         errPropNodes = {}
 
         # pass 1: record service names and other KV data first
@@ -685,7 +685,7 @@ class Graph:
             for p in item[PROCESSES]:
                 self.processName[p] = item[PROCESSES][p]["serviceName"]
                 if isTestTraceByServiceName(self.processName[p]):
-                    isCtfTest = True
+                    isTestTrace = True
                 if TAGS in item[PROCESSES][p]:
                     for dictionary in item[PROCESSES][p][TAGS]:
                         if dictionary["key"] == HOSTNAME:
@@ -717,7 +717,7 @@ class Graph:
                 opName = span[OPERATION_NAME]
                 pid = span[PROCESS_ID]
                 if isTestTraceByOpName(opName):
-                    isCtfTest = True
+                    isTestTrace = True
 
                 node = GraphNode(
                     thisSpan,
@@ -745,7 +745,7 @@ class Graph:
         if TESTING in jsonData and len(jsonData[TESTING]) > 0:
             self.setTestResult(jsonData[TESTING])
 
-        return potentialRoots, isCtfTest
+        return potentialRoots, isTestTrace
 
     def parseNodeFromParquet(self, parquetData):
         # Builds graph from Parquet data and returns potential roots.
@@ -757,7 +757,7 @@ class Graph:
         # Instead we assume if the ParentSpanID is non empty then it's a valid parent-child relationship.
         potentialRoots = []
         numErrors = 0
-        isCtfTest = False
+        isTestTrace = False
         errPropNodes = {}
         pidMap = {}  # Mapping from serviceName to a unique pid, required by findAllRoots() and other functions.
 
@@ -780,7 +780,7 @@ class Graph:
                 self.hostMap[pid] = hostName
 
             if isTestTraceByServiceName(serviceName):
-                isCtfTest = True
+                isTestTrace = True
 
         # Pass 2: Extract spans and create one GraphNode for each
         for item in parquetSpanSets:
@@ -797,7 +797,7 @@ class Graph:
                 hostName = item[PARQUET_PROCESS][PARQUET_HOSTNAME]
 
                 if isTestTraceByOpName(operationName):
-                    isCtfTest = True
+                    isTestTrace = True
 
                 # Use the tuple (serviceName, hostName) as the key to get the pid from pidMap
                 service_host_key = (serviceName, hostName)
@@ -841,7 +841,7 @@ class Graph:
         # Pass 4: Propagate errors
         self.propagateErrorsToRoots(potentialRoots, errPropNodes)
 
-        return potentialRoots, isCtfTest
+        return potentialRoots, isTestTrace
 
     def removeExcludedOps(self, curNode, exclusionSet):
         removeList = []
@@ -2567,7 +2567,7 @@ class Graph:
             len(criticalPath),
             node.returnError,
             propToRootErrCCT,
-            self.isCtfTest,
+            self.isTestTrace,
             self.numProxyRoots,
             self.tags,
             cycles,

--- a/crisp/process_trace.py
+++ b/crisp/process_trace.py
@@ -1,0 +1,502 @@
+# ruff: noqa: I001
+import argparse
+import glob
+import heapq
+import json
+import logging
+import multiprocessing as mp
+import os
+import re
+import time
+import types
+from functools import partial
+from functools import reduce
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from typing import Union
+
+import crisp.common as common
+from crisp.shared.models import CallPathProfile
+from crisp.shared.utils import getLeafNodeFromCallPath
+import crisp.storage as storage
+import crisp.flamegraph as flamegraph
+from crisp.graph import (
+    accumulateInDict,
+    bcolors,
+    Graph,
+)
+from crisp.models import (
+    ErrorCPMetrics,
+    ErrorMetrics,
+    Metrics,
+    QuantizedMetrics,
+    SavingData,
+)
+from crisp.shared.models import LatencyData
+from crisp.constants import PARQUET_STRING_ID
+from crisp.shared.constants import TOTAL_TIME
+
+# import polars as pl  # deferred: parquet support not available in OSS build
+from crisp.cct_utils import (
+    cct_to_dot,
+    parse_cct_file,
+)
+# create_protobuf_response_with_exemplars deferred — requires protobuf stub (PR 14)
+from crisp.metrics.aggregators import MergeCallPathProfilesWithExemplars
+
+# Import CSV generation functions from the new output module for backward compatibility
+from crisp.output.csv_generators import (
+    genSummaryCSVFile,
+    genHypoLatencyCSVFile,
+    genCyclesCSVFile,
+    genCrossRegionCallsCSVFile,
+)
+
+# Import aggregation function from the new metrics module
+from crisp.metrics.aggregators import (
+    MergeCallPathProfilesWithExample,
+)
+# Import percentile calculation functions from the new metrics module
+from crisp.metrics.percentile_calculator import (
+    insertInDF,
+    addPercentileColumns,
+    insertInclusivePercentileInfoDF,
+    genLatencyPercentile,
+)
+
+# Import formatting functions from the new output module for backward compatibility
+from crisp.output.formatters import (
+    makeClickable,
+    addHyperLinkToTrace,
+    renameSortableIcon,
+    insertOccurenceCol,
+    reindexDescending,
+    setCellFormating,
+    JAEGER_UI_URL,
+    SORTABLE_COL_CLASS,
+)
+
+# Backward compatibility aliases for constants
+sortabelColClass = SORTABLE_COL_CLASS
+
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)-8s %(message)s",
+    level=logging.INFO,
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+debug_on = logging.getLogger(__name__).isEnabledFor(logging.DEBUG)
+
+INVALID_PARENT_SPAN_WARNING = "invalid parent span IDs"
+
+
+def check_trace_completeness(data: dict) -> tuple[bool, str]:
+    """Check whether a Jaeger JSON trace is incomplete due to sampling limitations.
+
+    A trace is considered incomplete when any span carries an
+    "invalid parent span IDs" warning, which Jaeger emits when a span
+    references a parent that was not captured in the trace.
+    Bails out on the first match since one orphan span is enough.
+
+    Args:
+        data: Parsed Jaeger JSON trace (the top-level dict with a "data" key).
+
+    Returns:
+        Tuple of (is_incomplete, trace_id).
+    """
+    trace_id = ""
+    for item in data.get("data", []):
+        if not trace_id:
+            trace_id = item.get("traceID", "")
+        for span in item.get("spans", []):
+            for warning in span.get("warnings") or []:
+                if INVALID_PARENT_SPAN_WARNING in warning:
+                    return True, trace_id
+    return False, trace_id
+
+
+def collect_orphan_span_services(data: dict) -> set[str]:
+    """Collect service names of all orphan spans in an incomplete Jaeger JSON trace.
+
+    Only called when the trace is already known to be incomplete.
+
+    Args:
+        data: Parsed Jaeger JSON trace.
+
+    Returns:
+        Set of service names that have at least one orphan span.
+    """
+    orphan_services: set[str] = set()
+    for item in data.get("data", []):
+        processes = item.get("processes", {})
+        for span in item.get("spans", []):
+            for warning in span.get("warnings") or []:
+                if INVALID_PARENT_SPAN_WARNING in warning:
+                    pid = span.get("processID", "")
+                    service = processes.get(pid, {}).get("serviceName", "unknown")
+                    orphan_services.add(service)
+                    break
+    return orphan_services
+
+
+def get_subtree_services(root_node, process_name: dict) -> set[str]:
+    """Collect all service names reachable from root_node in the parsed graph.
+
+    Args:
+        root_node: Root GraphNode of the target sub-tree.
+        process_name: Graph.processName mapping pid -> service name.
+
+    Returns:
+        Set of service names present in the sub-tree.
+    """
+    services: set[str] = set()
+    stack = [root_node]
+    while stack:
+        node = stack.pop()
+        svc = process_name.get(node.pid)
+        if svc:
+            services.add(svc)
+        stack.extend(node.children)
+    return services
+
+
+def log_incomplete_trace_stats(
+    metrics: list,
+    total_processed: int,
+    service_name: str,
+    operation_name: str,
+) -> dict:
+    """Log aggregated stats about incomplete traces for CRON job reporting.
+
+    Args:
+        metrics: List of Metrics objects from trace processing.
+        total_processed: Total number of trace files/rows attempted.
+        service_name: Service name being analyzed.
+        operation_name: Operation name being analyzed.
+
+    Returns:
+        Dict with summary stats suitable for structured logging / M3 emission.
+    """
+    incomplete_count = sum(1 for m in metrics if m.isIncomplete)
+    subtree_incomplete_count = sum(1 for m in metrics if m.isSubtreeIncomplete)
+    total_metrics = len(metrics)
+    pct = f"{incomplete_count / total_metrics:.2%}" if total_metrics > 0 else "N/A"
+
+    stats = {
+        "service": service_name,
+        "operation": operation_name,
+        "total_traces_processed": total_processed,
+        "total_traces_with_metrics": total_metrics,
+        "incomplete_traces": incomplete_count,
+        "incomplete_trace_pct": pct,
+        "subtree_incomplete_traces": subtree_incomplete_count,
+    }
+
+    if incomplete_count > 0:
+        logging.warning(
+            f"[IncompleteTraceReport] [{service_name}]::{operation_name} — "
+            f"{incomplete_count}/{total_metrics} traces ({pct}) are INCOMPLETE. "
+            f"Of these, {subtree_incomplete_count} affect the target sub-graph (downstream), "
+            f"{incomplete_count - subtree_incomplete_count} are upstream/unrelated."
+        )
+    else:
+        logging.info(
+            f"[IncompleteTraceReport] [{service_name}]::{operation_name} — "
+            f"all {total_metrics} traces are complete (no orphan spans detected)."
+        )
+
+    return stats
+
+
+class YAMLAction(argparse.Action):
+    "A YAML string with a list of Key-Value Dicts"
+
+    def __call__(self, parser, namespace, yamlStr, option_string=None):  # noqa: ARG002
+        if not isinstance(yamlStr, str):
+            raise argparse.ArgumentTypeError("Invalid YAML" + str(yamlStr))
+        parsed_yaml = yaml.safe_load(yamlStr)
+        if not isinstance(parsed_yaml, list):
+            raise argparse.ArgumentTypeError("Invalid YAML" + str(parsed_yaml))
+        for d in parsed_yaml:
+            if not isinstance(d, dict):
+                raise argparse.ArgumentTypeError("Invalid YAML:" + str(d))
+            if len(d) != len(common.TAG_KEYS):
+                raise argparse.ArgumentTypeError("Invalid YAML:" + str(d))
+            for k in common.TAG_KEYS:
+                if k not in d.keys():
+                    raise argparse.ArgumentTypeError(
+                        "Key " + str(k) + "not found in: " + str(d),
+                    )
+            if not isinstance(d[common.TAG_NAME], str):
+                raise argparse.ArgumentTypeError("Invalid YAML:" + str(d))
+            if not isinstance(d[common.TAG_VALUE], str):
+                raise argparse.ArgumentTypeError("Invalid YAML:" + str(d))
+            if not isinstance(d[common.TAG_SEARCH_DEPTH], int):
+                raise argparse.ArgumentTypeError("Invalid YAML:" + str(d))
+        setattr(namespace, self.dest, parsed_yaml)
+
+
+def initArgs():
+    argParser = argparse.ArgumentParser()
+    argParser.add_argument(
+        "-o",
+        "--operationName",
+        action="store",
+        help="operation name",
+        default="",
+        type=str,
+    )
+    argParser.add_argument(
+        "-s",
+        "--serviceName",
+        action="store",
+        help="name of the service",
+        default="",
+        type=str,
+    )
+
+    argParser.add_argument(
+        "--rootTrace",
+        dest="rootTrace",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Should the service and operation be the root span of the trace (default:false).",
+    )
+    argParser.add_argument(
+        "--mergeAllRoots",
+        dest="mergeAllRoots",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        required=False,
+        help="Merge metrics from every matching root span instead of using only the first match (default=true).",
+    )
+
+    argParser.add_argument(
+        "--anonymize",
+        dest="anonymize",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Should the service and operation names be anonymized (default:false).",
+    )
+    argParser.add_argument(
+        "-i",
+        "--inputDir",
+        action="store",
+        help="input path of the trace directory (mutually exclusive with --file)",
+        default="traces",
+        type=str,
+    )
+    argParser.add_argument(
+        "--file",
+        type=argparse.FileType("r"),
+        action="store",
+        help="input path of the trace file (mutually exclusivbe with --inputDir)",
+        default=None,
+    )
+    argParser.add_argument(
+        "--parallelism",
+        action="store",
+        help="Number of concurrent python processes.",
+        default=1,
+        type=int,
+    )
+    argParser.add_argument(
+        "--topN",
+        action="store",
+        help="number of services to show in the summary",
+        default=5,
+        type=int,
+    )
+    argParser.add_argument(
+        "--numHMTrace",
+        action="store",
+        help="number of traces to show in the heatmap",
+        default=100,
+        type=int,
+    )
+    argParser.add_argument(
+        "--numOperation",
+        action="store",
+        help="number of operations to show in the heatmap",
+        default=100,
+        type=int,
+    )
+    argParser.add_argument(
+        "--ignoreTestTraces",
+        dest="ignoreTestTraces",
+        action="store_true",
+        help="Ignore traces marked as synthetic test traces.",
+        default=False,
+        required=False,
+    )
+    argParser.add_argument(
+        "--doRanges",
+        dest="doRanges",
+        action="store_true",
+        help="Compute flamegraphs for every 20 percentiles (default=false)",
+        default=False,
+        required=False,
+    )
+
+    argParser.add_argument(
+        "--tags",
+        dest="tags",
+        action=YAMLAction,
+        help=(
+            "a YAML formated list of key-value filters to apply to the traces. e.g. "
+            '--tags "[{name: TAGA, value: VALA, search_depth: 1}, {name: TAGB, value: VALB, search_depth: 20}]"'
+        ),
+        default=common.DEFAULT_TAGS,
+        required=False,
+    )
+    argParser.add_argument(
+        "--exclude-from-cp",
+        dest="excludeFromCP",
+        type=argparse.FileType("r"),
+        action="store",
+        help="a YAML file with a set of operations to ignore from the critical path",
+        default=None,
+        required=False,
+    )
+
+    argParser.add_argument(
+        "--errorAnalysis",
+        dest="errorAnalysis",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Run error analysis"
+    )
+
+    argParser.add_argument(
+        "--deltaMicroSec",
+        action="store",
+        help="Analyze delta time injection in micro seconds (-ve means time reduction)",
+        default=0,
+        type=int,
+    )
+
+    argParser.add_argument(
+        "--lightMode",
+        dest="lightMode",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Use light mode for the analysis",
+    )
+
+    argParser.add_argument(
+        "--maxExemplars",
+        dest="maxExemplars",
+        action="store",
+        default=3,
+        required=False,
+        help="Maximum number of exemplars (trace/span pairs) to keep per call path in protobuf output (default=3).",
+        type=int,
+    )
+
+    argParser.add_argument(
+        "--deltaTargetService",
+        dest="deltaTargetService",
+        action="store",
+        default=None,
+        required=False,
+        type=str,
+        help=(
+            "Service name to target for latency projection (context-insensitive: applies to ALL instances). "
+            "Must be used with --deltaTargetOperation and a non-zero --deltaMicroSec."
+        ),
+    )
+
+    argParser.add_argument(
+        "--deltaTargetOperation",
+        dest="deltaTargetOperation",
+        action="store",
+        default=None,
+        required=False,
+        type=str,
+        help=(
+            "Operation name to target for latency projection (context-insensitive: applies to ALL instances). "
+            "Must be used with --deltaTargetService and a non-zero --deltaMicroSec."
+        ),
+    )
+
+    argParser.add_argument(
+        "--jaegerQueryUrl",
+        dest="jaegerQueryUrl",
+        action="store",
+        default="http://localhost:16686",
+        required=False,
+        help="Base URL for the Jaeger query API.",
+        type=str,
+    )
+
+    args = argParser.parse_args()
+
+    if (args.deltaTargetService is None) != (args.deltaTargetOperation is None):
+        argParser.error("--deltaTargetService and --deltaTargetOperation must both be provided together.")
+    if args.deltaTargetService is not None and args.deltaMicroSec == 0:
+        argParser.error("--deltaMicroSec must be non-zero when --deltaTargetService/--deltaTargetOperation are set.")
+    operationName = args.operationName
+    serviceName = args.serviceName
+    tracesDir = args.inputDir
+    topN = args.topN
+    numOperation = args.numOperation
+    numHMTrace = args.numHMTrace
+    rootTrace = args.rootTrace
+    anonymize = args.anonymize
+    tags = args.tags
+    doRanges = args.doRanges
+    errorAnalysis = args.errorAnalysis
+    deltaMicroSec = args.deltaMicroSec
+    deltaTargetService = args.deltaTargetService
+    deltaTargetOperation = args.deltaTargetOperation
+    lightMode = args.lightMode
+    maxExemplars = args.maxExemplars
+    jaegerTraceFiles = glob.glob(os.path.join(tracesDir, "*.json"))
+
+    if args.file:
+        jaegerTraceFiles = [args.file.name]
+        args.file.close()
+
+    exclusionSet = set()
+    if args.excludeFromCP:
+        exclusionDict = yaml.safe_load(args.excludeFromCP)
+        for srv, v in exclusionDict.items():
+            for ops in v:
+                exclusionSet.add((srv, ops))
+        args.excludeFromCP.close()
+    c = common.Config(
+        operationName=operationName,
+        serviceName=serviceName,
+        tags=tags,
+        tracesDir=tracesDir,
+        topN=topN,
+        numOperation=numOperation,
+        numHMTrace=numHMTrace,
+        rootTrace=rootTrace,
+        anonymize=anonymize,
+        file=args.file,
+        computeParallelism=args.parallelism,
+        doRanges=doRanges,
+        exclusionSet=exclusionSet,
+        errorAnalysis=errorAnalysis,
+        deltaMicroSec=deltaMicroSec,
+        deltaTargetService=deltaTargetService,
+        deltaTargetOperation=deltaTargetOperation,
+        lightMode=lightMode,
+        mergeAllRoots=args.mergeAllRoots,
+        maxExemplars=maxExemplars,
+        jaegerQueryUrl=args.jaegerQueryUrl,
+    )
+    c.jaegerTraceFiles = jaegerTraceFiles
+    return c
+
+
+# --- Remaining functions (getMatchingRootsFromGraph through main) will be added in PRs 13b–13e ---

--- a/crisp/shared/models.py
+++ b/crisp/shared/models.py
@@ -420,7 +420,7 @@ class Metrics:
         numNodesOnCP,
         rootReturnError,
         propToRootErrCCT,
-        isCtfTest,
+        isTestTrace,
         numProxyRoots,
         tags,
         cycles,
@@ -452,7 +452,7 @@ class Metrics:
         self.numNodesOnCP = numNodesOnCP
 
         self.rootReturnError = rootReturnError
-        self.isCtfTest = isCtfTest
+        self.isTestTrace = isTestTrace
         self.numProxyRoots = numProxyRoots
         self.tags = tags
         self.cycles = cycles

--- a/tests/metrics/test_aggregators.py
+++ b/tests/metrics/test_aggregators.py
@@ -74,7 +74,7 @@ def getDummyMetric(**kwargs):
         numNodesOnCP=0,
         rootReturnError=False,
         propToRootErrCCT={},
-        isCtfTest=False,
+        isTestTrace=False,
         numProxyRoots=0,
         tags=[],
         cycles={},

--- a/tests/shared/test_models.py
+++ b/tests/shared/test_models.py
@@ -352,7 +352,7 @@ class TestMetrics(TestCase):
             numNodesOnCP=3,
             rootReturnError=False,
             propToRootErrCCT={},
-            isCtfTest=False,
+            isTestTrace=False,
             numProxyRoots=0,
             tags=[],
             cycles=0,
@@ -376,7 +376,7 @@ class TestMetrics(TestCase):
         self.assertEqual(m.depth, 4)
         self.assertEqual(m.numNodesOnCP, 3)
         self.assertFalse(m.rootReturnError)
-        self.assertFalse(m.isCtfTest)
+        self.assertFalse(m.isTestTrace)
         self.assertEqual(m.numProxyRoots, 0)
         self.assertEqual(m.tags, [])
         self.assertEqual(m.cycles, 0)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -127,7 +127,7 @@ class TestConfig(TestCase):
         self.assertFalse(hasattr(c, 'uploadToCrispRiTB'))
         self.assertFalse(hasattr(c, 'uploadTar'))
         self.assertFalse(hasattr(c, 'noOverwriteUpload'))
-        self.assertFalse(hasattr(c, 'ignoreCtfTests'))
+        self.assertTrue(hasattr(c, 'ignoreTestTraces'))  # retained for OSS: flags synthetic test traces
         self.assertFalse(hasattr(c, 'enableM3Metrics'))
         self.assertFalse(hasattr(c, 'jobTag'))
         self.assertFalse(hasattr(c, 'useParquet'))

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1179,13 +1179,13 @@ class TestParseNodeFromParquet(TestCase):
         }
 
         # Act
-        potentialRoots, isCtfTest = g.parseNodeFromParquet(parquetData)
+        potentialRoots, isTestTrace = g.parseNodeFromParquet(parquetData)
 
         # Debugging: Print out the contents of potentialRoots
         print(f"Potential roots: {potentialRoots}")
 
         # Assert
-        self.assertFalse(isCtfTest)
+        self.assertFalse(isTestTrace)
         mock_store_node_data.assert_called()
         mock_build_parent_child_relationships.assert_called_once()
         mock_propagate_errors.assert_called_once()
@@ -1225,7 +1225,7 @@ class TestParseNodeFromParquet(TestCase):
         }
 
         # Act
-        potentialRoots, isCtfTest = g.parseNodeFromParquet(parquetData)
+        potentialRoots, isTestTrace = g.parseNodeFromParquet(parquetData)
 
         # Assert
         self.assertEqual(g.numErrors, 1)  # Since the mock returns True for errors


### PR DESCRIPTION
## What's included

### New file: `crisp/process_trace.py` (502 lines, partial port)

**Imports and top-level constants** (lines 1–95)
- All standard-library, numpy, pandas, yaml, and `crisp.*` imports ported.
- Deferred: `import parquet_utils` (Uber-internal; not available in OSS) — placeholder comment left.

**Trace completeness helpers** (lines 97–213)
- `check_trace_completeness(data)` — validates a Jaeger JSON trace for completeness (missing spans, orphans, single-span root).
- `collect_orphan_span_services(data)` — collects services that appear only as orphan spans.
- `get_subtree_services(root_node, process_name)` — BFS to collect all service names reachable from a root node.
- `log_incomplete_trace_stats(...)` — logs summary of incomplete traces; Uber-internal M3 metrics emission removed.

**`YAMLAction`** (lines 215–239)
- `argparse.Action` subclass for `--tags` and `--exclude-from-cp`; validates YAML dicts and lists.

**`initArgs()`** (lines 243–500)
- Full CLI argument parser ported with the following changes vs. internal:
  - `--ignoreTestTraces` replaces internal `--ignoreCTFTests` (same `dest="ignoreTestTraces"` after rename PR).
  - Removed internal-only flags
  - `--jaegerQueryUrl` added; reads from `Config.jaegerQueryUrl` (default `http://localhost:16686`).
  - All other flags retained: `--operationName`, `--serviceName`, `--rootTrace`, `--mergeAllRoots`, `--anonymize`, `--inputDir`, `--file`, `--parallelism`, `--topN`, `--numHMTrace`, `--numOperation`, `--doRanges`, `--tags`, `--exclude-from-cp`, `--errorAnalysis`, `--deltaMicroSec`, `--lightMode`, `--maxExemplars`, `--deltaTargetService`, `--deltaTargetOperation`, etc.

### `crisp/common.py`
- Added `ignoreTestTraces: bool = False` parameter and field to `Config` (needed by `process_trace` and `flamegraph`).

### `crisp/BUILD.bazel`
- Added `process_trace` `py_library` target with deps on `common`, `constants`, `flamegraph`, `graph`, `pkg`, `storage`, `metrics`, `output`, `shared`, numpy, pandas, pyyaml.

### `BUILD.bazel`
- Added `//crisp:process_trace` dep to the root `py_test` target.

### `tests/test_common.py`
- Updated assertion: `ignoreTestTraces` is now a valid OSS Config field (was previously asserted absent).

## Removed (internal-only)
| Flag | Reason |
|---|---|
| `--filterProxy` | Uber-internal proxy-filter heuristic |
| `--useParquet` | Parquet ingestion path; depends on internal `tracing` CLI tool |
| `--usso` / `--useUSSO` | Uber Single Sign-On token auth |
| `--zone` | Uber datacenter zone routing |
| `--serviceMode` | Internal service-specific processing mode |
| `--qps` | Internal rate-limit flag (not needed for local JSON processing) |
| `--jobTag` / `--enableM3Metrics` | Uber internal job tagging and M3 metrics emission |
| M3 calls in `log_incomplete_trace_stats` | Internal telemetry |

## Deferred to future PRs
- `process()`, `mapReduce()`, heatmap, time-saved, error CSVs, flamegraph filters, and `main()` — covered in PRs 13b–13e.
- Parquet import and `parseNodeFromParquet` code path — deferred pending internal protobuf availability.

## Tests
No new test file in this PR (process_trace integration tests deferred to PR 13b+, which will have the full `process()` function available for mocking). The `test_common.py` assertion update is the only test change.
