### PR TITLE
port/pr-15: add Bazel py_test targets for crisp/utils, shared, metrics, output

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -143,3 +143,117 @@ py_test(
     ],
     imports = ["."],
 )
+
+# ---------------------------------------------------------------------------
+# crisp/utils tests
+# ---------------------------------------------------------------------------
+
+py_test(
+    name = "test_dict_utils",
+    srcs = ["tests/utils/test_dict_utils.py"],
+    main = "tests/utils/test_dict_utils.py",
+    deps = ["//crisp/utils:utils"],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_singleton_wrapper",
+    srcs = ["tests/utils/test_singleton_wrapper.py"],
+    main = "tests/utils/test_singleton_wrapper.py",
+    deps = ["//crisp/utils:utils"],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_span_utils",
+    srcs = ["tests/utils/test_span_utils.py"],
+    main = "tests/utils/test_span_utils.py",
+    deps = ["//crisp/utils:utils"],
+    imports = ["."],
+)
+
+# ---------------------------------------------------------------------------
+# crisp/shared tests
+# ---------------------------------------------------------------------------
+
+py_test(
+    name = "test_shared_constants",
+    srcs = ["tests/shared/test_constants.py"],
+    main = "tests/shared/test_constants.py",
+    deps = ["//crisp/shared:shared"],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_shared_models",
+    srcs = ["tests/shared/test_models.py"],
+    main = "tests/shared/test_models.py",
+    deps = [
+        "//crisp/shared:shared",
+        "//crisp/utils:utils",
+    ],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_shared_utils",
+    srcs = ["tests/shared/test_utils.py"],
+    main = "tests/shared/test_utils.py",
+    deps = ["//crisp/shared:shared"],
+    imports = ["."],
+)
+
+# ---------------------------------------------------------------------------
+# crisp/metrics tests
+# ---------------------------------------------------------------------------
+
+py_test(
+    name = "test_aggregators",
+    srcs = ["tests/metrics/test_aggregators.py"],
+    main = "tests/metrics/test_aggregators.py",
+    deps = [
+        "//crisp/metrics:metrics",
+        "//crisp/shared:shared",
+        "@pypi//pytest",
+    ],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_percentile_calculator",
+    srcs = ["tests/metrics/test_percentile_calculator.py"],
+    main = "tests/metrics/test_percentile_calculator.py",
+    deps = [
+        "//crisp/metrics:metrics",
+        "@pypi//pandas",
+    ],
+    imports = ["."],
+)
+
+# ---------------------------------------------------------------------------
+# crisp/output tests
+# ---------------------------------------------------------------------------
+
+py_test(
+    name = "test_csv_generators",
+    srcs = ["tests/output/test_csv_generators.py"],
+    main = "tests/output/test_csv_generators.py",
+    deps = [
+        "//crisp/output:output",
+        "//crisp/shared:shared",
+        "@pypi//pandas",
+    ],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_formatters",
+    srcs = ["tests/output/test_formatters.py"],
+    main = "tests/output/test_formatters.py",
+    deps = [
+        "//crisp/output:output",
+        "//crisp/shared:shared",
+        "@pypi//pandas",
+    ],
+    imports = ["."],
+)

--- a/crisp/shared/BUILD.bazel
+++ b/crisp/shared/BUILD.bazel
@@ -10,4 +10,5 @@ py_library(
     ],
     imports = ["../.."],
     visibility = ["//visibility:public"],
+    deps = ["//crisp/utils:utils"],
 )


### PR DESCRIPTION
## What's included

### 10 new `py_test` targets in `BUILD.bazel`

One target per test file for the four sub-package test directories that were previously covered only by the `pytest` omnibus:

| Target | Source |
|---|---|
| `test_dict_utils` | `tests/utils/test_dict_utils.py` |
| `test_singleton_wrapper` | `tests/utils/test_singleton_wrapper.py` |
| `test_span_utils` | `tests/utils/test_span_utils.py` |
| `test_shared_constants` | `tests/shared/test_constants.py` |
| `test_shared_models` | `tests/shared/test_models.py` |
| `test_shared_utils` | `tests/shared/test_utils.py` |
| `test_aggregators` | `tests/metrics/test_aggregators.py` |
| `test_percentile_calculator` | `tests/metrics/test_percentile_calculator.py` |
| `test_csv_generators` | `tests/output/test_csv_generators.py` |
| `test_formatters` | `tests/output/test_formatters.py` |

### Bug fix: `crisp/shared/BUILD.bazel` — add missing `//crisp/utils:utils` dep

`crisp/shared/models.py` imports `crisp.utils.dict_utils.getCPSize`, so `//crisp/shared:shared` must depend on `//crisp/utils:utils`. This dep was absent, which caused `ModuleNotFoundError: No module named 'crisp.utils'` when any of the three new targets (`test_aggregators`, `test_percentile_calculator`, `test_csv_generators`) were run in isolation under Bazel's strict sandbox.

## Verification
- All **22** Bazel test targets pass: `bazel test //...`
  - 12 pre-existing targets (unchanged, all cached)
  - 10 new targets (all green on first run)
