### PR TITLE
feat: add multi-trace aggregation to dependency graph inference

### DIFF
--- a/crisp/dependency_graph.py
+++ b/crisp/dependency_graph.py
@@ -1,7 +1,7 @@
-"""Single-trace dependency inference for critical path call trees.
+"""Single-trace and multi-trace dependency inference for critical path call trees.
 
 This module infers timing dependencies between sibling and parent/child
-spans of a single trace's :class:`~crisp.graph.Graph`.
+spans of a trace's :class:`~crisp.graph.Graph`.
 
 Nodes are keyed by :meth:`Graph.getCallPath`, the established call-path
 identity used throughout this codebase (see ``CallPathProfile``,
@@ -12,8 +12,27 @@ Sibling ordering is inferred with :meth:`Graph.happensBefore`, the same
 clock-skew-tolerant primitive the critical-path algorithm itself uses
 (see ``Graph.computeCriticalPath``).
 
-Cross-trace aggregation is out of scope for this module; it accumulates
-dependency information for exactly one :class:`Graph`.
+Two modes are supported:
+
+* :meth:`DependencyGraph.get_dependencies` accumulates dependency
+  information for exactly one :class:`Graph` (single trace).
+* :meth:`DependencyGraph.get_aggregate_dependencies` folds the single-trace
+  results of many :class:`Graph` instances (e.g. many traces of the same
+  endpoint) into one aggregate dependency dict, per call-path name.
+
+Aggregation of ``async_children``, ``child_dependents``, and the delay
+lists is a straightforward union/concatenation across traces. Aggregation
+of ``happens_before`` is subtler: it follows a "one counter-example
+permanently drops the edge" rule. A candidate call-path name is only
+recorded as happening before a node once it has been observed doing so
+*and never subsequently contradicted*. If some later trace has evidence
+that the same node and the same candidate call-path both occurred but the
+candidate did NOT happen before the node, the edge is dropped forever --
+even if a still-later trace goes on to re-observe the original confirming
+ordering. This intentionally biases towards precision (few false-positive
+edges) over recall. A trace that simply never observed a given call-path
+at all cannot contradict prior evidence about it (absence is not a
+counter-example).
 """
 
 from __future__ import annotations
@@ -68,10 +87,16 @@ class DependencyGraphNode:
 
 
 class DependencyGraph:
-    """Infers sibling/parent-child timing dependencies for a single trace's Graph."""
+    """Infers sibling/parent-child timing dependencies for one or many traces' Graphs."""
 
-    def __init__(self, graph: Graph):
-        self.deps: dict[str, DependencyGraphNode] = self.get_dependencies(graph)
+    def __init__(self, graph: Graph | None = None, graphs: list[Graph] | None = None):
+        if (graph is None) == (graphs is None):
+            raise ValueError("DependencyGraph requires exactly one of `graph` or `graphs`.")
+
+        if graph is not None:
+            self.deps: dict[str, DependencyGraphNode] = self.get_dependencies(graph)
+        else:
+            self.deps = self.get_aggregate_dependencies(graphs)
 
     @classmethod
     def _get_or_create(cls, deps: dict[str, DependencyGraphNode], name: str) -> DependencyGraphNode:
@@ -137,3 +162,79 @@ class DependencyGraph:
                         child_dep.happens_before.add(graph.getCallPath(candidate))
 
         return deps
+
+    @classmethod
+    def get_aggregate_dependencies(cls, graphs: list[Graph]) -> dict[str, DependencyGraphNode]:
+        """Fold single-trace dependencies from many traces into one aggregate dict.
+
+        Traces are processed in order, maintaining a running aggregate. See the
+        module docstring for the "one counter-example permanently drops the
+        edge" rule applied to ``happens_before``; ``async_children`` is a plain
+        union; ``child_dependents`` is a union that evicts any name observed as
+        async (in this trace or an earlier one); and the delay lists are
+        concatenated across all traces, in order.
+
+        Args:
+            graphs: the traces' Graphs to aggregate, in the order to process them.
+
+        Returns:
+            A dict mapping call-path name (Graph.getCallPath) to a fresh
+            aggregate DependencyGraphNode (never aliased to any per-trace node).
+        """
+        aggregate: dict[str, DependencyGraphNode] = {}
+        # Every call-path name ever proposed as a happens_before candidate for a
+        # given node_name, whether currently confirmed or previously rejected.
+        ever_proposed: dict[str, set[str]] = {}
+
+        for graph in graphs:
+            dependencies = cls.get_dependencies(graph)
+
+            for node_name, dependency in dependencies.items():
+                if node_name not in aggregate:
+                    agg_node = DependencyGraphNode(node_name)
+                    agg_node.happens_before = set(dependency.happens_before)
+                    ever_proposed[node_name] = set(dependency.happens_before)
+                    aggregate[node_name] = agg_node
+                else:
+                    agg_node = aggregate[node_name]
+                    seen = ever_proposed[node_name]
+                    new_happens_before: set[str] = set()
+
+                    for candidate in dependency.happens_before:
+                        if candidate in agg_node.happens_before:
+                            new_happens_before.add(candidate)
+                        elif candidate not in seen:
+                            new_happens_before.add(candidate)
+                            seen.add(candidate)
+                        # else: previously proposed but not currently confirmed --
+                        # a prior trace already contradicted it, so it must not
+                        # be resurrected even if this trace's evidence matches.
+
+                    for candidate in agg_node.happens_before:
+                        if candidate in dependency.happens_before:
+                            continue  # already handled above
+                        if candidate not in dependencies:
+                            # This trace never observed the candidate call-path at
+                            # all, so it can't contradict prior evidence about it.
+                            new_happens_before.add(candidate)
+                        # else: candidate was observed in this trace but not
+                        # confirmed as happens-before here -- a genuine
+                        # counter-example, so drop it.
+
+                    agg_node.happens_before = new_happens_before
+
+                # async_children: plain union. child_dependents: union, but a name
+                # must be evicted if it's async in this trace OR any earlier one.
+                async_before_this_trace = set(agg_node.async_children)
+                for name in dependency.child_dependents:
+                    if name not in async_before_this_trace:
+                        agg_node.child_dependents.add(name)
+
+                newly_async = dependency.async_children - agg_node.async_children
+                agg_node.async_children |= dependency.async_children
+                agg_node.child_dependents -= newly_async
+
+                agg_node.parent_start_delay.extend(dependency.parent_start_delay)
+                agg_node.parent_end_delay.extend(dependency.parent_end_delay)
+
+        return aggregate

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -263,6 +263,83 @@ def orphan_node_graph():
     return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "O1")
 
 
+# --- Fixtures used only by the multi-trace aggregation tests below. ---
+
+
+# A ([S1] O1) -> C ([S2] O3)
+#             -> D ([S2] O4)
+# A runs 0-300; C runs 0-80; D runs 200-280 -- same shape as
+# three_series_siblings_graph() but with the "B" call-path entirely absent, to
+# simulate a trace that never observed that call-path at all.
+def two_series_siblings_no_b_graph():
+    spans = [
+        _span("A", "O1", "S1", 0, 300),
+        _span("C", "O3", "S2", 0, 80, parent_id="A"),
+        _span("D", "O4", "S2", 200, 80, parent_id="A"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "O1")
+
+
+# A ([S1] O1) -> B ([S2] O2)
+#             -> D ([S2] O4)
+# A runs 0-300; B runs 0-80; D runs 200-280. B strictly finishes before D
+# starts, so this trace confirms "B happens-before D".
+def two_series_b_then_d_graph():
+    spans = [
+        _span("A", "O1", "S1", 0, 300),
+        _span("B", "O2", "S2", 0, 80, parent_id="A"),
+        _span("D", "O4", "S2", 200, 80, parent_id="A"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "O1")
+
+
+# A ([S1] O1) -> D ([S2] O4)
+#             -> B ([S2] O2)
+# Same two call-paths as two_series_b_then_d_graph(), but with the order
+# reversed (D runs 0-80, B runs 200-280) -- this trace contradicts
+# "B happens-before D".
+def two_series_d_then_b_graph():
+    spans = [
+        _span("A", "O1", "S1", 0, 300),
+        _span("D", "O4", "S2", 0, 80, parent_id="A"),
+        _span("B", "O2", "S2", 200, 80, parent_id="A"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "O1")
+
+
+# A ([S1] O1) -> B ([S2] O2), a single child whose timing is caller-supplied,
+# used to build several traces with distinct parent_start_delay/parent_end_delay
+# values for the delay-concatenation aggregation test.
+def single_child_with_delay_graph(child_start, child_duration):
+    spans = [
+        _span("A", "O1", "S1", 0, 100),
+        _span("B", "O2", "S2", child_start, child_duration, parent_id="A"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "O1")
+
+
+# A ([S1] O1) -> B1 ([S2] Ob), a single occurrence of fanout_same_callpath_graph()'s
+# fanout op (no second sibling at the same call-path). Used to contradict that
+# graph's self-referential happens_before edge for "[S1] O1->[S2] Ob".
+def single_ob_child_graph():
+    spans = [
+        _span("A", "O1", "S1", 0, 1000),
+        _span("B1", "Ob", "S2", 0, 400, parent_id="A"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "O1")
+
+
+# A ([S1] O1) -> Z ([S2] O9), a single child at a different op than
+# single_child_graph()'s B, at the same parent call-path. Used to confirm that
+# distinct call-paths observed in different traces both end up in the aggregate.
+def single_child_graph_alt_op():
+    spans = [
+        _span("A", "O1", "S1", 0, 100),
+        _span("Z", "O9", "S2", 10, 80, parent_id="A"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "O1")
+
+
 @pytest.fixture
 def restore_config():
     yield
@@ -544,3 +621,182 @@ def test_deps_keys_use_full_getcallpath_strings():
 def test_dependency_graph_node_repr_contains_name():
     node = DependencyGraphNode("[S1] O1")
     assert "[S1] O1" in repr(node)
+
+
+# --- Multi-trace aggregation (get_aggregate_dependencies / DependencyGraph(graphs=...)). ---
+
+
+def test_aggregate_happens_before_survives_when_two_traces_confirm_same_edge():
+    g1 = three_series_siblings_graph()
+    g2 = three_series_siblings_graph()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2])
+
+    name_b = "[S1] O1->[S2] O2"
+    name_c = "[S1] O1->[S2] O3"
+    name_d = "[S1] O1->[S2] O4"
+
+    assert agg[name_c].happens_before == {name_b}
+    assert agg[name_d].happens_before == {name_b, name_c}
+
+
+def test_aggregate_happens_before_dropped_by_genuine_counter_example():
+    # g1 confirms "B happens-before C"; g2 has both B and C present but runs
+    # them concurrently, contradicting that ordering.
+    g1 = three_series_siblings_graph()
+    g2 = parallel_siblings_graph()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2])
+
+    name_c = "[S1] O1->[S2] O3"
+    assert agg[name_c].happens_before == set()
+
+
+def test_aggregate_happens_before_survives_when_later_trace_omits_candidate_entirely():
+    # g2 never observed "B" at all (different call pattern), so it cannot
+    # contradict D's confirmed happens_before relationship with B from g1.
+    g1 = three_series_siblings_graph()
+    g2 = two_series_siblings_no_b_graph()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2])
+
+    name_b = "[S1] O1->[S2] O2"
+    name_c = "[S1] O1->[S2] O3"
+    name_d = "[S1] O1->[S2] O4"
+
+    assert agg[name_d].happens_before == {name_b, name_c}
+
+
+def test_aggregate_happens_before_rejection_is_permanent_across_three_traces():
+    # trace 1 confirms "B happens-before D"; trace 2 contradicts it (D runs
+    # first); trace 3 re-observes the exact same confirming pattern as trace 1
+    # -- the edge must remain dropped, never resurrected.
+    g1 = two_series_b_then_d_graph()
+    g2 = two_series_d_then_b_graph()
+    g3 = two_series_b_then_d_graph()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2, g3])
+
+    name_d = "[S1] O1->[S2] O4"
+    assert agg[name_d].happens_before == set()
+
+
+def test_aggregate_first_trace_non_confirmation_does_not_block_later_confirmation():
+    # g1 sees B and C concurrently (no order between them); since this is the
+    # *first* sighting of C, there is no prior confirmed evidence yet to
+    # contradict, so a later trace can still add a brand-new confirmed edge.
+    g1 = parallel_siblings_graph()
+    g2 = three_series_siblings_graph()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2])
+
+    name_b = "[S1] O1->[S2] O2"
+    name_c = "[S1] O1->[S2] O3"
+    assert agg[name_c].happens_before == {name_b}
+
+
+def test_aggregate_self_referential_happens_before_survives_confirmation():
+    # Fan-out self-edges (see test_fanout_same_callpath_shares_one_node_...)
+    # must follow the exact same aggregation rules as any other candidate name.
+    g1 = fanout_same_callpath_graph()
+    g2 = fanout_same_callpath_graph()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2])
+
+    name_b = "[S1] O1->[S2] Ob"
+    assert agg[name_b].happens_before == {name_b}
+
+
+def test_aggregate_self_referential_happens_before_dropped_by_counter_example():
+    # g2 has only a single occurrence of the fanout call-path, so it observes
+    # "Ob" without confirming Ob happens-before itself -- a genuine
+    # counter-example against the self-referential edge confirmed by g1.
+    g1 = fanout_same_callpath_graph()
+    g2 = single_ob_child_graph()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2])
+
+    name_b = "[S1] O1->[S2] Ob"
+    assert agg[name_b].happens_before == set()
+
+
+def test_aggregate_async_children_union_evicts_from_child_dependents():
+    # B is a plain (sync) child_dependent in g1, but async in g2 -- the
+    # aggregate must mark it async and evict it from child_dependents, even
+    # though an earlier trace had it there as a plain dependent.
+    g1 = single_child_graph()
+    g2 = async_child_graph()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2])
+
+    name_a, name_b = "[S1] O1", "[S1] O1->[S2] O2"
+    assert agg[name_a].async_children == {name_b}
+    assert name_b not in agg[name_a].child_dependents
+
+
+def test_aggregate_child_dependents_union_across_distinct_traces():
+    g1 = single_child_graph()
+    g2 = single_child_graph_alt_op()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2])
+
+    name_a = "[S1] O1"
+    name_b = "[S1] O1->[S2] O2"
+    name_z = "[S1] O1->[S2] O9"
+
+    assert name_b in agg
+    assert name_z in agg
+    assert agg[name_a].child_dependents == {name_b, name_z}
+
+
+def test_aggregate_delay_lists_concatenate_across_traces():
+    g1 = single_child_with_delay_graph(10, 80)
+    g2 = single_child_with_delay_graph(20, 70)
+    g3 = single_child_with_delay_graph(5, 90)
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2, g3])
+
+    name_a = "[S1] O1"
+    assert sorted(agg[name_a].parent_start_delay) == [5, 10, 20]
+    assert sorted(agg[name_a].parent_end_delay) == [5, 10, 10]
+
+
+def test_aggregate_new_node_first_seen_in_later_trace_is_not_aliased():
+    # "[S2] O2" only exists starting from g2; when first observed, its
+    # aggregate DependencyGraphNode must be a fresh object, not aliased to the
+    # per-trace one -- mutating the aggregate must not leak into a separately
+    # computed per-trace result.
+    g1 = leaf_only_graph()
+    g2 = single_child_graph()
+    agg = DependencyGraph.get_aggregate_dependencies([g1, g2])
+
+    name_b = "[S1] O1->[S2] O2"
+    per_trace_deps = DependencyGraph(g2).deps
+
+    assert name_b in agg
+    assert agg[name_b] is not per_trace_deps[name_b]
+
+    agg[name_b].happens_before.add("BOGUS")
+    agg[name_b].child_dependents.add("BOGUS")
+    agg[name_b].parent_start_delay.append(999)
+
+    assert "BOGUS" not in per_trace_deps[name_b].happens_before
+    assert "BOGUS" not in per_trace_deps[name_b].child_dependents
+    assert 999 not in per_trace_deps[name_b].parent_start_delay
+
+
+def test_aggregate_single_graph_list_matches_single_trace_mode():
+    g = three_series_siblings_graph()
+    via_single = DependencyGraph(g).deps
+    via_aggregate = DependencyGraph(graphs=[g]).deps
+
+    assert via_single.keys() == via_aggregate.keys()
+    for name in via_single:
+        assert via_single[name].happens_before == via_aggregate[name].happens_before
+        assert via_single[name].child_dependents == via_aggregate[name].child_dependents
+        assert via_single[name].async_children == via_aggregate[name].async_children
+        assert via_single[name].parent_start_delay == via_aggregate[name].parent_start_delay
+        assert via_single[name].parent_end_delay == via_aggregate[name].parent_end_delay
+
+
+def test_aggregate_constructor_requires_exactly_one_of_graph_or_graphs():
+    g = leaf_only_graph()
+
+    with pytest.raises(ValueError):
+        DependencyGraph()
+
+    with pytest.raises(ValueError):
+        DependencyGraph(graph=g, graphs=[g])
+
+    # existing positional single-graph call style must keep working unchanged.
+    assert DependencyGraph(g).deps.keys() == DependencyGraph.get_dependencies(g).keys()


### PR DESCRIPTION
## Summary

- Extends `DependencyGraph` with `get_aggregate_dependencies()`, which folds
  single-trace dependency results from many traces of the same endpoint into
  one aggregate dict, keyed by call-path name.
- The constructor now accepts either `graph=` (single trace, unchanged
  behavior) or `graphs=` (multi-trace aggregation) — exactly one is required.
- Aggregation rules per field:
  - `happens_before` — "one counter-example permanently drops the edge": a
    candidate is only kept confirmed if it's never contradicted by a later
    trace that observed both call-paths but in the opposite order. A trace
    that never observed the candidate at all cannot contradict prior
    evidence. Rejections are permanent, even if a later trace re-confirms
    the original ordering. This biases toward precision over recall.
  - `async_children` — plain union across traces.
  - `child_dependents` — union, but evicts any name that's async in this
    trace or any earlier one.
  - `parent_start_delay` / `parent_end_delay` — concatenated across traces,
    in order.
- Aggregate `DependencyGraphNode`s are always fresh objects, never aliased
  to any single-trace result.
- Adds 13 new unit tests covering confirmation across traces, counter-example
  rejection (including permanence across 3+ traces), self-referential
  fan-out edges, async eviction, delay concatenation, non-aliasing, and
  constructor validation — 34/34 pass.
- Still fully self-contained — no new dependencies.

## Test plan

- [x] `bazel test //...` — all 30 targets pass
- [ ] `pytest tests/test_dependency_graph.py -v` — 34/34 pass