### PR TITLE
feat: port e2e integration tests (PR 23)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,7 +6,7 @@ py_test(
     size = "small",
     srcs = ["pytest_runner.py"],
     main = "pytest_runner.py",
-    data = glob(["tests/**"]) + ["pyproject.toml", "services.yaml"],
+    data = glob(["tests/**"]) + glob(["test_cases/**"]) + ["pyproject.toml", "services.yaml"],
     deps = [
         "//crisp:cli",
         "//crisp:common",
@@ -26,6 +26,8 @@ py_test(
         "//crisp:process_trace",
         "@pypi//boto3",
         "@pypi//botocore",
+        "@pypi//jinja2",
+        "@pypi//matplotlib",
         "@pypi//pytest",
         "@pypi//requests",
         "@pypi//ratelimit",
@@ -256,14 +258,27 @@ py_test(
     imports = ["."],
 )
 
+# ---------------------------------------------------------------------------
+# End-to-end integration tests
+# ---------------------------------------------------------------------------
+
 py_test(
-    name = "test_formatters",
-    srcs = ["tests/output/test_formatters.py"],
-    main = "tests/output/test_formatters.py",
+    name = "test_e2e",
+    size = "medium",
+    srcs = ["tests/test_e2e.py"],
+    data = glob(["test_cases/**"]),
     deps = [
-        "//crisp/output:output",
-        "//crisp/shared:shared",
+        "//crisp:flamegraph",
+        "//crisp:process_trace",
+        "//crisp/proto:proto",
+        "@pypi//jinja2",
+        "@pypi//matplotlib",
+        "@pypi//numpy",
         "@pypi//pandas",
+        "@pypi//pyyaml",
+        "@pypi//protobuf",
     ],
     imports = ["."],
+    env = {"MPLBACKEND": "Agg"},
 )
+

--- a/crisp/flamegraph.py
+++ b/crisp/flamegraph.py
@@ -139,7 +139,7 @@ def aggregateCallPathProfiles(cpps):
     flameGraph = ""
     for k, v in cpp.profile.items():
         newKey = k.replace(";", "_").replace("->", ";")
-        flameGraph += newKey + " " + str(v.excl) + "\n"
+        flameGraph += newKey + " " + str(v.excl) + " <<" + str(v.freq) + ">>\n"
 
     return flameGraph
 

--- a/crisp/process_trace.py
+++ b/crisp/process_trace.py
@@ -2130,12 +2130,11 @@ def processReal(c: common.Config) -> int:
 # Entry point
 # ---------------------------------------------------------------------------
 
-def main() -> None:
+def main() -> int:
     c = initArgs()
     if c.lightMode:
-        lightProcess(c)
-        return
-    processReal(c)
+        return lightProcess(c)
+    return processReal(c)
 
 
 if __name__ == "__main__":

--- a/test_cases/11.json
+++ b/test_cases/11.json
@@ -1,0 +1,77 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 30,
+                    "duration": 30,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 70,
+            "[S2] O2": 30
+        },
+        "noErrCP": {
+            "[S1] O1": 70
+        },
+        "totalWork": 130,
+        "timeSavedOnWork": 30,
+        "timeSavedOnCP": 30,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": 30
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[[S1] O1->[S2] O2": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/12.json
+++ b/test_cases/12.json
@@ -1,0 +1,120 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 10,
+                    "duration": 60,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 25,
+                    "duration": 20,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ],
+                    "logs": [
+                        {
+                            "timestamp": 100,
+                            "fields": [
+                                {
+                                    "key": "event",
+                                    "type": "string",
+                                    "value": "error"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O4",
+                    "startTime": 30,
+                    "duration": 20,
+                    "processID": "S4",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 40,
+            "[S2] O2": 40,
+            "[S4] O4": 20
+        },
+        "noErrCP": {
+            "[S1] O1": 40,
+            "[S2] O2": 40,
+            "[S4] O4": 20
+        },
+        "totalWork": 200,
+        "timeSavedOnWork": 20,
+        "timeSavedOnCP": 0
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/13.json
+++ b/test_cases/13.json
@@ -1,0 +1,122 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 10,
+                    "duration": 60,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 25,
+                    "duration": 20,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O4",
+                    "startTime": 30,
+                    "duration": 20,
+                    "processID": "S4",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "string",
+                            "value": "ClientSideError"
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 40,
+            "[S2] O2": 40,
+            "[S4] O4": 20
+        },
+        "noErrCP": {
+            "[S1] O1": 40,
+            "[S2] O2": 35,
+            "[S3] O3": 20
+        },
+        "totalWork": 200,
+        "timeSavedOnWork": 20,
+        "timeSavedOnCP": 5,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S4] O4": 20
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S4] O4": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/14.json
+++ b/test_cases/14.json
@@ -1,0 +1,121 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 80,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 10,
+                    "duration": 20,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 20,
+                    "duration": 25,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O4",
+                    "startTime": 40,
+                    "duration": 25,
+                    "processID": "S4",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "string",
+                            "value": "ClientSideError"
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                }
+            ]
+        }
+        ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 35,
+            "[S2] O2": 20,
+            "[S4] O4": 25
+        },
+        "noErrCP": {
+            "[S1] O1": 35,
+            "[S3] O3": 25
+        },
+        "totalWork": 150,
+        "timeSavedOnWork": 25,
+        "timeSavedOnCP": 20,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": 25
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/15.json
+++ b/test_cases/15.json
@@ -1,0 +1,254 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                },
+                "S5": {
+                    "serviceName": "S5",
+                    "tags": [
+                    ]
+                },
+                "S6": {
+                    "serviceName": "S6",
+                    "tags": [
+                    ]
+                },
+                "S7": {
+                    "serviceName": "S7",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 10,
+                    "duration": 10,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O2",
+                    "startTime": 25,
+                    "duration": 10,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "string",
+                            "value": "ClientSideError"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O2",
+                    "startTime": 40,
+                    "duration": 10,
+                    "processID": "S4",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "logs": [
+                        {
+                            "timestamp": 50,
+                            "fields": [
+                                {
+                                    "key": "error.object",
+                                    "type": "string",
+                                    "value": "com.uber.marketplace.: ..."
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "E",
+                    "operationName": "O2",
+                    "startTime": 55,
+                    "duration": 10,
+                    "processID": "S5",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "logs": [
+                        {
+                            "timestamp": 65,
+                            "fields": [
+                                {
+                                    "key": "error",
+                                    "type": "string",
+                                    "value": "context canceled"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "F",
+                    "operationName": "O2",
+                    "startTime": 70,
+                    "duration": 10,
+                    "processID": "S6",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "logs": [
+                        {
+                            "timestamp": 80,
+                            "fields": [
+                                {
+                                    "key": "event",
+                                    "type": "string",
+                                    "value": "error"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "G",
+                    "operationName": "O3",
+                    "startTime": 85,
+                    "duration": 15,
+                    "processID": "S7",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 35,
+            "[S2] O2": 10,
+            "[S3] O2": 10,
+            "[S4] O2": 10,
+            "[S5] O2": 10,
+            "[S6] O2": 10,
+            "[S7] O3": 15
+        },
+        "noErrCP": {
+            "[S1] O1": 35,
+            "[S7] O3": 15
+        },
+        "totalWork": 165,
+        "timeSavedOnWork": 50,
+        "timeSavedOnCP": 50,
+        "errOpTimeInclusive": {
+            "[S1] O1": 50,
+            "[S2] O2": 10,
+            "[S3] O2": 10,
+            "[S4] O2": 10,
+            "[S5] O2": 10,
+            "[S6] O2": 10
+        },
+        "errOpTimeExclusive": {
+            "[S2] O2": 10,
+            "[S3] O2": 10,
+            "[S4] O2": 10,
+            "[S5] O2": 10,
+            "[S6] O2": 10
+        },
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": 10,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S3] O2": 10,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O2": 10,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S5] O2": 10,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O2": 10
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S3] O2": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O2": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S5] O2": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O2": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/16.json
+++ b/test_cases/16.json
@@ -1,0 +1,207 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                },
+                "S5": {
+                    "serviceName": "S5",
+                    "tags": [
+                    ]
+                },
+                "S6": {
+                    "serviceName": "S6",
+                    "tags": [
+                    ]
+                },
+                "S7": {
+                    "serviceName": "S7",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 110,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 10,
+                    "duration": 10,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 15,
+                    "duration": 20,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O4",
+                    "startTime": 30,
+                    "duration": 10,
+                    "processID": "S4",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "E",
+                    "operationName": "O5",
+                    "startTime": 50,
+                    "duration": 10,
+                    "processID": "S5",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 400
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "F",
+                    "operationName": "O6",
+                    "startTime": 70,
+                    "duration": 30,
+                    "processID": "S6",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "G",
+                    "operationName": "O7",
+                    "startTime": 80,
+                    "duration": 10,
+                    "processID": "S7",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "grpc.status",
+                            "type": "string",
+                            "value": "NOT_FOUND"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive":{
+            "[S1] O1": 50,
+            "[S2] O2": 10,
+            "[S4] O4": 10,
+            "[S5] O5": 10,
+            "[S6] O6": 20,
+            "[S7] O7": 10
+        },
+        "noErrCP": {
+            "[S1] O1": 45,
+            "[S3] O3": 20,
+            "[S6] O6": 20
+        },
+        "totalWork": 200,
+        "timeSavedOnWork": 30,
+        "timeSavedOnCP": 25,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": 10,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S5] O5": 10,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6->[S7] O7": 10
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S5] O5": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6->[S7] O7": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/17.json
+++ b/test_cases/17.json
@@ -1,0 +1,137 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 20,
+                    "duration": 50,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 30,
+                    "duration": 20,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "string",
+                            "value": "ClientSideError"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O4",
+                    "startTime": 80,
+                    "duration": 10,
+                    "processID": "S4",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "string",
+                            "value": "ClientSideError"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 40,
+            "[S2] O2": 30,
+            "[S3] O3": 20,
+            "[S4] O4": 10
+        },
+        "noErrCP": {},
+        "totalWork": 180,
+        "timeSavedOnWork": 130,
+        "timeSavedOnCP": 100,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": 40,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S3] O3": 20,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": 10
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,1,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S3] O3": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/18.json
+++ b/test_cases/18.json
@@ -1,0 +1,282 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                },
+                "S5": {
+                    "serviceName": "S5",
+                    "tags": [
+                    ]
+                },
+                "S6": {
+                    "serviceName": "S6",
+                    "tags": [
+                    ]
+                },
+                "S7": {
+                    "serviceName": "S7",
+                    "tags": [
+                    ]
+                },
+                "S8": {
+                    "serviceName": "S8",
+                    "tags": [
+                    ]
+                },
+                "S9": {
+                    "serviceName": "S9",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 250,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 10,
+                    "duration": 100,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 30,
+                    "duration": 10,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O4",
+                    "startTime": 50,
+                    "duration": 10,
+                    "processID": "S4",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "string",
+                            "value": "ClientSideError"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "E",
+                    "operationName": "O5",
+                    "startTime": 70,
+                    "duration": 10,
+                    "processID": "S5",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "string",
+                            "value": "ClientSideError"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "F",
+                    "operationName": "O6",
+                    "startTime": 120,
+                    "duration": 100,
+                    "processID": "S6",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "logs": [
+                        {
+                            "timestamp": 140,
+                            "fields": [
+                                {
+                                    "key": "event",
+                                    "type": "string",
+                                    "value": "error"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "G",
+                    "operationName": "O7",
+                    "startTime": 140,
+                    "duration": 60,
+                    "processID": "S7",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "H",
+                    "operationName": "O8",
+                    "startTime": 150,
+                    "duration": 20,
+                    "processID": "S8",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "G"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "string",
+                            "value": "ClientSideError"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "I",
+                    "operationName": "O9",
+                    "startTime": 180,
+                    "duration": 10,
+                    "processID": "S9",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "G"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "string",
+                            "value": "ClientSideError"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 50,
+            "[S2] O2": 70,
+            "[S3] O3": 10,
+            "[S4] O4": 10,
+            "[S5] O5": 10,
+            "[S6] O6": 40,
+            "[S7] O7": 30,
+            "[S8] O8": 20,
+            "[S9] O9": 10
+        },
+        "noErrCP": {
+            "[S1] O1": 50
+        },
+        "totalWork": 570,
+        "timeSavedOnWork": 250,
+        "timeSavedOnCP": 200,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": 70,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S4] O4": 10,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S5] O5": 10,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6": 40,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6->[S7] O7->[S8] O8": 20,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6->[S7] O7->[S9] O9": 10
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [0,1,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S4] O4": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S5] O5": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6->[S7] O7": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6->[S7] O7->[S8] O8": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S6] O6->[S7] O7->[S9] O9": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/19.json
+++ b/test_cases/19.json
@@ -1,0 +1,136 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 600,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 10,
+                    "duration": 200,
+                    "processID": "S2",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 205,
+                    "duration": 100,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 400
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O4",
+                    "startTime": 300,
+                    "duration": 300,
+                    "processID": "S4",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 504
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                }
+            ]
+        }
+        ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 0,
+            "[S2] O2": 200,
+            "[S3] O3": 100,
+            "[S4] O4": 300
+        },
+        "totalWork": 1200,
+        "timeSavedOnWork": 600,
+        "timeSavedOnCP": 590,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": 200,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S3] O3": 100,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": 300
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S3] O3": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/20.json
+++ b/test_cases/20.json
@@ -1,0 +1,127 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 600,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 10,
+                    "duration": 200,
+                    "processID": "S2",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 205,
+                    "duration": 100,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O4",
+                    "startTime": 300,
+                    "duration": 300,
+                    "processID": "S4",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 504
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                }
+            ]
+        }
+        ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 0,
+            "[S2] O2": 200,
+            "[S3] O3": 100,
+            "[S4] O4": 300
+        },
+        "totalWork": 1200,
+        "timeSavedOnWork": 500,
+        "timeSavedOnCP": 495,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": 200,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": 300
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/21.json
+++ b/test_cases/21.json
@@ -1,0 +1,127 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                },
+                "S4": {
+                    "serviceName": "S4",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 600,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 10,
+                    "duration": 200,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 205,
+                    "duration": 100,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O4",
+                    "startTime": 300,
+                    "duration": 300,
+                    "processID": "S4",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 504
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                }
+            ]
+        }
+        ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 0,
+            "[S2] O2": 200,
+            "[S3] O3": 100,
+            "[S4] O4": 300
+        },
+        "totalWork": 1200,
+        "timeSavedOnWork": 400,
+        "timeSavedOnCP": 395,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S3] O3": 100,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": 300
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S3] O3": [1,0,0],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S4] O4": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/22.json
+++ b/test_cases/22.json
@@ -1,0 +1,119 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [ ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 300,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 50,
+                    "duration":  50,
+                    "processID": "S2",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O2",
+                    "startTime": 150,
+                    "duration": 50,
+                    "processID": "S2",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O2",
+                    "startTime": 250,
+                    "duration": 50,
+                    "processID": "S2",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 504
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                }
+            ]
+        }
+        ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 150,
+            "[S2] O2": 150
+        },
+        "totalWork": 450,
+        "timeSavedOnWork": 150,
+        "timeSavedOnCP": 150,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": 150
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [3,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/23.json
+++ b/test_cases/23.json
@@ -1,0 +1,227 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 700,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 50,
+                    "duration": 300,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 100,
+                    "duration":  50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O3",
+                    "startTime": 200,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "E",
+                    "operationName": "O3",
+                    "startTime": 300,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 504
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "F",
+                    "operationName": "O2",
+                    "startTime": 400,
+                    "duration": 300,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "G",
+                    "operationName": "O3",
+                    "startTime": 450,
+                    "duration":  50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "H",
+                    "operationName": "O3",
+                    "startTime": 550,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "I",
+                    "operationName": "O3",
+                    "startTime": 650,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 504
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                }
+            ]
+        }
+        ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 100,
+            "[S2] O2": 300,
+            "[S3] O3": 300
+        },
+        "totalWork": 1600,
+        "timeSavedOnWork": 300,
+        "timeSavedOnCP": 300,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S3] O3": 300
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [0,0,2],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S3] O3": [6,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/24.json
+++ b/test_cases/24.json
@@ -1,0 +1,236 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 700,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 50,
+                    "duration": 300,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 100,
+                    "duration":  50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O3",
+                    "startTime": 200,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "E",
+                    "operationName": "O3",
+                    "startTime": 300,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 504
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "F",
+                    "operationName": "O2",
+                    "startTime": 400,
+                    "duration": 300,
+                    "processID": "S2",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "G",
+                    "operationName": "O3",
+                    "startTime": 450,
+                    "duration":  50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "H",
+                    "operationName": "O3",
+                    "startTime": 550,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "I",
+                    "operationName": "O3",
+                    "startTime": 650,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 504
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 100,
+            "[S2] O2": 300,
+            "[S3] O3": 300
+        },
+        "totalWork": 1600,
+        "timeSavedOnWork": 600,
+        "timeSavedOnCP": 450,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": 150,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S3] O3": 300
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [0,1,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S3] O3": [6,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/25.json
+++ b/test_cases/25.json
@@ -1,0 +1,215 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 700,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 50,
+                    "duration": 300,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 100,
+                    "duration":  50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "D",
+                    "operationName": "O3",
+                    "startTime": 200,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "E",
+                    "operationName": "O3",
+                    "startTime": 300,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 504
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "F",
+                    "operationName": "O2",
+                    "startTime": 400,
+                    "duration": 300,
+                    "processID": "S2",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "http.status_code",
+                            "type": "int64",
+                            "value": 404
+                        }
+                    ],
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "G",
+                    "operationName": "O3",
+                    "startTime": 450,
+                    "duration":  50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "H",
+                    "operationName": "O3",
+                    "startTime": 550,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "I",
+                    "operationName": "O3",
+                    "startTime": 650,
+                    "duration": 50,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "F"
+                        }
+                    ]
+                }
+            ]
+        }
+        ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 100,
+            "[S2] O2": 300,
+            "[S3] O3": 300
+        },
+        "totalWork": 1600,
+        "timeSavedOnWork": 450,
+        "timeSavedOnCP": 450,
+        "errCPCallpathTimeExclusive": {
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": 150,
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S3] O3": 150
+        },
+        "errCPErrCounts": {
+            "errorCriticalPathSyntheticRoot->[S1] O1": [0,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2": [1,0,1],
+            "errorCriticalPathSyntheticRoot->[S1] O1->[S2] O2->[S3] O3": [3,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/err_pattern1/err1.json
+++ b/test_cases/err_pattern1/err1.json
@@ -1,0 +1,92 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 70,
+                    "duration": 30,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 70,
+            "[S2] O2": 30
+        },
+        "noErrCP": {
+        },
+        "totalWork": 130,
+        "timeSavedOnWork": 130,
+        "timeSavedOnCP": 100,
+        "errOpTimeInclusive": {
+            "[S1] O1": 100,
+            "[S2] O2": 30
+        },
+        "errOpTimeExclusive": {
+            "[S1] O1": 70,
+            "[S2] O2": 30
+        },
+        "errCallpathTimeExclusive": {
+            "[S1] O1": 70,
+            "[S1] O1->[S2] O2": 30
+        },
+        "errCounts": {
+            "[S1] O1": [0,1,0],
+            "[S1] O1->[S2] O2": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/err_pattern1/err2.json
+++ b/test_cases/err_pattern1/err2.json
@@ -1,0 +1,92 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 70,
+                    "duration": 30,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 70,
+            "[S2] O2": 30
+        },
+        "noErrCP": {
+        },
+        "totalWork": 130,
+        "timeSavedOnWork": 130,
+        "timeSavedOnCP": 100,
+        "errOpTimeInclusive": {
+            "[S1] O1": 100,
+            "[S2] O2": 30
+        },
+        "errOpTimeExclusive": {
+            "[S1] O1": 70,
+            "[S2] O2": 30
+        },
+        "errCallpathTimeExclusive": {
+            "[S1] O1": 70,
+            "[S1] O1->[S2] O2": 30
+        },
+        "errCounts": {
+            "[S1] O1": [0, 1, 0],
+            "[S1] O1->[S2] O2": [1, 0, 0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/err_pattern2/err1.json
+++ b/test_cases/err_pattern2/err1.json
@@ -1,0 +1,84 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 70,
+                    "duration": 30,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 70,
+            "[S2] O2": 30
+        },
+        "noErrCP": {
+            "[S1] O1": 70
+        },
+        "totalWork": 130,
+        "timeSavedOnWork": 30,
+        "timeSavedOnCP": 30,
+        "errOpTimeInclusive": {
+            "[S1] O1": 30,
+            "[S2] O2": 30
+        },
+        "errOpTimeExclusive": {
+            "[S2] O2": 30
+        },
+        "errCallpathTimeExclusive": {
+            "[S1] O1->[S2] O2": 30
+        },
+        "errCounts": {
+            "[S1] O1": [0,0,1],
+            "[S1] O1->[S2] O2": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/err_pattern2/err2.json
+++ b/test_cases/err_pattern2/err2.json
@@ -1,0 +1,81 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null,
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 70,
+                    "duration": 30,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 70,
+            "[S2] O2": 30
+        },
+        "noErrCP": {
+        },
+        "totalWork": 130,
+        "timeSavedOnWork": 100,
+        "timeSavedOnCP": 100,
+        "errOpTimeInclusive": {
+            "[S1] O1": 100
+        },
+        "errOpTimeExclusive": {
+            "[S1] O1": 70
+        },
+        "errCallpathTimeExclusive": {
+            "[S1] O1": 70
+        },
+        "errCounts": {
+            "[S1] O1": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/err_pattern3/err1.json
+++ b/test_cases/err_pattern3/err1.json
@@ -1,0 +1,116 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 70,
+                    "duration": 30,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 0,
+            "[S2] O2": 70,
+            "[S3] O3": 30
+        },
+        "noErrCP": {
+        },
+        "totalWork": 230,
+        "timeSavedOnWork": 130,
+        "timeSavedOnCP": 100,
+        "errOpTimeInclusive": {
+            "[S1] O1": 100,
+            "[S2] O2": 100,
+            "[S3] O3": 30
+        },
+        "errOpTimeExclusive": {
+            "[S2] O2": 70,
+            "[S3] O3": 30
+        },
+        "errCallpathTimeExclusive": {
+            "[S1] O1->[S2] O2": 70,
+            "[S1] O1->[S2] O2->[S3] O3": 30
+        },
+        "errCounts": {
+            "[S1] O1": [0,0,1],
+            "[S1] O1->[S2] O2": [0,1,0],
+            "[S1] O1->[S2] O2->[S3] O3": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/err_pattern3/err2.json
+++ b/test_cases/err_pattern3/err2.json
@@ -1,0 +1,116 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 70,
+                    "duration": 30,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 0,
+            "[S2] O2": 70,
+            "[S3] O3": 30
+        },
+        "noErrCP": {
+        },
+        "totalWork": 230,
+        "timeSavedOnWork": 130,
+        "timeSavedOnCP": 100,
+        "errOpTimeInclusive": {
+            "[S1] O1": 100,
+            "[S2] O2": 100,
+            "[S3] O3": 30
+        },
+        "errOpTimeExclusive": {
+            "[S2] O2": 70,
+            "[S3] O3": 30
+        },
+        "errCallpathTimeExclusive": {
+            "[S1] O1->[S2] O2": 70,
+            "[S1] O1->[S2] O2->[S3] O3": 30
+        },
+        "errCounts": {
+            "[S1] O1": [0,0,1],
+            "[S1] O1->[S2] O2": [0,1,0],
+            "[S1] O1->[S2] O2->[S3] O3": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/err_pattern4/err1.json
+++ b/test_cases/err_pattern4/err1.json
@@ -1,0 +1,105 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 70,
+                    "duration": 30,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 0,
+            "[S2] O2": 70,
+            "[S3] O3": 30
+        },
+        "noErrCP": {
+        },
+        "totalWork": 230,
+        "timeSavedOnWork": 100,
+        "timeSavedOnCP": 100,
+        "errOpTimeInclusive": {
+            "[S1] O1": 100,
+            "[S2] O2": 100
+        },
+        "errOpTimeExclusive": {
+            "[S2] O2": 70
+        },
+        "errCallpathTimeExclusive": {
+            "[S1] O1->[S2] O2": 70
+        },
+        "errCounts": {
+            "[S1] O1": [0,0,1],
+            "[S1] O1->[S2] O2": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/test_cases/err_pattern4/err2.json
+++ b/test_cases/err_pattern4/err2.json
@@ -1,0 +1,116 @@
+{
+    "data": [
+        {
+            "processes": {
+                "S1": {
+                    "serviceName": "S1",
+                    "tags": [
+                    ]
+                },
+                "S2": {
+                    "serviceName": "S2",
+                    "tags": [
+                    ]
+                },
+                "S3": {
+                    "serviceName": "S3",
+                    "tags": [
+                    ]
+                }
+            },
+            "traceID": "A",
+            "spans": [
+                {
+                    "traceID": "A",
+                    "spanID": "A",
+                    "operationName": "O1",
+                    "references": [],
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S1",
+                    "warnings": null
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "B",
+                    "operationName": "O2",
+                    "startTime": 0,
+                    "duration": 100,
+                    "processID": "S2",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "A"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "traceID": "A",
+                    "spanID": "C",
+                    "operationName": "O3",
+                    "startTime": 70,
+                    "duration": 30,
+                    "processID": "S3",
+                    "warnings": null,
+                    "references": [
+                        {
+                            "refType": "CHILD_OF",
+                            "traceID": "A",
+                            "spanID": "B"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "key": "error",
+                            "type": "bool",
+                            "value": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "testing": {
+        "opTimeExclusive": {
+            "[S1] O1": 0,
+            "[S2] O2": 70,
+            "[S3] O3": 30
+        },
+        "noErrCP": {
+        },
+        "totalWork": 230,
+        "timeSavedOnWork": 130,
+        "timeSavedOnCP": 100,
+        "errOpTimeInclusive": {
+            "[S1] O1": 100,
+            "[S2] O2": 100,
+            "[S3] O3": 30
+        },
+        "errOpTimeExclusive": {
+            "[S2] O2": 70,
+            "[S3] O3": 30
+        },
+        "errCallpathTimeExclusive": {
+            "[S1] O1->[S2] O2": 70,
+            "[S1] O1->[S2] O2->[S3] O3": 30
+        },
+        "errCounts": {
+            "[S1] O1": [0,0,1],
+            "[S1] O1->[S2] O2": [0,1,0],
+            "[S1] O1->[S2] O2->[S3] O3": [1,0,0]
+        }
+    },
+    "total": 0,
+    "limit": 0,
+    "offset": 0,
+    "errors": null
+}

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,179 @@
+"""End-to-end tests for the CRISP critical-path pipeline.
+
+Each test runs process_trace.main() against real Jaeger JSON fixtures,
+exercising the full pipeline from trace ingestion through output file
+generation.  The fixtures live in test_cases/ at the repository root.
+"""
+
+import glob
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+from unittest import TestCase, mock
+
+import crisp.process_trace as process_trace
+from crisp.proto import analyzer_pb2
+
+# Absolute path to the test_cases directory at the repo root.
+_FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "test_cases")
+
+
+def _run_single(json_path: str, extra_args: list[str] | None = None) -> int:
+    """Run the full pipeline against one JSON trace file in a temp directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dest = os.path.join(tmpdir, os.path.basename(json_path))
+        shutil.copyfile(json_path, dest)
+        argv = ["process_trace.py", "--operationName", "O1", "--serviceName", "S1",
+                "--file", dest]
+        if extra_args:
+            argv.extend(extra_args)
+        with mock.patch.object(sys, "argv", argv):
+            return process_trace.main()
+
+
+def _run_dir(traces_dir: str, extra_args: list[str] | None = None) -> int:
+    """Run the full pipeline against a directory of JSON trace files."""
+    argv = ["process_trace.py", "--operationName", "O1", "--serviceName", "S1",
+            "--inputDir", traces_dir]
+    if extra_args:
+        argv.extend(extra_args)
+    with mock.patch.object(sys, "argv", argv):
+        return process_trace.main()
+
+
+class TestCriticalPathE2E(TestCase):
+
+    def test_criticalpath_all_fixtures(self):
+        """All 25 regular trace fixtures must process without error."""
+        jsons = sorted(glob.glob(os.path.join(_FIXTURES_DIR, "*.json")))
+        self.assertGreater(len(jsons), 0, "No fixture files found")
+        for json_path in jsons:
+            with self.subTest(fixture=os.path.basename(json_path)):
+                rc = _run_single(json_path)
+                self.assertEqual(rc, 0, f"Non-zero exit for {json_path}")
+
+    def test_errorpath1(self):
+        for json_path in sorted(glob.glob(os.path.join(_FIXTURES_DIR, "err_pattern1", "*.json"))):
+            with self.subTest(fixture=os.path.basename(json_path)):
+                self.assertEqual(0, _run_single(json_path))
+
+    def test_errorpath2(self):
+        for json_path in sorted(glob.glob(os.path.join(_FIXTURES_DIR, "err_pattern2", "*.json"))):
+            with self.subTest(fixture=os.path.basename(json_path)):
+                self.assertEqual(0, _run_single(json_path))
+
+    def test_errorpath3(self):
+        for json_path in sorted(glob.glob(os.path.join(_FIXTURES_DIR, "err_pattern3", "*.json"))):
+            with self.subTest(fixture=os.path.basename(json_path)):
+                self.assertEqual(0, _run_single(json_path))
+
+    def test_errorpath4(self):
+        for json_path in sorted(glob.glob(os.path.join(_FIXTURES_DIR, "err_pattern4", "*.json"))):
+            with self.subTest(fixture=os.path.basename(json_path)):
+                self.assertEqual(0, _run_single(json_path))
+
+    def test_light_mode_cct_proto_parity(self):
+        """CCT and proto must carry identical (averaged) durations and frequencies.
+
+        Regression test for a bug where the .pb carried raw summed exclusive
+        durations (N × latency) instead of per-trace averages, while the .cct
+        correctly stored averages.  Creates N copies of 3.json with distinct
+        traceIDs so the same call paths are aggregated N times in light mode.
+        """
+        source = os.path.join(_FIXTURES_DIR, "3.json")
+        self.assertTrue(os.path.exists(source), f"Fixture missing: {source}")
+
+        with open(source) as f:
+            base_trace = json.load(f)
+
+        num_copies = 5
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for i in range(num_copies):
+                trace = json.loads(json.dumps(base_trace))
+                tid = f"trace{i:04d}"
+                trace["data"][0]["traceID"] = tid
+                for span in trace["data"][0]["spans"]:
+                    span["traceID"] = tid
+                    span["spanID"] = f"{span['spanID']}_{i}"
+                    for ref in span.get("references", []):
+                        ref["traceID"] = tid
+                        ref["spanID"] = f"{ref['spanID']}_{i}"
+                with open(os.path.join(tmpdir, f"{tid}.json"), "w") as f:
+                    json.dump(trace, f)
+
+            argv = [
+                "process_trace.py",
+                "--operationName", "O1", "--serviceName", "S1",
+                "--lightMode",
+                "--inputDir", tmpdir,
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                rc = process_trace.main()
+            self.assertEqual(rc, 0)
+
+            cct_path = os.path.join(tmpdir, "light-flame-graph-P100.cct")
+            pb_path = os.path.join(tmpdir, "light-flame-graph-P100.pb")
+            self.assertTrue(os.path.exists(cct_path), "CCT file not written")
+            self.assertTrue(os.path.exists(pb_path), "Protobuf file not written")
+
+            # Parse the CCT: each line is  <path> <excl_us> <<freq>>
+            timing_re = re.compile(r'(\d+)\s*<<(\d+)>>$')
+            cct_map: dict[str, tuple[int, int]] = {}
+            with open(cct_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    m = timing_re.search(line)
+                    if not m:
+                        continue
+                    excl, freq = int(m.group(1)), int(m.group(2))
+                    path = line[:m.start()].strip()
+                    cct_map[path] = (excl, freq)
+
+            # Parse the proto
+            resp = analyzer_pb2.AnalyzeResponse()
+            with open(pb_path, "rb") as f:
+                resp.ParseFromString(f.read())
+
+            proto_map: dict[str, tuple[int, int]] = {}
+            for entry in resp.report_window_1:
+                parts = [
+                    f"[{node.service}] {node.operation_name}"
+                    for node in entry.call_path
+                ]
+                path = ";".join(parts)
+                proto_map[path] = (
+                    entry.base.duration.ToMicroseconds(),
+                    entry.base.frequency,
+                )
+
+            self.assertGreater(len(cct_map), 0, "Expected at least one CCT entry")
+            self.assertEqual(
+                len(cct_map), len(proto_map),
+                f"Entry count mismatch: CCT={len(cct_map)} proto={len(proto_map)}",
+            )
+
+            for path, (cct_excl, cct_freq) in cct_map.items():
+                self.assertIn(path, proto_map, f"Path missing from proto: {path}")
+                proto_excl, proto_freq = proto_map[path]
+                self.assertEqual(
+                    cct_excl, proto_excl,
+                    f"Duration mismatch for '{path}': CCT={cct_excl} proto={proto_excl}"
+                    f" (if proto is {num_copies}× CCT, the sum-vs-avg bug is back)",
+                )
+                self.assertEqual(
+                    cct_freq, proto_freq,
+                    f"Frequency mismatch for '{path}': CCT={cct_freq} proto={proto_freq}",
+                )
+
+            # Each call path should appear in all num_copies traces
+            for path, (_excl, freq) in cct_map.items():
+                self.assertEqual(
+                    freq, num_copies,
+                    f"Expected freq={num_copies} for '{path}' (all {num_copies} copies "
+                    f"share this path), got {freq}",
+                )


### PR DESCRIPTION
## Summary

- Ports `tests/test_e2e.py` from the internal `test_e2e.py`. Six tests exercise the full pipeline end-to-end against real Jaeger JSON fixtures:
  - **`test_criticalpath_all_fixtures`** — runs all 25 regular traces through `performCriticalPathAnalysis`, asserts `rc=0`
  - **`test_errorpath{1-4}`** — same for 4 error-pattern fixture sets
  - **`test_light_mode_cct_proto_parity`** — regression test for the sum-vs-avg bug: creates 5 copies of `3.json`, runs light mode, then asserts the `.cct` and `.pb` files carry identical averaged durations and frequencies

- **Bug fix in `flamegraph.py`**: `aggregateCallPathProfiles` was missing `<<freq>>` in its CCT output, so `parse_cct_file` always returned empty summaries and all `.pb` files were empty in light mode. Fixed to match the internal format.

- **`main()` now returns `int`**: previously `-> None`, now returns `0`/`1` so callers (and tests) can assert the exit code.

- Adds fixtures `test_cases/11-25.json` and `test_cases/err_pattern{1-4}/` copied from the internal repo.

- Bazel: new `:test_e2e` target (`size=medium`); `test_cases/**` added to `:pytest` catch-all data glob; `@pypi//jinja2` and `@pypi//matplotlib` added to both targets (required by `df.style.background_gradient`).

## Test plan

- [x] `pytest tests/test_e2e.py -v` — 6 passed, 33 subtests passed
- [x] `pytest --ignore=tests/test_get_trace.py -q` — 396 passed
- [x] `bazel test //...` — 23/23 pass
