### PR TITLE
PR 24: PyPI publish workflow + v0.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,140 @@
+# Publish to PyPI (and TestPyPI) on version tags.
+#
+# Authentication uses OpenID Connect (OIDC) Trusted Publishers — no API token
+# needed in GitHub Secrets.  You must register two trusted publishers on
+# https://test.pypi.org and https://pypi.org before the first push:
+#
+#   PyPI project  : crisp-trace
+#   Owner         : uber-research
+#   Repository    : CRISP
+#   Workflow file : publish.yml
+#   Environment   : testpypi  (for TestPyPI)
+#                   pypi      (for PyPI)
+#
+# Trigger: push a semver tag, e.g.:
+#   git tag v0.1.0 && git push origin v0.1.0
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+.*"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target"
+        required: true
+        default: testpypi
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+
+jobs:
+  # ── 1. Run the full test suite before touching PyPI ──────────────────────────
+  test:
+    name: Test (Python 3.11)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements_lock.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_lock.txt
+
+      - name: Run tests
+        env:
+          MPLBACKEND: Agg
+          PYTHON: python
+        run: bash scripts/ci-local.sh
+
+  # ── 2. Build sdist + wheel ────────────────────────────────────────────────────
+  build:
+    name: Build distribution
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build frontend
+        run: pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check distributions
+        run: |
+          pip install twine
+          twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  # ── 3. Publish to TestPyPI ────────────────────────────────────────────────────
+  publish-testpypi:
+    name: Publish → TestPyPI
+    needs: build
+    # Always publish to TestPyPI on a tag push; skip for manual "pypi" target.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/crisp-trace
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          print-hash: true
+
+  # ── 4. Publish to PyPI (production) ──────────────────────────────────────────
+  publish-pypi:
+    name: Publish → PyPI
+    needs: publish-testpypi
+    # On tag push: always promote after TestPyPI succeeds.
+    # On manual trigger: only when target == 'pypi'.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/crisp-trace
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+---
+
+## [0.1.0] — 2026-06-19
+
 ### Added
 - Full critical-path analysis pipeline: error analysis helpers, flamegraph
   tag filters, and orchestration (`performCriticalPathAnalysis`,
@@ -16,21 +20,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Error CSV generators: `genPercentErrorFile`, `genSavingPotential`,
   `genErrStatsFiles`, `genMaxErrDepthPropToRootToNumTracesFiles`,
   `genSelfErrDepthToNumTracesFiles`.
-- Call-chain tree output (`_writeCCTOutputs`): writes `.cct` and `.dot` files.
+- Call-chain tree output (`_writeCCTOutputs`): writes `.cct`, `.dot`, and
+  `.pb` (Protocol Buffers) files.
+- Protobuf schema (`crisp/proto/analyzer.proto`) and generated bindings
+  (`analyzer_pb2.py`) for `CallPath`, `Exemplar`, `PathStats`,
+  `CallChainSummary`, and `AnalyzeResponse`.
 - Flamegraph tag filters: `GetFilteredMetrics`, `TagToStr`,
   `ProduceFlameGraphsForEachFilter`, `GetAllFlameGraphFiles`,
   `GetAllErrorFlameGraphFiles`, `genTagYAML`.
 - `pyproject.toml` runtime dependencies: `boto3`, `numpy`, `pandas`,
-  `python-dateutil`, `PyYAML`, `ratelimit`, `requests`, `tenacity`.
+  `protobuf`, `python-dateutil`, `PyYAML`, `ratelimit`, `requests`,
+  `tenacity`.
+- End-to-end integration tests (`tests/test_e2e.py`) covering 25 trace
+  fixtures and 4 error-pattern scenarios, including a protobuf/CCT parity
+  regression test.
+- GitHub Actions publish workflow (`.github/workflows/publish.yml`):
+  automatic build → TestPyPI → PyPI on `v*` tags using OIDC trusted
+  publishers (no API token required).
 
 ### Changed
 - `mergeCallChains`, `mergeExampleID`, `makeClickable`, `renameSortableIcon`
   are now imported from `crisp.metrics.aggregators` /
   `crisp.output.formatters` instead of being redefined in `process_trace.py`.
+- `main()` in `process_trace.py` returns an integer exit code (`0` on
+  success, `1` on failure) instead of `None`.
 
 ---
 
-## [0.1.0-dev] — initial release
+## [0.1.0-dev] — initial OSS snapshot
 
 CRISP (**C**ritical-path **I**nsights into **S**ervice **P**erformance) is a
 Python library and CLI tool for extracting and visualising the critical path
@@ -89,8 +106,6 @@ crisp/
 
 ### Known limitations
 
-- **Protobuf output** — `_writeCCTOutputs` writes `.cct` and `.dot` but not
-  `.pb`; protobuf serialization is deferred to a future release.
 - **Storage upload** — `storage.py` exposes the upload interface but the
   implementation is a stub; bring your own upload logic or use `tb_client.py`
   directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crisp-trace"
-version = "0.1.0.dev0"
+version = "0.1.0"
 description = "Critical-path analysis of distributed traces (Jaeger)"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- **`.github/workflows/publish.yml`** — triggers on `v*` semver tags (and `workflow_dispatch`):
  1. Runs the full test suite (`ci-local.sh`) first
  2. Builds sdist + wheel via `python -m build`, verified with `twine check`
  3. Publishes to **TestPyPI** (environment: `testpypi`)
  4. Promotes to **PyPI** (environment: `pypi`)
  Authentication uses [OIDC Trusted Publishers](https://docs.pypi.org/trusted-publishers/) — no API token secret required.
- **`pyproject.toml`** — version bumped `0.1.0.dev0` → `0.1.0`
- **`CHANGELOG.md`** — `[Unreleased]` section promoted to `[0.1.0] 2026-06-19`

## Pre-merge setup (one-time, do in PyPI dashboard before merging)

1. Create project `crisp-trace` on https://test.pypi.org (if not already there)
2. Add a Trusted Publisher on **TestPyPI**: owner=`uber-research`, repo=`CRISP`, workflow=`publish.yml`, environment=`testpypi`
3. Add a Trusted Publisher on **PyPI**: same fields, environment=`pypi`
4. Create GitHub Environments `testpypi` and `pypi` in repo Settings → Environments (add required reviewers to `pypi` for an approval gate)

## Test plan

After merging:
```bash
git tag v0.1.0 && git push origin v0.1.0
```
- CI: verify `test` job passes, `build` job produces sdist+wheel artifacts
- Verify package appears at https://test.pypi.org/project/crisp-trace/0.1.0/
- Verify package appears at https://pypi.org/project/crisp-trace/0.1.0/
