### PR TITLE
port/pr-13e: add crisp_trace py_binary and crisp-trace console script

### DIFF
--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -163,3 +163,13 @@ py_library(
         "@pypi//pyyaml",
     ],
 )
+
+py_binary(
+    name = "crisp_trace",
+    srcs = ["main.py"],
+    main = "main.py",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crisp:process_trace",
+    ],
+)

--- a/crisp/main.py
+++ b/crisp/main.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Entry point for the ``crisp-trace`` command-line tool."""
+
+from crisp.process_trace import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ Issues = "https://github.com/uber-research/CRISP/issues"
 [tool.setuptools.packages.find]
 include = ["crisp*"]
 
+[project.scripts]
+crisp-trace = "crisp.process_trace:main"
+
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]


### PR DESCRIPTION
## What's included

Three files changed.

### `crisp/main.py` (new, 20 lines)
Thin entry-point module that imports and calls `process_trace.main()`.
Used as the `main` source for the Bazel `py_binary` target and as the backing
module for the pip console script.

### `crisp/BUILD.bazel` (+11 lines)
Added `py_binary` target:
```
py_binary(
    name = "crisp_trace",
    srcs = ["main.py"],
    main = "main.py",
    deps = ["//crisp:process_trace"],
)
```
Produces `bazel-bin/crisp/crisp_trace`; runnable as:
```
bazel run //crisp:crisp_trace -- --operationName foo --serviceName bar --inputDir ./traces
```

### `pyproject.toml` (+3 lines)
Added `[project.scripts]` section:
```
crisp-trace = "crisp.process_trace:main"
```
After `pip install crisp-trace`, users can invoke the tool as:
```
crisp-trace --operationName foo --serviceName bar --inputDir ./traces
```

## Notes
- No logic changes; this PR is purely wiring.
- `pyproject.toml` runtime `dependencies = []` is intentionally left empty until PR 15 (publish-ready packaging).
- The `process_trace.py` `if __name__ == "__main__": main()` guard remains intact for direct `python -m crisp.process_trace` invocation as well.
