### PR TITLE
fix: use float literal for zeroed-out exclusive drag values

### DIFF
--- a/crisp/slack_drag.py
+++ b/crisp/slack_drag.py
@@ -100,7 +100,7 @@ def _exclusive_cp_time(cp: list[GraphNode]) -> dict[str, float]:
 
     for sid, value in exclusive_time.items():
         if value < 0:
-            exclusive_time[sid] = 0
+            exclusive_time[sid] = 0.0
 
     return exclusive_time
 


### PR DESCRIPTION
## Summary
- \`_exclusive_cp_time\` zeroed out negative entries with the int literal `0` instead of `0.0`, despite the dict being typed `dict[str, float]`.
- Purely a type-hygiene nit for consistency (no behavioral or type-checking difference, since Python's numeric tower already treats `int` as assignable to `float`).

## Test plan
- \`pytest tests/test_slack_drag.py\` — all 22 tests pass.
