### PR TITLE
refactor: remove duplicate helpers from process_trace, import from subpackages

### DIFF
--- a/crisp/process_trace.py
+++ b/crisp/process_trace.py
@@ -666,6 +666,20 @@ def getTraceIdFromFilePath(traceFile: str) -> str:
     return traceFile.split("/")[-1].split(".")[0]
 
 
+def mergeCallpathTime(
+    callMap: dict,
+    callPathMap: dict,
+    totalBreakdownTime: dict,
+) -> None:
+    """Collect per-call-path times into totalBreakdownTime."""
+    for opName, paths in callMap.items():
+        if opName not in totalBreakdownTime:
+            totalBreakdownTime[opName] = {}
+        for p in paths:
+            if p not in totalBreakdownTime[opName]:
+                totalBreakdownTime[opName][p] = []
+            totalBreakdownTime[opName][p].append(callPathMap[p])
+
 
 def aggregateMetrics(
     metrics: list,

--- a/crisp/process_trace.py
+++ b/crisp/process_trace.py
@@ -16,6 +16,8 @@ import yaml
 import crisp.common as common
 import crisp.flamegraph as flamegraph
 from crisp.graph import Graph
+from crisp.metrics.aggregators import mergeCallChains, mergeExampleID
+from crisp.output.formatters import makeClickable, renameSortableIcon
 from crisp.shared.utils import getLeafNodeFromCallPath
 
 
@@ -664,50 +666,6 @@ def getTraceIdFromFilePath(traceFile: str) -> str:
     return traceFile.split("/")[-1].split(".")[0]
 
 
-def mergeCallChains(callMap: dict, totalCallMap: dict) -> None:
-    """Collect all call chains per operation name into totalCallMap."""
-    for opName, names in callMap.items():
-        if opName not in totalCallMap:
-            totalCallMap[opName] = set()
-        for name in names:
-            totalCallMap[opName].add(name)
-
-
-def mergeCallpathTime(
-    callMap: dict,
-    callPathMap: dict,
-    totalBreakdownTime: dict,
-) -> None:
-    """Collect per-call-path times into totalBreakdownTime."""
-    for opName, paths in callMap.items():
-        if opName not in totalBreakdownTime:
-            totalBreakdownTime[opName] = {}
-        for p in paths:
-            if p not in totalBreakdownTime[opName]:
-                totalBreakdownTime[opName][p] = []
-            totalBreakdownTime[opName][p].append(callPathMap[p])
-
-
-def mergeExampleID(
-    traceID: str,
-    localExampleMap: dict,
-    exampleMap: dict,
-) -> None:
-    """Maintain the worst-case example (traceID, spanID, time) per call path."""
-    for opName in localExampleMap:
-        if opName not in exampleMap:
-            exampleMap[opName] = (
-                traceID,
-                localExampleMap[opName][0],
-                localExampleMap[opName][1],
-            )
-        elif localExampleMap[opName][1] > exampleMap[opName][2]:
-            exampleMap[opName] = (
-                traceID,
-                localExampleMap[opName][0],
-                localExampleMap[opName][1],
-            )
-
 
 def aggregateMetrics(
     metrics: list,
@@ -889,10 +847,6 @@ def reindexDescending(
 # Display helpers
 # ---------------------------------------------------------------------------
 
-def makeClickable(url: str, name: str) -> str:
-    return '<a href="{}" rel="noopener noreferrer" target="_blank">{}</a>'.format(url, name)
-
-
 def addHyperLinkToTrace(
     df: "pd.DataFrame",
     tracespanIDmap: dict,
@@ -905,13 +859,6 @@ def addHyperLinkToTrace(
             "{}/trace/{}?uiFind={}".format(jaegerQueryUrl, k, v), "#"
         )
     df.rename(columns=hyperLinkHT, inplace=True)
-    return df
-
-
-def renameSortableIcon(df: "pd.DataFrame", columns: list) -> "pd.DataFrame":
-    """Append a FontAwesome sort icon to each sortable column header."""
-    sortableRenameHT = {col: col + ' <i class="fas fa-sort"></i>' for col in columns}
-    df.rename(columns=sortableRenameHT, inplace=True)
     return df
 
 


### PR DESCRIPTION
## Summary

- `mergeCallChains` and `mergeExampleID` in `crisp/process_trace.py` were byte-for-byte copies of the same functions in `crisp/metrics/aggregators.py`
- `makeClickable` and `renameSortableIcon` were identical copies of functions in `crisp/output/formatters.py`
- Replace all four local definitions with explicit imports; single source of truth is now in the subpackages

Seven other same-named functions (`mergeCallpathTime`, `insertInDF`, `addPercentileColumns`, `addHyperLinkToTrace`, `setCellFormating`, `reindexDescending`, `insertOccurenceCol`) have intentionally different signatures or semantics and remain local.

## Test plan

- [x] `python3 -m pytest tests/ --ignore=tests/test_get_trace.py` → 373 passed
