### PR TITLE
feat: Add slack calculation alongside drag

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,6 +166,7 @@ py_test(
     deps = [
         "//crisp:slack_drag",
         "//crisp:graph",
+        "//crisp:dependency_graph",
         "//crisp/shared:shared",
         "@pypi//pytest",
     ],

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -67,6 +67,7 @@ py_library(
     srcs = ["slack_drag.py"],
     visibility = ["//visibility:public"],
     deps = [
+        ":dependency_graph",
         "//crisp/utils:utils",
     ],
 )
@@ -75,9 +76,12 @@ py_library(
     name = "dependency_graph",
     srcs = ["dependency_graph.py"],
     visibility = ["//visibility:public"],
-    deps = [
-        ":graph",
-    ],
+    # NOTE: dependency_graph.py only references Graph under `if TYPE_CHECKING:`
+    # (with `from __future__ import annotations`, so the annotation is never
+    # evaluated at runtime) -- it has no real runtime dependency on `:graph`.
+    # A `:graph` dep here would create a Bazel-level cycle now that `slack_drag`
+    # (a real dependency of `:graph`) also depends on `:dependency_graph`.
+    deps = [],
 )
 
 py_library(

--- a/crisp/graph.py
+++ b/crisp/graph.py
@@ -39,7 +39,7 @@ from crisp.configuration import (
 from crisp.utils.dict_utils import (
     accumulateInDict, getCPSize
 )
-from crisp.slack_drag import calculate_drag
+from crisp.slack_drag import calculate_drag, calculate_slack
 
 # Re-export for backward compatibility
 __all__ = ['Graph', 'accumulateInDict', 'bcolors', 'getCPSize']
@@ -1968,6 +1968,24 @@ class Graph:
         if cp is None:
             cp = self.findCriticalPath()
         return calculate_drag(self, cp, exclusive)
+
+    def calculateSlack(self, cp=None, dependency_graph=None):
+        """Calculate slack for every node in this Graph.
+
+        See :func:`slack_drag.calculate_slack` for the definition of slack
+        and its "every node gets an entry" contract.
+
+        Args:
+            cp: Optional critical path (as returned by findCriticalPath()) to
+                calculate slack against. If None, uses findCriticalPath() on
+                this Graph's own rootNode.
+            dependency_graph: Optional pre-built DependencyGraph. If None,
+                calculate_slack builds one internally via
+                DependencyGraph(graph=self).
+        """
+        if cp is None:
+            cp = self.findCriticalPath()
+        return calculate_slack(self, cp, dependency_graph)
 
     def findErrorsOnCriticalPath(self, rootNode=None):
         """Find errors on the critical path starting from the given root node.

--- a/crisp/slack_drag.py
+++ b/crisp/slack_drag.py
@@ -1,16 +1,24 @@
-"""Drag calculation for a critical path call tree.
+"""Drag and slack calculation for a critical path call tree.
 
-This module ports the "drag" concept from Google's `calligator` project
-(Apache-2.0, see
+This module ports the "drag" and "slack" concepts from Google's `calligator`
+project (Apache-2.0, see
 https://github.com/google/calligator/blob/main/critical_path.py,
-class ``CriticalPath``, methods ``calculate_drag``, ``_get_exclusive_cp_time``)
-to this codebase's :class:`~crisp.graph.Graph` and :meth:`Graph.computeCriticalPath`.
+class ``CriticalPath``, methods ``calculate_drag``, ``_get_exclusive_cp_time``,
+``calculate_slack``, ``_compute_earliest_start_times``,
+``_compute_latest_start_times``) to this codebase's
+:class:`~crisp.graph.Graph` and :meth:`Graph.computeCriticalPath`.
 
 Drag measures, for a node on the critical path, how much its duration could
 shrink before it stops being the limiting factor for its parent's/ancestors'
 timing. It is capped at the node's own duration (or exclusive duration, in
 exclusive mode): a node can never have "negative existence", so drag can
 never exceed how much time the node itself contributes.
+
+Slack measures, for any node, how much scheduling room it has: the gap
+between the earliest it could have started (without violating any inferred
+happens-before ordering among its siblings) and the latest it could have
+started while still finishing by its critical-path boundary. Critical-path
+nodes always have zero slack -- they're already the bottleneck.
 
 IMPORTANT -- correctness note (why this isn't a straight copy of calligator):
 calligator's ``calculate_drag`` assumes that for a node at index ``i`` in the
@@ -35,6 +43,11 @@ recurse into -- regardless of whether the node arrived in the flat list as
 its parent's primary or secondary/chained pick). When a node has no
 children, there is no child term to net out at all.
 
+``calculate_slack`` never had this hazard: it always resolves parent/sibling
+via ``node.parent``/``parent.children`` directly, never via ``cp`` position
+(see
+``test_naive_index_adjacency_would_misreport_chained_sibling_dependent_slack``).
+
 See also :meth:`Graph.accumeCPMetrics`, this codebase's own existing
 "exclusive critical-path time per node" primitive, which already computes an
 equivalent quantity to calligator's ``_get_exclusive_cp_time`` (and already
@@ -46,6 +59,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from crisp.dependency_graph import DependencyGraph
 from crisp.utils.dict_utils import accumulateInDict
 
 if TYPE_CHECKING:
@@ -201,3 +215,198 @@ def calculate_drag(graph: Graph, cp: list[GraphNode], exclusive: bool = False) -
 
     total_drag = sum(drag_per_span.values())
     return Drag(drag_per_span, total_drag)
+
+
+@dataclass(frozen=True)
+class Slack:
+    """Slack for every node in a graph.
+
+    Contrast with :class:`Drag`: ``drag_per_span`` only has entries for
+    critical-path nodes; ``slack_per_span`` covers *every* node in the graph,
+    with an explicit ``0.0`` for critical-path nodes (matches calligator's
+    own ``calculate_slack``). Callers can safely index
+    ``slack_per_span[sid]`` directly for any span id -- no ``.get(sid, 0.0)``
+    fallback needed (unlike ``Drag.drag_per_span``).
+
+    Attributes:
+        slack_per_span: mapping from span id to that node's slack -- the gap
+            between the earliest it could have started (without violating
+            any inferred happens-before ordering among its siblings) and the
+            latest it could have started while still finishing by its
+            critical-path boundary. Critical-path nodes (and thus the root)
+            are exactly ``0.0``.
+        total_slack: ``sum(slack_per_span.values())``.
+    """
+
+    slack_per_span: dict[str, float]
+    total_slack: float
+
+
+def _critical_end_times(graph: Graph, cp: list[GraphNode]) -> dict[str, float]:
+    """Compute each node's "critical end time": the endTime ceiling it must respect.
+
+    For a critical-path node, this is its own endTime. For a true sibling of
+    a critical-path node that ends earlier, this is that critical-path
+    node's endTime (the sibling could run later, up to that boundary,
+    without becoming the new bottleneck). Every other node falls back to its
+    immediate parent's endTime.
+
+    Args:
+        graph: the trace's Graph that ``cp`` was computed from.
+        cp: the critical path, as returned by ``Graph.findCriticalPath()``.
+
+    Returns:
+        A mapping from span id (for every node in ``graph.nodeHT``) to its
+        critical end time.
+    """
+    critical_end_times: dict[str, float] = {}
+    for node in cp:
+        critical_end_times[node.sid] = node.endTime
+
+        parent = node.parent
+        if parent is not None:
+            for sibling in parent.children:
+                if sibling.endTime < node.endTime:
+                    critical_end_times[sibling.sid] = node.endTime
+
+    for sid, node in graph.nodeHT.items():
+        if sid not in critical_end_times:
+            parent = node.parent
+            critical_end_times[sid] = parent.endTime if parent is not None else node.endTime
+
+    return critical_end_times
+
+
+def _compute_earliest_start_time(
+    node: GraphNode,
+    earliest_start_times: dict[str, float],
+    dependency_graph: DependencyGraph,
+    graph: Graph,
+) -> None:
+    """Compute the earliest ``node`` could start without violating happens-before.
+
+    Without any inferred happens-before constraint, a node's true siblings
+    are assumed schedulable in any order, so the earliest it could have
+    started is the earliest start time among all of them. If ``node`` does
+    have a happens-before constraint (from ``dependency_graph``), its
+    earliest start is instead the ``endTime`` of the *last* true sibling
+    that both (a) shares a call-path name in ``node``'s happens-before set,
+    and (b) genuinely finished (by real timestamp comparison, never by
+    name-membership alone) before ``node`` started.
+
+    ``happens_before`` can legitimately contain ``node``'s own call-path name
+    (a parent fanning out to the same call-path more than once in series --
+    see ``dependency_graph.py``). This is handled correctly: siblings are
+    only considered up to (not including) ``node`` itself in start-time
+    order, so an earlier same-call-path instance can still match while
+    ``node`` never spuriously matches itself.
+
+    Args:
+        node: the node to compute an earliest start time for.
+        earliest_start_times: mapping from span id to earliest start time,
+            updated in place with ``node``'s entry.
+        dependency_graph: dependency info keyed by call-path name (see
+            ``DependencyGraph.deps``), used to look up ``node``'s
+            happens-before set.
+        graph: the trace's Graph that ``node`` belongs to (needed for
+            ``Graph.getCallPath``, the same key function ``dependency_graph``
+            itself is keyed by).
+    """
+    parent = node.parent
+    if parent is None:
+        earliest_start_times[node.sid] = node.startTime
+        return
+
+    siblings = sorted(parent.children, key=lambda s: s.startTime)
+    if node not in siblings:
+        return
+
+    first_sibling_start_time = siblings[0].startTime
+
+    dep_node = dependency_graph.deps.get(graph.getCallPath(node))
+    happens_before = dep_node.happens_before if dep_node is not None else set()
+
+    if not happens_before:
+        earliest_start_times[node.sid] = first_sibling_start_time
+        return
+
+    previous_happens_before_node = None
+    for sibling in siblings:
+        if sibling.sid == node.sid:
+            break
+        if graph.getCallPath(sibling) in happens_before and sibling.endTime < node.startTime:
+            previous_happens_before_node = sibling
+
+    earliest_start_times[node.sid] = previous_happens_before_node.endTime if previous_happens_before_node is not None else first_sibling_start_time
+
+
+def _compute_latest_start_time(
+    node: GraphNode,
+    latest_start_times: dict[str, float],
+    critical_end_times: dict[str, float],
+) -> None:
+    """Compute the latest ``node`` could start while still meeting its critical end time.
+
+    This is the scenario where ``node`` finishes right at the boundary that
+    ``critical_end_times`` assigns it: starting any later would push its own
+    endTime past that boundary.
+
+    Args:
+        node: the node to compute a latest start time for.
+        latest_start_times: mapping from span id to latest start time,
+            updated in place with ``node``'s entry.
+        critical_end_times: each node's endTime ceiling, from
+            ``_critical_end_times``.
+    """
+    if node.sid not in latest_start_times:
+        latest_start_times[node.sid] = critical_end_times[node.sid] - node.duration
+
+
+def calculate_slack(
+    graph: Graph,
+    cp: list[GraphNode],
+    dependency_graph: DependencyGraph | None = None,
+) -> Slack:
+    """Calculate slack for every node in ``graph``.
+
+    Slack is the gap between the earliest a node could have started (without
+    violating any inferred happens-before ordering among its true siblings)
+    and the latest it could have started while still finishing by its
+    critical-path boundary -- how much scheduling room it has before it'd
+    become (part of) the new bottleneck. Nodes on ``cp`` have zero slack by
+    construction; see ``Slack.slack_per_span`` for the full key contract.
+
+    Args:
+        graph: the trace's Graph that ``cp`` was computed from.
+        cp: the critical path, as returned by ``Graph.findCriticalPath()``.
+        dependency_graph: optional pre-built dependency info (see
+            ``dependency_graph.py``). If None, one is built internally via
+            ``DependencyGraph(graph=graph)``. A multi-trace aggregate (built
+            via ``DependencyGraph(graphs=[...])``) is also accepted as a
+            drop-in -- this function only ever reads
+            ``dependency_graph.deps[name].happens_before``.
+
+    Returns:
+        A Slack with one entry per node in ``graph.nodeHT``.
+    """
+    if dependency_graph is None:
+        dependency_graph = DependencyGraph(graph=graph)
+
+    critical_end_times = _critical_end_times(graph, cp)
+
+    earliest_start_times: dict[str, float] = {}
+    latest_start_times: dict[str, float] = {}
+    for node in graph.nodeHT.values():
+        _compute_earliest_start_time(node, earliest_start_times, dependency_graph, graph)
+        _compute_latest_start_time(node, latest_start_times, critical_end_times)
+
+    cp_nodes = set(cp)
+    slack_per_span: dict[str, float] = {}
+    for node in graph.nodeHT.values():
+        if node not in cp_nodes and node.sid in latest_start_times and node.sid in earliest_start_times:
+            slack_per_span[node.sid] = latest_start_times[node.sid] - earliest_start_times[node.sid]
+        else:
+            slack_per_span[node.sid] = 0.0
+
+    total_slack = sum(slack_per_span.values())
+    return Slack(slack_per_span, total_slack)

--- a/tests/test_slack_drag.py
+++ b/tests/test_slack_drag.py
@@ -6,7 +6,14 @@ import pytest
 
 from crisp.graph import Graph, GraphNode
 from crisp.shared.models import SpanKind
-from crisp.slack_drag import Drag, calculate_drag, _exclusive_cp_time
+from crisp.dependency_graph import DependencyGraph
+from crisp.slack_drag import (
+    Drag,
+    Slack,
+    calculate_drag,
+    calculate_slack,
+    _exclusive_cp_time,
+)
 
 
 def _span(span_id, op, pid, start, duration, parent_id=None):
@@ -208,6 +215,93 @@ def branch_with_noncritical_sibling_graph():
         _span("B", "OB", "S2", 0, 50, parent_id="R"),
     ]
     return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "OR")
+
+
+# --- Fixtures for calculate_slack. ---
+
+
+# Same shape as sequential_siblings_with_slight_overlap_graph() (R -> A, B, C
+# chaining onto cp = [R, C, B, A]) plus a 4th sibling D that stays off the
+# critical path. D has a real happens_before dependency on A (A ends at 200,
+# well before D starts at 250), and its critical_end_time ceiling should come
+# from B's real endTime (400) via R.children -- not from whatever cp[i - 1]
+# happens to be when B is visited (see
+# test_naive_index_adjacency_would_misreport_chained_sibling_dependent_slack).
+def sequential_siblings_with_dependent_off_cp_sibling_graph():
+    spans = [
+        _span("R", "OR", "S1", 0, 1000),
+        _span("A", "OA", "S2", 0, 200, parent_id="R"),
+        _span("B", "OB", "S2", 195, 205, parent_id="R"),
+        _span("C", "OC", "S2", 500, 500, parent_id="R"),
+        _span("D", "OD", "S2", 250, 130, parent_id="R"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "OR")
+
+
+# R -> N (off cp, runs 400-520, overlaps TAIL's start by 2% -- past tolerance --
+# so never joins cp) and R -> TAIL (on cp, runs 500-1000, ends exactly when R
+# does). N is the earliest-starting sibling with no happens_before constraint, so
+# its earliest possible start is its own actual start (400) -- no banked slack.
+# Its critical_end_time is inherited from TAIL via R.children, and TAIL ends
+# exactly at R's endTime (1000), making this a tight boundary for the cross-check
+# in test_extending_leaf_by_exactly_its_slack_reaches_root_endtime_boundary.
+def leaf_slack_capped_by_root_endtime_via_sibling_graph():
+    spans = [
+        _span("R", "OR", "S1", 0, 1000),
+        _span("N", "ON", "S2", 400, 120, parent_id="R"),
+        _span("TAIL", "OT", "S2", 500, 500, parent_id="R"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "OR")
+
+
+# R -> P -> N, and R -> C. P runs 0-1000 (P.endTime == R.endTime exactly) with
+# its only child N running 10-800. C runs 900-1000, tied with P on endTime but
+# wins the tie-break (inserted after P; computeCriticalPath's stable sort favors
+# it), so P stays off cp: cp = [R, C]. N, as P's only child, has no competing
+# sibling, so its earliest possible start is trivially its own actual start (10).
+# Since N's parent (P) isn't a cp node, N's critical_end_time falls to the
+# "inherit my parent's own endTime" fallback -- and P's endTime happens to equal
+# R's (1000), giving a tight boundary bounded purely by "parent's endTime, no
+# competing sibling" (contrast with the sibling-gap-bounded fixture above).
+def leaf_slack_capped_by_root_endtime_via_nested_only_child_graph():
+    spans = [
+        _span("R", "OR", "S1", 0, 1000),
+        _span("P", "OP", "S2", 0, 1000, parent_id="R"),
+        _span("N", "ON", "S3", 10, 790, parent_id="P"),
+        _span("C", "OC", "S2", 900, 100, parent_id="R"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2", "S3": "S3"}, "S1", "OR")
+
+
+# R -> A (runs 0-100), R -> B (runs 300-750, depends on A), R -> D (runs
+# 700-1000, on cp as R's last-running child). B overlaps D's tail by 5% (past
+# tolerance), so B never joins cp. A's real happens_before predecessor
+# relationship with B (DependencyGraph checks all sibling pairs, not just
+# cp-adjacent ones) makes B's earliest possible start A's endTime (100), not the
+# naive "earliest of any sibling's start" fallback (which would be A's own
+# start, 0).
+def happens_before_chain_constrains_sibling_slack_graph():
+    spans = [
+        _span("R", "OR", "S1", 0, 1000),
+        _span("A", "OA", "S2", 0, 100, parent_id="R"),
+        _span("B", "OB", "S3", 300, 450, parent_id="R"),
+        _span("D", "OD", "S4", 700, 300, parent_id="R"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2", "S3": "S3", "S4": "S4"}, "S1", "OR")
+
+
+# P -> B1, B2 (two instances of the same call-path "Ob") and P -> C (on cp,
+# spans all of P, 0-1000). B1 runs 0-100; B2 runs 200-300 (off cp). Since B1 (an
+# earlier instance of "Ob") finishes before B2 starts, DependencyGraph records a
+# self-referential happens_before edge for "Ob" (see dependency_graph.py).
+def fanout_same_callpath_off_cp_graph():
+    spans = [
+        _span("P", "OP", "S1", 0, 1000),
+        _span("B1", "Ob", "S2", 0, 100, parent_id="P"),
+        _span("B2", "Ob", "S2", 200, 100, parent_id="P"),
+        _span("C", "Oc", "S3", 0, 1000, parent_id="P"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2", "S3": "S3"}, "S1", "OP")
 
 
 def _load_test_case(filename):
@@ -547,3 +641,328 @@ def test_drag_dataclass_is_frozen():
     drag = Drag(drag_per_span={"A": 1.0}, total_drag=1.0)
     with pytest.raises(AttributeError):
         drag.total_drag = 2.0
+
+
+# ============================================================================
+# calculate_slack tests.
+# ============================================================================
+
+
+# --- Every critical-path node has zero slack. ---
+
+
+def test_every_critical_path_node_has_zero_slack_on_a_linear_chain():
+    g = linear_chain_graph()
+    cp = g.findCriticalPath()
+    slack = calculate_slack(g, cp)
+
+    for node in cp:
+        assert slack.slack_per_span[node.sid] == 0
+
+
+def test_every_critical_path_node_has_zero_slack_on_a_branching_graph():
+    g = sequential_siblings_with_slight_overlap_graph()
+    cp = g.findCriticalPath()
+    assert [n.sid for n in cp] == ["R", "C", "B", "A"]
+
+    slack = calculate_slack(g, cp)
+
+    for node in cp:
+        assert slack.slack_per_span[node.sid] == 0
+
+
+# --- The rigorous "slack is a tight boundary" cross-check. ---
+
+
+def test_extending_leaf_by_exactly_its_slack_reaches_but_never_exceeds_root_endtime_via_sibling_gap():
+    g = leaf_slack_capped_by_root_endtime_via_sibling_graph()
+    cp = g.findCriticalPath()
+    assert [n.sid for n in cp] == ["R", "TAIL"]
+
+    slack = calculate_slack(g, cp)
+    n_node = g.nodeHT["N"]
+    assert n_node.children == {}
+    assert slack.slack_per_span["N"] > 0
+    root_end_time = g.rootNode.endTime
+
+    n_node.duration += slack.slack_per_span["N"]
+    n_node.endTime = n_node.startTime + n_node.duration
+    assert n_node.endTime <= root_end_time
+
+
+def test_extending_leaf_by_one_more_than_its_slack_exceeds_root_endtime_via_sibling_gap():
+    g = leaf_slack_capped_by_root_endtime_via_sibling_graph()
+    cp = g.findCriticalPath()
+    slack = calculate_slack(g, cp)
+    n_node = g.nodeHT["N"]
+    root_end_time = g.rootNode.endTime
+
+    n_node.duration += slack.slack_per_span["N"] + 1
+    n_node.endTime = n_node.startTime + n_node.duration
+    assert n_node.endTime > root_end_time
+
+
+def test_extending_leaf_by_exactly_its_slack_reaches_but_never_exceeds_root_endtime_via_nested_only_child():
+    g = leaf_slack_capped_by_root_endtime_via_nested_only_child_graph()
+    cp = g.findCriticalPath()
+    assert [n.sid for n in cp] == ["R", "C"]
+
+    slack = calculate_slack(g, cp)
+    n_node = g.nodeHT["N"]
+    assert n_node.children == {}
+    assert len(n_node.parent.children) == 1  # no competing sibling at N's own level.
+    assert slack.slack_per_span["N"] > 0
+    root_end_time = g.rootNode.endTime
+
+    n_node.duration += slack.slack_per_span["N"]
+    n_node.endTime = n_node.startTime + n_node.duration
+    assert n_node.endTime <= root_end_time
+
+
+def test_extending_leaf_by_one_more_than_its_slack_exceeds_root_endtime_via_nested_only_child():
+    g = leaf_slack_capped_by_root_endtime_via_nested_only_child_graph()
+    cp = g.findCriticalPath()
+    slack = calculate_slack(g, cp)
+    n_node = g.nodeHT["N"]
+    root_end_time = g.rootNode.endTime
+
+    n_node.duration += slack.slack_per_span["N"] + 1
+    n_node.endTime = n_node.startTime + n_node.duration
+    assert n_node.endTime > root_end_time
+
+
+# --- happens_before chain constrains a sibling's slack. ---
+
+
+def test_happens_before_chain_constrains_sibling_slack_tighter_than_naive_sibling_gap():
+    g = happens_before_chain_constrains_sibling_slack_graph()
+    cp = g.findCriticalPath()
+
+    # B overlaps D's start by 5% (past tolerance), so it never joins cp -- it's
+    # the one node whose slack we're testing.
+    assert "B" not in [n.sid for n in cp]
+
+    dep = DependencyGraph(graph=g)
+    b_name = g.getCallPath(g.nodeHT["B"])
+    a_name = g.getCallPath(g.nodeHT["A"])
+    assert dep.deps[b_name].happens_before == {a_name}
+
+    slack = calculate_slack(g, cp, dep)
+
+    a_node = g.nodeHT["A"]
+    # B's earliest possible start is A's real endTime (100), not the naive
+    # "earliest of any sibling's start" fallback (which would use A's start, 0).
+    assert slack.slack_per_span["B"] == 450
+
+    naive_slack_ignoring_happens_before = slack.slack_per_span["B"] + (a_node.endTime - a_node.startTime)
+    assert naive_slack_ignoring_happens_before == 550
+    assert slack.slack_per_span["B"] != naive_slack_ignoring_happens_before
+
+
+# --- Same-call-path fanout: self-referential happens_before. ---
+
+
+def test_fanout_same_callpath_second_instance_uses_real_predecessor_span_not_bare_name_match():
+    g = fanout_same_callpath_off_cp_graph()
+    cp = g.findCriticalPath()
+    assert [n.sid for n in cp] == ["P", "C"]
+
+    dep = DependencyGraph(graph=g)
+    ob_name = g.getCallPath(g.nodeHT["B1"])
+    assert g.getCallPath(g.nodeHT["B2"]) == ob_name
+    # Self-referential edge: an earlier instance of the same call-path ("Ob")
+    # is recorded as happening before it.
+    assert dep.deps[ob_name].happens_before == {ob_name}
+
+    slack = calculate_slack(g, cp, dep)
+
+    # B1 is the earlier instance: nothing precedes it, so it falls back to the
+    # "earliest sibling start" rule -- it never spuriously matches itself, since
+    # the search breaks at B1's own span id before comparing against itself.
+    assert slack.slack_per_span["B1"] == 900
+
+    # B2's earliest possible start correctly uses B1's real endTime (100), not
+    # a bare name-membership match against its own call-path name.
+    assert slack.slack_per_span["B2"] == 800
+    assert slack.slack_per_span["B2"] != slack.slack_per_span["B1"]
+
+
+# --- Regression: node.parent/node.children, never cp list-adjacency. ---
+
+
+def test_naive_index_adjacency_would_misreport_chained_sibling_dependent_slack():
+    g = sequential_siblings_with_dependent_off_cp_sibling_graph()
+    cp = g.findCriticalPath()
+
+    # Same chained-sibling shape as the drag regression fixture, plus a 4th
+    # off-cp sibling D with a real happens_before dependency on A.
+    assert [n.sid for n in cp] == ["R", "C", "B", "A"]
+    d_node = g.nodeHT["D"]
+    assert d_node.sid not in [n.sid for n in cp]
+
+    dep = DependencyGraph(graph=g)
+    d_name = g.getCallPath(d_node)
+    a_name = g.getCallPath(g.nodeHT["A"])
+    assert dep.deps[d_name].happens_before == {a_name}
+
+    slack = calculate_slack(g, cp, dep)
+
+    # The naive (buggy) computation: a cp[i - 1]-based "parent" for B would be
+    # the leaf C, so D never gets updated via B's inheritance step, leaving
+    # D's critical_end_time at R's (coincidentally correct for C, but not B): 1000.
+    naive_critical_end_time_for_d = g.rootNode.endTime
+    naive_latest_start = naive_critical_end_time_for_d - d_node.duration
+    a_node = g.nodeHT["A"]
+    earliest_start_for_d = a_node.endTime  # unaffected by the cp-adjacency bug.
+    naive_slack = naive_latest_start - earliest_start_for_d
+    assert naive_slack == 670
+
+    # The correct computation, using D's real parent (R) and real siblings,
+    # finds B's real endTime (400) -- not C's (1000) -- as D's tightest cap.
+    assert slack.slack_per_span["D"] == 70
+    assert slack.slack_per_span["D"] != naive_slack
+
+
+# --- Default dependency_graph=None builds one internally. ---
+
+
+def test_default_dependency_graph_matches_explicit_prebuilt_one():
+    g = sequential_siblings_with_slight_overlap_graph()
+    cp = g.findCriticalPath()
+
+    via_default = calculate_slack(g, cp)
+    via_explicit = calculate_slack(g, cp, dependency_graph=DependencyGraph(graph=g))
+
+    assert via_default.slack_per_span == via_explicit.slack_per_span
+    assert via_default.total_slack == via_explicit.total_slack
+
+
+# --- Accepts a multi-trace aggregate DependencyGraph. ---
+
+
+def test_accepts_multi_trace_aggregate_dependency_graph_without_erroring():
+    g = sequential_siblings_with_slight_overlap_graph()
+    cp = g.findCriticalPath()
+    aggregate = DependencyGraph(graphs=[g, g])
+
+    slack = calculate_slack(g, cp, dependency_graph=aggregate)
+
+    assert set(slack.slack_per_span.keys()) == set(g.nodeHT.keys())
+    for node in cp:
+        assert slack.slack_per_span[node.sid] == 0
+    assert slack.total_slack == sum(slack.slack_per_span.values())
+
+
+# --- Root node slack. ---
+
+
+def test_root_node_always_has_zero_slack():
+    for fixture in (
+        linear_chain_graph,
+        sequential_siblings_with_slight_overlap_graph,
+        branch_with_noncritical_sibling_graph,
+    ):
+        g = fixture()
+        cp = g.findCriticalPath()
+        slack = calculate_slack(g, cp)
+        assert slack.slack_per_span[g.rootNode.sid] == 0
+
+
+# --- total_slack correctness. ---
+
+
+def test_total_slack_equals_sum_of_slack_per_span_values():
+    g = happens_before_chain_constrains_sibling_slack_graph()
+    cp = g.findCriticalPath()
+    slack = calculate_slack(g, cp)
+
+    assert slack.total_slack == sum(slack.slack_per_span.values())
+
+
+# --- slack_per_span covers every node (contrast with Drag's key-omission). ---
+
+
+def test_non_critical_path_node_is_present_in_slack_per_span_unlike_drag():
+    g = branch_with_noncritical_sibling_graph()
+    cp = g.findCriticalPath()
+    assert [n.sid for n in cp] == ["R", "A"]
+
+    slack = calculate_slack(g, cp)
+
+    # Unlike Drag.drag_per_span (which omits "B" entirely -- see
+    # test_non_critical_path_node_is_omitted_from_drag_per_span above), "B" IS
+    # a key here, with a real, non-negative value.
+    assert "B" in slack.slack_per_span
+    assert slack.slack_per_span["B"] >= 0
+    assert slack.slack_per_span["B"] == 350
+
+    # Every node in nodeHT gets a slack_per_span entry, not just cp members.
+    assert set(slack.slack_per_span.keys()) == set(g.nodeHT.keys())
+
+
+# --- Graph.calculateSlack() hook. ---
+
+
+def test_graph_calculate_slack_hook_matches_direct_module_call():
+    g = happens_before_chain_constrains_sibling_slack_graph()
+    cp = g.findCriticalPath()
+    dep = DependencyGraph(graph=g)
+
+    via_hook = g.calculateSlack(cp, dependency_graph=dep)
+    via_module = calculate_slack(g, cp, dep)
+
+    assert via_hook.slack_per_span == via_module.slack_per_span
+    assert via_hook.total_slack == via_module.total_slack
+
+
+def test_graph_calculate_slack_hook_defaults_cp_and_dependency_graph():
+    g = happens_before_chain_constrains_sibling_slack_graph()
+
+    via_default = g.calculateSlack()
+    via_explicit = calculate_slack(g, g.findCriticalPath())
+
+    assert via_default.slack_per_span == via_explicit.slack_per_span
+    assert via_default.total_slack == via_explicit.total_slack
+    # Sanity: this isn't just two empty dicts matching each other.
+    assert via_default.slack_per_span
+
+
+# --- Realistic fixtures from test_cases/*.json. ---
+
+
+def test_realistic_fixtures_every_node_has_nonnegative_slack_and_cp_nodes_are_zero():
+    for filename in ("1.json", "5.json"):
+        g = _load_test_case(filename)
+        assert g.rootNode is not None
+        cp = g.findCriticalPath()
+
+        slack = calculate_slack(g, cp)
+
+        assert set(slack.slack_per_span.keys()) == set(g.nodeHT.keys())
+        for sid, value in slack.slack_per_span.items():
+            assert value >= 0, f"expected non-negative slack for {sid}, got {value}"
+
+        for node in cp:
+            assert slack.slack_per_span[node.sid] == 0
+
+
+# --- General API contract sanity. ---
+
+
+def test_calculate_slack_is_pure_and_deterministic():
+    g = sequential_siblings_with_slight_overlap_graph()
+    cp = g.findCriticalPath()
+    durations_before = {sid: node.duration for sid, node in g.nodeHT.items()}
+
+    first = calculate_slack(g, cp)
+    second = calculate_slack(g, cp)
+
+    assert first.slack_per_span == second.slack_per_span
+    assert first.total_slack == second.total_slack
+    assert {sid: node.duration for sid, node in g.nodeHT.items()} == durations_before
+
+
+def test_slack_dataclass_is_frozen():
+    slack = Slack(slack_per_span={"A": 1.0}, total_slack=1.0)
+    with pytest.raises(AttributeError):
+        slack.total_slack = 2.0


### PR DESCRIPTION
## Summary
Ports `calculate_slack` from calligator's `CriticalPath` (the sibling primitive to the drag calculation already in `crisp/slack_drag.py`), giving every node in a trace's graph a measure of how much scheduling room it has before it would become part of the new critical-path bottleneck. Nodes on the critical path always have zero slack.

A node's earliest possible start is the earliest start time among its true siblings, tightened using inferred happens-before ordering (via the existing `DependencyGraph`) when one sibling is known to always finish before another. Its latest possible start is derived from a "critical end time" ceiling: its own end time if it's on the critical path, its critical-path sibling's end time if it's an off-path sibling that ends earlier, or its parent's end time otherwise. As with drag, all of this is resolved through `node.parent`/`parent.children` directly rather than critical-path list adjacency, since `Graph.computeCriticalPath` can chain multiple siblings of the same parent back-to-back in the flat list.

Adds a new `Slack` dataclass (`slack_per_span`, `total_slack`) and a `Graph.calculateSlack()` hook alongside the existing `calculateDrag()`.

## What's included
- `crisp/slack_drag.py`: `Slack` dataclass, `_critical_end_times`, `_compute_earliest_start_time`, `_compute_latest_start_time`, `calculate_slack()`, and an updated module docstring covering both drag and slack.
- `crisp/graph.py`: `Graph.calculateSlack()`, mirroring the existing `calculateDrag()` hook.
- `tests/test_slack_drag.py`: new fixtures and tests covering zero-slack critical-path nodes, tight-boundary cross-checks (extending a leaf by exactly its slack reaches but never exceeds its ceiling), happens-before-constrained sibling slack, self-referential same-call-path fanout, the list-adjacency regression, default/explicit `DependencyGraph` handling, and realistic fixture sanity checks.
- `crisp/BUILD.bazel` / `BUILD.bazel`: wired `//crisp:dependency_graph` as a dep of `//crisp:slack_drag` and `//:test_slack_drag`. Also dropped the `dependency_graph → graph` edge in `crisp/BUILD.bazel`, since it only existed for a `TYPE_CHECKING`-only import that's never evaluated at runtime (the file uses `from __future__ import annotations`) — keeping it would have created a real Bazel dependency cycle now that `slack_drag` (a dep of `graph`) also depends on `dependency_graph`.

## Test Plan
- `bazel test //...`: 31/31 test targets pass.
- `pytest`: 493 passed (pre-existing, unrelated `psutil`/`tenacity` collection errors on `main` confirmed present before this change too).
- `ruff check`: clean.