### PR TITLE
feat: cap mapReduce parallelism for large traces to prevent OOM

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,6 +35,7 @@ py_test(
         "@pypi//jinja2",
         "@pypi//matplotlib",
         "@pypi//protobuf",
+        "@pypi//psutil",
         "@pypi//pytest",
         "@pypi//pytest_asyncio",
         "@pypi//requests",
@@ -135,7 +136,9 @@ py_test(
     srcs = ["tests/test_pipeline.py"],
     deps = [
         "//crisp:pipeline",
+        "//crisp:process_trace",
         "//crisp:common",
+        "@pypi//psutil",
     ],
     imports = ["."],
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -403,7 +403,7 @@
         "usagesDigest": "bW0K8rtcOKhprT4m41L0QM8RyjxUZYMvAMydPv5WUB8=",
         "recordedFileInputs": {
           "@@rules_python~//tools/publish/requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",
-          "@@//requirements_lock.txt": "ee86b4510063ea1ea310f92d834e84b0edfd0815b89de2bc1c8b2f8973bd9ade",
+          "@@//requirements_lock.txt": "5265e9bd75139487e053fc7d399132418ce673fc09cc31956af08a5f0bb273cc",
           "@@rules_fuzzing~//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
           "@@rules_python~//tools/publish/requirements_windows.txt": "7673adc71dc1a81d3661b90924d7a7c0fc998cd508b3cb4174337cef3f2de556",
           "@@protobuf~//python/requirements.txt": "983be60d3cec4b319dcab6d48aeb3f5b2f7c3350f26b3a9e97486c37967c73c5",
@@ -833,6 +833,16 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "pypi_311",
               "requirement": "protobuf==7.35.1"
+            }
+          },
+          "pypi_311_psutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "pypi_311",
+              "requirement": "psutil==7.2.2"
             }
           },
           "pypi_311_pydantic": {
@@ -3642,6 +3652,7 @@
                 "pillow": "{\"pypi_311_pillow\":[{\"version\":\"3.11\"}]}",
                 "pluggy": "{\"pypi_311_pluggy\":[{\"version\":\"3.11\"}]}",
                 "protobuf": "{\"pypi_311_protobuf\":[{\"version\":\"3.11\"}]}",
+                "psutil": "{\"pypi_311_psutil\":[{\"version\":\"3.11\"}]}",
                 "pydantic": "{\"pypi_311_pydantic\":[{\"version\":\"3.11\"}]}",
                 "pydantic_core": "{\"pypi_311_pydantic_core\":[{\"version\":\"3.11\"}]}",
                 "pygments": "{\"pypi_311_pygments\":[{\"version\":\"3.11\"}]}",
@@ -3701,6 +3712,7 @@
                 "pillow",
                 "pluggy",
                 "protobuf",
+                "psutil",
                 "pydantic",
                 "pydantic_core",
                 "pygments",

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -168,6 +168,7 @@ py_library(
         "//crisp/shared:shared",
         "@pypi//numpy",
         "@pypi//pandas",
+        "@pypi//psutil",
         "@pypi//pyyaml",
     ],
 )

--- a/crisp/process_trace.py
+++ b/crisp/process_trace.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from functools import partial, reduce
 from typing import Any
 
+import psutil
+
 import numpy as np
 import pandas as pd
 import yaml
@@ -651,9 +653,59 @@ def process(filename: str, config: common.Config) -> Any:
     return metrics
 
 
+# Trace-size constants used by mapReduce() to cap parallelism when individual
+# trace files are large enough to risk OOM.
+# Traces with 1M spans can be ~1 GB on disk and expand ~4x in memory as Python
+# objects.  Loading 16 such traces concurrently would require ~64 GB of RSS.
+_LARGE_TRACE_THRESHOLD_BYTES: int = 100 * 1024 * 1024   # 100 MB — trigger the guard
+_IN_MEMORY_EXPANSION: int = 4   # conservative JSON → Python object expansion factor
+_MEMORY_HEADROOM_FRACTION: float = 0.8   # use at most 80% of available memory
+
+
+def _memory_aware_workers(num_workers: int, trace_files: list[str]) -> int:
+    """Return a worker count capped so that peak RSS stays within available memory.
+
+    For each file that actually exists, we stat its size (one syscall per
+    file — negligible compared to json.load).  When the largest file exceeds
+    _LARGE_TRACE_THRESHOLD_BYTES we query psutil for the current available
+    memory and apply:
+
+        capped = max(1, int(available * headroom / (max_size * expansion)))
+
+    For small traces (below the threshold) we return num_workers unchanged,
+    so the normal code path has essentially zero overhead.
+    """
+    if num_workers <= 1 or not trace_files:
+        return num_workers
+
+    existing = [f for f in trace_files if os.path.exists(f)]
+    if not existing:
+        return num_workers
+
+    max_trace_bytes = max(os.path.getsize(f) for f in existing)
+    if max_trace_bytes <= _LARGE_TRACE_THRESHOLD_BYTES:
+        return num_workers
+
+    available_bytes = psutil.virtual_memory().available
+    capped = max(1, int(available_bytes * _MEMORY_HEADROOM_FRACTION / (max_trace_bytes * _IN_MEMORY_EXPANSION)))
+    if capped < num_workers:
+        logging.warning(
+            "Large traces detected (max %.2f GB, available %.2f GB); "
+            "reducing computeParallelism from %d to %d to avoid OOM",
+            max_trace_bytes / (1024 ** 3),
+            available_bytes / (1024 ** 3),
+            num_workers,
+            capped,
+        )
+        return capped
+    return num_workers
+
+
 def mapReduce(numWorkers: int, jaegerTraceFiles: list, config: common.Config) -> list:
     """Build graph + critical path for each trace file using a process pool."""
     process_fn = partial(process, config=config)
+    # Cap workers to avoid OOM when individual trace files are very large.
+    numWorkers = _memory_aware_workers(numWorkers, jaegerTraceFiles)
     with mp.Pool(numWorkers) as p:
         metrics = p.map(process_fn, jaegerTraceFiles)
     return metrics

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ pyyaml>=6.0
 python-dateutil>=2.8
 requests>=2.31
 ratelimit>=2.2
+psutil>=5.9
 tenacity>=8.2
 # server extra
 aiofiles>=23.0

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -93,6 +93,8 @@ pluggy==1.6.0
     # via pytest
 protobuf==7.35.1
     # via -r requirements.in
+psutil==7.2.2
+    # via -r requirements.in
 pydantic==2.13.4
     # via fastapi
 pydantic-core==2.46.4

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,11 +1,18 @@
 import multiprocessing as mp
 from unittest import TestCase
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import crisp.common as common
 import crisp.pipeline as pipeline
 from crisp.common import PipelinePhase
+from crisp.process_trace import (
+    mapReduce,
+    _memory_aware_workers,
+    _LARGE_TRACE_THRESHOLD_BYTES,
+    _IN_MEMORY_EXPANSION,
+    _MEMORY_HEADROOM_FRACTION,
+)
 
 
 def dummyWorker(c: common.Config, resultQ: mp.Queue) -> common.Config:
@@ -279,3 +286,153 @@ class PipelineWorkerRealTestCase(unittest.TestCase):
         # Clean up queues
         inputQ.close()
         outputQ.close()
+
+
+class TestMemoryAwareWorkers(TestCase):
+    """Tests for _memory_aware_workers() — the OOM-guard helper in mapReduce."""
+
+    def _mock_psutil(self, available_bytes: int):
+        mock_vm = MagicMock()
+        mock_vm.available = available_bytes
+        return patch("psutil.virtual_memory", return_value=mock_vm)
+
+    def test_small_traces_below_threshold_no_cap(self):
+        """Traces well below the threshold leave num_workers unchanged."""
+        small_size = _LARGE_TRACE_THRESHOLD_BYTES // 2  # 50 MB
+        with patch("os.path.exists", return_value=True), \
+             patch("os.path.getsize", return_value=small_size):
+            result = _memory_aware_workers(16, ["trace1.json", "trace2.json"])
+        self.assertEqual(result, 16)
+
+    def test_traces_at_threshold_no_cap(self):
+        """Traces exactly at the threshold (not exceeding) leave num_workers unchanged."""
+        with patch("os.path.exists", return_value=True), \
+             patch("os.path.getsize", return_value=_LARGE_TRACE_THRESHOLD_BYTES):
+            result = _memory_aware_workers(16, ["trace.json"])
+        self.assertEqual(result, 16)
+
+    def test_large_trace_caps_workers(self):
+        """A 1 GB trace file with 4 GB available caps to 1 worker.
+
+        budget = 4 GB * 0.8 = 3.2 GB
+        per_worker_cost = 1 GB * 4 = 4 GB
+        capped = max(1, int(3.2 / 4)) = 1
+        """
+        one_gb = 1024 * 1024 * 1024
+        four_gb = 4 * one_gb
+        with patch("os.path.exists", return_value=True), \
+             patch("os.path.getsize", return_value=one_gb), \
+             self._mock_psutil(four_gb):
+            result = _memory_aware_workers(16, ["huge_trace.json"])
+        expected = max(1, int(four_gb * _MEMORY_HEADROOM_FRACTION / (one_gb * _IN_MEMORY_EXPANSION)))
+        self.assertEqual(result, expected)
+        self.assertEqual(result, 1)
+
+    def test_medium_large_trace_partial_cap(self):
+        """A 512 MB trace with 8 GB available caps to 3 workers.
+
+        budget = 8 GB * 0.8 = 6.4 GB
+        per_worker_cost = 512 MB * 4 = 2 GB
+        capped = max(1, int(6.4 / 2)) = 3
+        """
+        half_gb = 512 * 1024 * 1024
+        eight_gb = 8 * 1024 * 1024 * 1024
+        with patch("os.path.exists", return_value=True), \
+             patch("os.path.getsize", return_value=half_gb), \
+             self._mock_psutil(eight_gb):
+            result = _memory_aware_workers(16, ["trace.json"])
+        expected = max(1, int(eight_gb * _MEMORY_HEADROOM_FRACTION / (half_gb * _IN_MEMORY_EXPANSION)))
+        self.assertEqual(result, expected)
+        self.assertEqual(result, 3)
+
+    def test_cap_never_exceeds_requested_workers(self):
+        """If budget allows more workers than requested, returns the original count."""
+        small_but_above_threshold = _LARGE_TRACE_THRESHOLD_BYTES + 1
+        sixty_four_gb = 64 * 1024 * 1024 * 1024
+        with patch("os.path.exists", return_value=True), \
+             patch("os.path.getsize", return_value=small_but_above_threshold), \
+             self._mock_psutil(sixty_four_gb):
+            result = _memory_aware_workers(2, ["trace.json"])
+        self.assertEqual(result, 2)
+
+    def test_single_worker_unchanged(self):
+        """num_workers=1 is returned immediately with no stat calls."""
+        with patch("os.path.getsize") as mock_stat:
+            result = _memory_aware_workers(1, ["trace.json"])
+        self.assertEqual(result, 1)
+        mock_stat.assert_not_called()
+
+    def test_empty_file_list_unchanged(self):
+        """Empty file list returns num_workers unchanged."""
+        result = _memory_aware_workers(16, [])
+        self.assertEqual(result, 16)
+
+    def test_nonexistent_files_skipped(self):
+        """Files that do not exist are excluded from the size check."""
+        with patch("os.path.exists", return_value=False):
+            result = _memory_aware_workers(16, ["ghost.json"])
+        self.assertEqual(result, 16)
+
+    def test_warning_logged_when_capping(self):
+        """A warning is emitted when parallelism is reduced."""
+        one_gb = 1024 * 1024 * 1024
+        with patch("os.path.exists", return_value=True), \
+             patch("os.path.getsize", return_value=one_gb), \
+             self._mock_psutil(4 * one_gb), \
+             patch("crisp.process_trace.logging") as mock_log:
+            _memory_aware_workers(16, ["big.json"])
+        mock_log.warning.assert_called_once()
+        warning_msg = mock_log.warning.call_args[0][0]
+        self.assertIn("Large traces detected", warning_msg)
+
+    def test_no_warning_for_small_traces(self):
+        """No warning is emitted when traces are below the threshold."""
+        small_size = _LARGE_TRACE_THRESHOLD_BYTES // 2
+        with patch("os.path.exists", return_value=True), \
+             patch("os.path.getsize", return_value=small_size), \
+             patch("crisp.process_trace.logging") as mock_log:
+            _memory_aware_workers(16, ["small.json"])
+        mock_log.warning.assert_not_called()
+
+
+class TestMapReduceOomGuard(TestCase):
+    """Tests that mapReduce() applies the memory-aware worker cap."""
+
+    @patch("multiprocessing.Pool")
+    @patch("crisp.process_trace.process")
+    def test_mapReduce_small_traces_unchanged(self, _mock_process, mock_pool):
+        """mapReduce uses the requested pool size for small traces."""
+        mock_pool_instance = MagicMock()
+        mock_pool.return_value.__enter__.return_value = mock_pool_instance
+        mock_pool_instance.map.return_value = []
+
+        mock_config = MagicMock()
+        with patch("os.path.exists", return_value=True), \
+             patch("os.path.getsize", return_value=1024):  # 1 KB — well below threshold
+            mapReduce(4, ["trace.json"], mock_config)
+
+        actual_workers = mock_pool.call_args[0][0]
+        self.assertEqual(actual_workers, 4)
+
+    @patch("multiprocessing.Pool")
+    @patch("crisp.process_trace.process")
+    def test_mapReduce_caps_workers_for_large_traces(self, _mock_process, mock_pool):
+        """mapReduce uses a smaller pool when trace files are very large.
+
+        1 GB file, 4 GB available → capped = max(1, int(4*0.8/4)) = 1
+        """
+        mock_pool_instance = MagicMock()
+        mock_pool.return_value.__enter__.return_value = mock_pool_instance
+        mock_pool_instance.map.return_value = []
+
+        mock_config = MagicMock()
+        one_gb = 1024 * 1024 * 1024
+        mock_vm = MagicMock()
+        mock_vm.available = 4 * one_gb
+        with patch("os.path.exists", return_value=True), \
+             patch("os.path.getsize", return_value=one_gb), \
+             patch("psutil.virtual_memory", return_value=mock_vm):
+            mapReduce(16, ["big_trace.json"], mock_config)
+
+        actual_workers = mock_pool.call_args[0][0]
+        self.assertEqual(actual_workers, 1)


### PR DESCRIPTION
## Summary

- Adds `_memory_aware_workers()` to `process_trace.py`: when the largest
  trace file exceeds 100 MB, queries `psutil` for available memory and caps
  the worker count to `max(1, floor(available × 0.8 / (max_file_size × 4)))`,
  logging a warning when reduced.
- `mapReduce()` calls the guard before spawning `mp.Pool`; small traces
  (< 100 MB) take the fast path with zero overhead.
- Adds `psutil>=5.9` to dependencies and Bazel build targets.
- Ports 12 unit tests from the internal codebase (`TestMemoryAwareWorkers`,
  `TestMapReduceOomGuard`) into `tests/test_pipeline.py`.

## Test plan

- [x] `bazel test //...` — all 29 targets pass
- [x] `pytest tests/test_pipeline.py -v`