### PR TITLE
feat: Add --computeSlackDrag CLI flag and per-call-path drag/slack CSV

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -292,6 +292,7 @@ py_test(
     srcs = ["tests/output/test_csv_generators.py"],
     main = "tests/output/test_csv_generators.py",
     deps = [
+        "//crisp:slack_drag",
         "//crisp/output:output",
         "//crisp/shared:shared",
         "@pypi//pandas",

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -185,6 +185,7 @@ py_library(
         "//crisp:flamegraph",
         "//crisp:graph",
         "//crisp:pkg",
+        "//crisp:slack_drag",
         "//crisp:storage",
         "//crisp/metrics:metrics",
         "//crisp/output:output",

--- a/crisp/common.py
+++ b/crisp/common.py
@@ -47,6 +47,7 @@ SAVING_POTENTIAL_CSV = "savingPotential.csv"
 PER_TRACE_ERR_INFO_CSV = "perTraceErrInfo.csv"
 CYCLES_CSV = "cycles.csv"
 CROSS_REGION_CALLS_CSV = "crossRegionCalls.csv"
+SLACK_DRAG_CSV = "slackDrag.csv"
 
 # various header names used in generated CSV files
 PRORP_TO_ROOT = "PropToRoot"
@@ -163,6 +164,7 @@ class Config:
         lightMode: bool = False,
         mergeAllRoots: bool = True,
         maxExemplars: int = 3,
+        computeSlackDrag: bool = False,
     ):
         self.operationName = operationName
         self.serviceName = serviceName
@@ -209,6 +211,7 @@ class Config:
         self.lightMode = lightMode
         self.mergeAllRoots = mergeAllRoots
         self.maxExemplars = maxExemplars
+        self.computeSlackDrag = computeSlackDrag
         # Compute the start and end UTC times for trace query.
         initialTimeStamp = getMidnightTimeStamp() if self.useMidnightTime else time.time() * 1000 * 1000
         self.startTimestamp = int(initialTimeStamp - (self.lookbackDays * 24 * 60 * 60) * 1000 * 1000) if not startTimestamp else startTimestamp

--- a/crisp/output/csv_generators.py
+++ b/crisp/output/csv_generators.py
@@ -236,6 +236,40 @@ def genCyclesCSVFile(metrics, c, filename=None):
     return cyclesCSVFile
 
 
+def genSlackDragCSVFile(perMethodSlackDrag, c, filename=None):
+    """Generate per-call-path Drag/Slack CSV file, sorted by descending average drag."""
+    outputDir = c.getOutputDir()
+    slackDragCSVFile = os.path.join(outputDir, filename or "slackDrag.csv")
+    columns = ["callPath", "spanCount", "avgDrag", "totalDrag", "avgSlack", "totalSlack"]
+
+    if not perMethodSlackDrag:
+        logging.info("No slack/drag data found")
+        return None
+
+    logging.info(
+        "Producing [%s]%s slack/drag csv file %s",
+        c.serviceName,
+        c.operationName,
+        slackDragCSVFile,
+    )
+    rows = [
+        [
+            agg.call_path,
+            agg.span_count,
+            agg.avg_drag,
+            agg.total_drag,
+            agg.avg_slack,
+            agg.total_slack,
+        ]
+        for agg in perMethodSlackDrag.values()
+    ]
+    df = pd.DataFrame(rows, columns=columns)
+    df = df.sort_values(by="avgDrag", ascending=False).reset_index(drop=True)
+    df.to_csv(slackDragCSVFile, index=False)
+
+    return slackDragCSVFile
+
+
 def genCrossRegionCallsCSVFile(metrics, c, filename=None):
     """Generate cross-region calls CSV file."""
     # Note: This function needs access to os and logging at runtime

--- a/crisp/process_trace.py
+++ b/crisp/process_trace.py
@@ -37,12 +37,14 @@ from crisp.output.csv_generators import (
     genCrossRegionCallsCSVFile,
     genCyclesCSVFile,
     genHypoLatencyCSVFile,
+    genSlackDragCSVFile,
     genSummaryCSVFile,
 )
 from crisp.output.formatters import makeClickable, renameSortableIcon
 from crisp.shared.constants import JAEGER_UI_URL
 from crisp.shared.models import LatencyData, QuantizedMetrics, SavingData
 from crisp.shared.utils import getLeafNodeFromCallPath
+from crisp.slack_drag import aggregate_drag_slack_by_callpath, merge_per_method_slack_drag
 
 
 logging.basicConfig(
@@ -363,6 +365,18 @@ def initArgs():
     )
 
     argParser.add_argument(
+        "--computeSlackDrag",
+        dest="computeSlackDrag",
+        action="store_true",
+        default=False,
+        required=False,
+        help=(
+            "Compute per-method Drag/Slack (see slack_drag.py) and emit a slackDrag.csv "
+            "output file (default=false). Opt-in: when not set, output is unchanged."
+        ),
+    )
+
+    argParser.add_argument(
         "--deltaTargetService",
         dest="deltaTargetService",
         action="store",
@@ -431,6 +445,7 @@ def initArgs():
     deltaTargetOperation = args.deltaTargetOperation
     lightMode = args.lightMode
     maxExemplars = args.maxExemplars
+    computeSlackDrag = args.computeSlackDrag
     jaegerTraceFiles = glob.glob(os.path.join(tracesDir, "*.json"))
 
     if args.file:
@@ -466,6 +481,7 @@ def initArgs():
         mergeAllRoots=args.mergeAllRoots,
         maxExemplars=maxExemplars,
         jaegerQueryUrl=args.jaegerQueryUrl,
+        computeSlackDrag=computeSlackDrag,
     )
     c.jaegerTraceFiles = jaegerTraceFiles
     c.outputDir = args.outputDir if args.outputDir else tracesDir
@@ -630,6 +646,11 @@ def process(filename: str, config: common.Config) -> Any:
         timeSavedOnCPAllSeries,
         {},
     )
+
+    if config.computeSlackDrag and metrics:
+        drag = graph.calculateDrag(cp=criticalPath)
+        slack = graph.calculateSlack(cp=criticalPath)
+        metrics.slackDragPerCallPath = aggregate_drag_slack_by_callpath(graph, drag, slack)
 
     logging.debug("critical path: %s", criticalPath)
     cpp = metrics.CPMetrics.profile if metrics.CPMetrics else {}
@@ -2074,6 +2095,13 @@ def performCriticalPathAnalysis(c: common.Config) -> int:
     cyclesCSVFile = genCyclesCSVFile(metrics, c, filename=common.CYCLES_CSV)
     logging.info("Starting genCrossRegionCallsCSVFile")
     crossRegionCallsCSVFile = genCrossRegionCallsCSVFile(metrics, c, filename=common.CROSS_REGION_CALLS_CSV)
+
+    slackDragCSVFile = None
+    if c.computeSlackDrag:
+        logging.info("Starting genSlackDragCSVFile")
+        mergedSlackDragPerCallPath = merge_per_method_slack_drag(m.slackDragPerCallPath for m in metrics if m.slackDragPerCallPath)
+        slackDragCSVFile = genSlackDragCSVFile(mergedSlackDragPerCallPath, c, filename=common.SLACK_DRAG_CSV)
+
     logging.info("Starting genHypoLatencyCSVFile")
     hypoLatencyCSVFile = genHypoLatencyCSVFile(headLatencyPercentile, hypoLatencyPercentile, c)
 
@@ -2105,6 +2133,8 @@ def performCriticalPathAnalysis(c: common.Config) -> int:
         c.filesToUpload.append(cyclesCSVFile)
     if crossRegionCallsCSVFile:
         c.filesToUpload.append(crossRegionCallsCSVFile)
+    if slackDragCSVFile:
+        c.filesToUpload.append(slackDragCSVFile)
     logMetrics(c, metrics, fg)
     return 0
 

--- a/crisp/shared/models.py
+++ b/crisp/shared/models.py
@@ -429,6 +429,7 @@ class Metrics:
         projectedLatency=None,
         isIncomplete=False,
         isSubtreeIncomplete=False,
+        slackDragPerCallPath=None,
     ):
         self.traceID = traceID
         self.CPMetrics = CPMetrics
@@ -461,3 +462,5 @@ class Metrics:
         self.projectedLatency = projectedLatency
         self.isIncomplete = isIncomplete
         self.isSubtreeIncomplete = isSubtreeIncomplete
+        # Per-call-path Drag/Slack aggregate, set only when --computeSlackDrag is enabled.
+        self.slackDragPerCallPath = slackDragPerCallPath

--- a/crisp/slack_drag.py
+++ b/crisp/slack_drag.py
@@ -63,6 +63,8 @@ from crisp.dependency_graph import DependencyGraph
 from crisp.utils.dict_utils import accumulateInDict
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from crisp.graph import Graph, GraphNode
 
 
@@ -410,3 +412,101 @@ def calculate_slack(
 
     total_slack = sum(slack_per_span.values())
     return Slack(slack_per_span, total_slack)
+
+
+@dataclass(frozen=True)
+class PerMethodSlackDrag:
+    """Drag and slack aggregated by call path (method) instead of per-span.
+
+    Attributes:
+        call_path: the ``Graph.getCallPath`` string this aggregate is keyed by.
+        span_count: number of spans sharing this call path.
+        total_drag: sum of drag across those spans (0.0 for spans off the
+            critical path, per ``Drag.drag_per_span``'s key-omission contract).
+        avg_drag: ``total_drag / span_count``.
+        total_slack: sum of slack across those spans.
+        avg_slack: ``total_slack / span_count``.
+    """
+
+    call_path: str
+    span_count: int
+    total_drag: float
+    avg_drag: float
+    total_slack: float
+    avg_slack: float
+
+
+def _sum_slack_drag_by_callpath(
+    entries: Iterable[tuple[str, int, float, float]],
+) -> dict[str, PerMethodSlackDrag]:
+    """Sum ``(call_path, span_count, drag, slack)`` entries by call path, deriving averages from the totals."""
+    totals: dict[str, list[float]] = {}
+    for call_path, span_count, drag_value, slack_value in entries:
+        totals.setdefault(call_path, [0, 0.0, 0.0])
+        entry = totals[call_path]
+        entry[0] += span_count
+        entry[1] += drag_value
+        entry[2] += slack_value
+
+    result: dict[str, PerMethodSlackDrag] = {}
+    for call_path, (span_count, total_drag, total_slack) in totals.items():
+        result[call_path] = PerMethodSlackDrag(
+            call_path=call_path,
+            span_count=span_count,
+            total_drag=total_drag,
+            avg_drag=total_drag / span_count if span_count else 0.0,
+            total_slack=total_slack,
+            avg_slack=total_slack / span_count if span_count else 0.0,
+        )
+    return result
+
+
+def aggregate_drag_slack_by_callpath(
+    graph: Graph,
+    drag: Drag,
+    slack: Slack,
+) -> dict[str, PerMethodSlackDrag]:
+    """Aggregate one graph's per-span drag/slack onto call-path identity.
+
+    Groups every node by ``graph.getCallPath(node)`` and sums drag/slack
+    across spans sharing that call path; does not recompute drag/slack.
+
+    Args:
+        graph: the Graph that ``drag``/``slack`` were computed from.
+        drag: per-span drag, as returned by ``calculate_drag``.
+        slack: per-span slack, as returned by ``calculate_slack``.
+
+    Returns:
+        Mapping from call path to its aggregated :class:`PerMethodSlackDrag`.
+    """
+    entries = (
+        (
+            graph.getCallPath(node),
+            1,
+            drag.drag_per_span.get(node.sid, 0.0),
+            slack.slack_per_span.get(node.sid, 0.0),
+        )
+        for node in graph.nodeHT.values()
+    )
+    return _sum_slack_drag_by_callpath(entries)
+
+
+def merge_per_method_slack_drag(
+    per_trace_aggregates: Iterable[dict[str, PerMethodSlackDrag]],
+) -> dict[str, PerMethodSlackDrag]:
+    """Merge per-call-path drag/slack aggregates from multiple traces into one.
+
+    Sums ``span_count``/``total_drag``/``total_slack`` per call path across
+    all inputs, then re-derives averages from those sums -- never by
+    averaging the per-trace averages directly, which would mis-weight
+    traces that saw a call path a different number of times.
+
+    Args:
+        per_trace_aggregates: aggregate dicts to merge, e.g. one per trace
+            as produced by :func:`aggregate_drag_slack_by_callpath`.
+
+    Returns:
+        A single mapping from call path to its merged :class:`PerMethodSlackDrag`.
+    """
+    entries = ((call_path, agg.span_count, agg.total_drag, agg.total_slack) for per_trace in per_trace_aggregates for call_path, agg in per_trace.items())
+    return _sum_slack_drag_by_callpath(entries)

--- a/tests/output/test_csv_generators.py
+++ b/tests/output/test_csv_generators.py
@@ -25,8 +25,10 @@ from crisp.output.csv_generators import (
     genCrossRegionCallsCSVFile,
     genEmptyCSVFile,
     genHypoLatencyCSVFile,
+    genSlackDragCSVFile,
 )
 from crisp.shared.models import LatencyData
+from crisp.slack_drag import PerMethodSlackDrag
 
 
 class TestComputeLatencyReduction(unittest.TestCase):
@@ -270,6 +272,72 @@ class TestGenCrossRegionCallsCSVFile(unittest.TestCase):
             result = genCrossRegionCallsCSVFile(metrics_list, self.mock_config)
 
         self.assertIsNone(result)
+
+
+class TestGenSlackDragCSVFile(unittest.TestCase):
+    def setUp(self):
+        self.mock_config = MagicMock()
+        self.mock_config.getOutputDir.return_value = tempfile.mkdtemp()
+        self.mock_config.serviceName = "TestService"
+        self.mock_config.operationName = "TestOperation"
+
+    def test_genSlackDragCSVFile_with_data(self):
+        perMethodSlackDrag = {
+            "[S1] OR->[S2] OA": PerMethodSlackDrag(
+                call_path="[S1] OR->[S2] OA",
+                span_count=2,
+                total_drag=100.0,
+                avg_drag=50.0,
+                total_slack=10.0,
+                avg_slack=5.0,
+            ),
+            "[S1] OR->[S3] OB": PerMethodSlackDrag(
+                call_path="[S1] OR->[S3] OB",
+                span_count=1,
+                total_drag=500.0,
+                avg_drag=500.0,
+                total_slack=0.0,
+                avg_slack=0.0,
+            ),
+        }
+
+        returned_csv_file = genSlackDragCSVFile(perMethodSlackDrag, self.mock_config)
+
+        self.assertTrue(os.path.exists(returned_csv_file))
+        df = pd.read_csv(returned_csv_file)
+        self.assertEqual(
+            list(df.columns),
+            ["callPath", "spanCount", "avgDrag", "totalDrag", "avgSlack", "totalSlack"],
+        )
+        self.assertEqual(len(df), 2)
+        # Sorted by avgDrag descending: the 500-avg-drag row comes first.
+        self.assertEqual(df.iloc[0]["callPath"], "[S1] OR->[S3] OB")
+        self.assertEqual(df.iloc[0]["avgDrag"], 500.0)
+        self.assertEqual(df.iloc[1]["callPath"], "[S1] OR->[S2] OA")
+        self.assertEqual(df.iloc[1]["spanCount"], 2)
+        self.assertEqual(df.iloc[1]["avgSlack"], 5.0)
+
+    def test_genSlackDragCSVFile_empty(self):
+        self.assertIsNone(genSlackDragCSVFile({}, self.mock_config))
+        self.assertIsNone(genSlackDragCSVFile(None, self.mock_config))
+
+    def test_genSlackDragCSVFile_custom_filename(self):
+        outputDir = self.mock_config.getOutputDir.return_value
+        perMethodSlackDrag = {
+            "[S1] OR": PerMethodSlackDrag(
+                call_path="[S1] OR",
+                span_count=1,
+                total_drag=10.0,
+                avg_drag=10.0,
+                total_slack=0.0,
+                avg_slack=0.0,
+            ),
+        }
+
+        returned_csv_file = genSlackDragCSVFile(perMethodSlackDrag, self.mock_config, filename="custom_slackdrag.csv")
+
+        self.assertEqual(returned_csv_file, os.path.join(outputDir, "custom_slackdrag.csv"))
+        self.assertTrue(os.path.exists(returned_csv_file))
 
 
 class TestComputeLatencyReductionOriginal(unittest.TestCase):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -177,3 +177,153 @@ class TestCriticalPathE2E(TestCase):
                     f"Expected freq={num_copies} for '{path}' (all {num_copies} copies "
                     f"share this path), got {freq}",
                 )
+
+
+# --- --computeSlackDrag: opt-in flag, default off. ---
+
+
+def _synthetic_two_root_child_trace(trace_id: str, scale: int = 1) -> dict:
+    """Two-service, two-root-child trace (R -> A, B) with non-trivial drag/slack.
+
+    ``scale`` avoids duration ties across traces, which some unrelated
+    aggregation steps break via nondeterministic object identity.
+    """
+    return {
+        "data": [
+            {
+                "traceID": trace_id,
+                "processes": {
+                    "P1": {"serviceName": "S1", "tags": []},
+                    "P2": {"serviceName": "S2", "tags": []},
+                },
+                "spans": [
+                    {
+                        "traceID": trace_id,
+                        "spanID": "R",
+                        "operationName": "O1",
+                        "references": [],
+                        "startTime": 0,
+                        "duration": 1000 * scale,
+                        "processID": "P1",
+                        "tags": [],
+                        "logs": [],
+                        "warnings": None,
+                    },
+                    {
+                        "traceID": trace_id,
+                        "spanID": "A",
+                        "operationName": "OA",
+                        "references": [
+                            {"refType": "CHILD_OF", "traceID": trace_id, "spanID": "R"},
+                        ],
+                        "startTime": 0,
+                        "duration": 400 * scale,
+                        "processID": "P2",
+                        "tags": [],
+                        "logs": [],
+                        "warnings": None,
+                    },
+                    {
+                        "traceID": trace_id,
+                        "spanID": "B",
+                        "operationName": "OB",
+                        "references": [
+                            {"refType": "CHILD_OF", "traceID": trace_id, "spanID": "R"},
+                        ],
+                        "startTime": 500 * scale,
+                        "duration": 500 * scale,
+                        "processID": "P2",
+                        "tags": [],
+                        "logs": [],
+                        "warnings": None,
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def _write_synthetic_traces(traces_dir: str, num_traces: int = 2) -> None:
+    for i in range(num_traces):
+        trace_id = f"T{i}"
+        with open(os.path.join(traces_dir, f"{trace_id}.json"), "w") as f:
+            json.dump(_synthetic_two_root_child_trace(trace_id, scale=(i + 1)), f)
+
+
+class TestComputeSlackDragFlag(TestCase):
+    """--computeSlackDrag is opt-in/default-off: verify slackDrag.csv only
+    appears when requested, and that turning it on/off never changes any
+    *other* output file.
+    """
+
+    def test_slack_drag_csv_only_written_when_flag_enabled(self):
+        with tempfile.TemporaryDirectory() as tmpdir_off, tempfile.TemporaryDirectory() as tmpdir_on:
+            _write_synthetic_traces(tmpdir_off)
+            _write_synthetic_traces(tmpdir_on)
+
+            self.assertEqual(0, _run_dir(tmpdir_off))
+            self.assertEqual(0, _run_dir(tmpdir_on, extra_args=["--computeSlackDrag"]))
+
+            self.assertFalse(os.path.exists(os.path.join(tmpdir_off, "slackDrag.csv")))
+            self.assertTrue(os.path.exists(os.path.join(tmpdir_on, "slackDrag.csv")))
+
+            with open(os.path.join(tmpdir_on, "slackDrag.csv")) as f:
+                content = f.read()
+            self.assertIn("callPath,spanCount,avgDrag,totalDrag,avgSlack,totalSlack", content)
+
+    def test_all_other_output_files_byte_identical_regardless_of_flag(self):
+        """Every output file other than slackDrag.csv must be byte-identical regardless of --computeSlackDrag."""
+        with tempfile.TemporaryDirectory() as tmpdir_off, tempfile.TemporaryDirectory() as tmpdir_on:
+            _write_synthetic_traces(tmpdir_off)
+            _write_synthetic_traces(tmpdir_on)
+            input_filenames = {"T0.json", "T1.json"}
+
+            self.assertEqual(0, _run_dir(tmpdir_off))
+            self.assertEqual(0, _run_dir(tmpdir_on, extra_args=["--computeSlackDrag"]))
+
+            files_off = set(os.listdir(tmpdir_off)) - input_filenames
+            files_on = set(os.listdir(tmpdir_on)) - input_filenames
+
+            # The only allowed difference in the generated file *set* is the new CSV.
+            self.assertNotIn("slackDrag.csv", files_off)
+            self.assertIn("slackDrag.csv", files_on)
+            self.assertEqual(files_on - {"slackDrag.csv"}, files_off)
+
+            for filename in sorted(files_off):
+                path_off = os.path.join(tmpdir_off, filename)
+                path_on = os.path.join(tmpdir_on, filename)
+                if os.path.isdir(path_off):
+                    continue
+                if filename.endswith(".svg"):
+                    # flamegraph.pl (the external tool that renders these) picks
+                    # each box's color at random on every invocation by design --
+                    # pre-existing, unrelated to --computeSlackDrag. Just confirm
+                    # both runs produced the file; content is not comparable.
+                    continue
+                with open(path_off, "rb") as f_off, open(path_on, "rb") as f_on:
+                    content_off = f_off.read()
+                    content_on = f_on.read()
+                if filename.endswith(".html"):
+                    # heatmap.py's pandas Styler embeds a random per-render CSS id
+                    # (e.g. "T_4b118_row0_col0") -- pre-existing nondeterminism,
+                    # unrelated to --computeSlackDrag. Normalize it away so this
+                    # test isolates the one thing it's actually checking.
+                    content_off = re.sub(rb"T_[0-9a-f]{5}", b"T_XXXXX", content_off)
+                    content_on = re.sub(rb"T_[0-9a-f]{5}", b"T_XXXXX", content_on)
+                if "vs" in filename and filename.endswith(".cct"):
+                    # The multi-percentile-window diff .cct files (produced via
+                    # difffolded.pl) can emit their per-call-path lines in a
+                    # run-dependent order that's pre-existing, unrelated to
+                    # --computeSlackDrag (it doesn't touch this code path at
+                    # all). Compare as a line multiset instead of raw bytes.
+                    self.assertEqual(
+                        sorted(content_off.splitlines()),
+                        sorted(content_on.splitlines()),
+                        f"{filename} must contain the same lines regardless of --computeSlackDrag",
+                    )
+                    continue
+                self.assertEqual(
+                    content_off,
+                    content_on,
+                    f"{filename} must be byte-identical regardless of --computeSlackDrag",
+                )

--- a/tests/test_slack_drag.py
+++ b/tests/test_slack_drag.py
@@ -10,8 +10,11 @@ from crisp.dependency_graph import DependencyGraph
 from crisp.slack_drag import (
     Drag,
     Slack,
+    PerMethodSlackDrag,
     calculate_drag,
     calculate_slack,
+    aggregate_drag_slack_by_callpath,
+    merge_per_method_slack_drag,
     _exclusive_cp_time,
 )
 
@@ -215,6 +218,34 @@ def branch_with_noncritical_sibling_graph():
         _span("B", "OB", "S2", 0, 50, parent_id="R"),
     ]
     return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "OR")
+
+
+# Same shape/op/service names as linear_chain_graph() above (so every node shares
+# the exact same Graph.getCallPath identity across the two graphs), but with
+# different durations throughout -- used to build two distinct "traces" that
+# genuinely share call paths, for testing merge_per_method_slack_drag's
+# cross-trace summation without hand-guessing drag/slack numbers.
+def linear_chain_graph_variant():
+    spans = [
+        _span("R", "OR", "S1", 0, 600),
+        _span("X", "OX", "S2", 0, 400, parent_id="R"),
+        _span("Y", "OY", "S3", 0, 200, parent_id="X"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2", "S3": "S3"}, "S1", "OR")
+
+
+# R ([S1] OR) -> A ([S2] OX)
+#             -> B ([S3] OX)
+# Same operation name ("OX") on both children, but different services (S2 vs
+# S3) -- Graph.getCallPath includes the service in its canonical name, so
+# these must NOT be merged into one call path by aggregate_drag_slack_by_callpath.
+def same_opname_different_service_siblings_graph():
+    spans = [
+        _span("R", "OR", "S1", 0, 500),
+        _span("A", "OX", "S2", 0, 100, parent_id="R"),
+        _span("B", "OX", "S3", 200, 300, parent_id="R"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2", "S3": "S3"}, "S1", "OR")
 
 
 # --- Fixtures for calculate_slack. ---
@@ -966,3 +997,260 @@ def test_slack_dataclass_is_frozen():
     slack = Slack(slack_per_span={"A": 1.0}, total_slack=1.0)
     with pytest.raises(AttributeError):
         slack.total_slack = 2.0
+
+
+# --- aggregate_drag_slack_by_callpath: single-trace per-method aggregation. ---
+
+
+def test_aggregate_by_callpath_distinct_paths_matches_per_span_values_exactly():
+    # No call path repeats in this graph, so every aggregate entry should be a
+    # trivial (span_count=1) passthrough of the underlying per-span values.
+    g = linear_chain_graph()
+    cp = g.findCriticalPath()
+    drag = calculate_drag(g, cp)
+    slack = calculate_slack(g, cp)
+
+    agg = aggregate_drag_slack_by_callpath(g, drag, slack)
+
+    assert len(agg) == len(g.nodeHT) == 3
+    for node in g.nodeHT.values():
+        call_path = g.getCallPath(node)
+        entry = agg[call_path]
+        assert entry.call_path == call_path
+        assert entry.span_count == 1
+        assert entry.total_drag == drag.drag_per_span.get(node.sid, 0.0)
+        assert entry.avg_drag == entry.total_drag
+        assert entry.total_slack == slack.slack_per_span[node.sid]
+        assert entry.avg_slack == entry.total_slack
+
+
+def test_aggregate_by_callpath_groups_same_callpath_and_averages():
+    g = fanout_same_callpath_off_cp_graph()
+    cp = g.findCriticalPath()
+    drag = calculate_drag(g, cp)
+    slack = calculate_slack(g, cp)
+
+    b1, b2 = g.nodeHT["B1"], g.nodeHT["B2"]
+    ob_call_path = g.getCallPath(b1)
+    # Sanity: confirm the two "Ob" instances really do share one call path
+    # (same op name/service, same parent) before relying on that below.
+    assert ob_call_path == g.getCallPath(b2)
+
+    agg = aggregate_drag_slack_by_callpath(g, drag, slack)
+    entry = agg[ob_call_path]
+
+    expected_total_drag = drag.drag_per_span.get("B1", 0.0) + drag.drag_per_span.get("B2", 0.0)
+    expected_total_slack = slack.slack_per_span["B1"] + slack.slack_per_span["B2"]
+
+    assert entry.span_count == 2
+    assert entry.total_drag == expected_total_drag
+    assert entry.avg_drag == expected_total_drag / 2
+    assert entry.total_slack == expected_total_slack
+    assert entry.avg_slack == expected_total_slack / 2
+
+    # Other call paths in the same graph (P, C) are unaffected -- span_count 1.
+    p_call_path = g.getCallPath(g.nodeHT["P"])
+    assert agg[p_call_path].span_count == 1
+
+
+def test_aggregate_by_callpath_distinguishes_same_opname_different_service():
+    g = same_opname_different_service_siblings_graph()
+    cp = g.findCriticalPath()
+    drag = calculate_drag(g, cp)
+    slack = calculate_slack(g, cp)
+
+    a_path = g.getCallPath(g.nodeHT["A"])
+    b_path = g.getCallPath(g.nodeHT["B"])
+    assert a_path != b_path
+
+    agg = aggregate_drag_slack_by_callpath(g, drag, slack)
+
+    assert agg[a_path].span_count == 1
+    assert agg[b_path].span_count == 1
+    assert len(agg) == 3  # R, A (S2::OX), B (S3::OX) all stay distinct
+
+
+@pytest.mark.parametrize(
+    "graph_fn",
+    [
+        linear_chain_graph,
+        sequential_siblings_with_slight_overlap_graph,
+        fanout_same_callpath_off_cp_graph,
+        branch_with_noncritical_sibling_graph,
+        happens_before_chain_constrains_sibling_slack_graph,
+        earliest_ending_sibling_with_own_child_graph,
+        exclusive_formula_branch_graph,
+        only_child_graph,
+        root_only_graph,
+    ],
+)
+def test_aggregate_by_callpath_totals_equal_underlying_drag_and_slack_totals(graph_fn):
+    # Regrouping by call path must never lose or double-count a span's drag/slack:
+    # summing back across every aggregate entry must reproduce the original totals.
+    g = graph_fn()
+    cp = g.findCriticalPath()
+    drag = calculate_drag(g, cp)
+    slack = calculate_slack(g, cp)
+
+    agg = aggregate_drag_slack_by_callpath(g, drag, slack)
+
+    assert sum(entry.total_drag for entry in agg.values()) == pytest.approx(drag.total_drag)
+    assert sum(entry.total_slack for entry in agg.values()) == pytest.approx(slack.total_slack)
+    assert sum(entry.span_count for entry in agg.values()) == len(g.nodeHT)
+
+
+def test_aggregate_by_callpath_reuses_given_drag_not_recomputed():
+    # exclusive_formula_branch_graph's own docstring documents that M's inclusive
+    # vs exclusive drag differ sharply (395 vs 15). aggregate_drag_slack_by_callpath
+    # must reflect whichever Drag it was handed -- never recompute its own.
+    g = exclusive_formula_branch_graph()
+    cp = g.findCriticalPath()
+    inclusive_drag = calculate_drag(g, cp, exclusive=False)
+    exclusive_drag = calculate_drag(g, cp, exclusive=True)
+    slack = calculate_slack(g, cp)
+
+    m_path = g.getCallPath(g.nodeHT["M"])
+    agg_inclusive = aggregate_drag_slack_by_callpath(g, inclusive_drag, slack)
+    agg_exclusive = aggregate_drag_slack_by_callpath(g, exclusive_drag, slack)
+
+    assert agg_inclusive[m_path].total_drag == inclusive_drag.drag_per_span["M"]
+    assert agg_exclusive[m_path].total_drag == exclusive_drag.drag_per_span["M"]
+    assert agg_inclusive[m_path].total_drag != agg_exclusive[m_path].total_drag
+
+
+@pytest.mark.parametrize("filename", ["1.json", "5.json"])
+def test_aggregate_by_callpath_realistic_fixtures_preserve_totals(filename):
+    g = _load_test_case(filename)
+    cp = g.findCriticalPath()
+    drag = calculate_drag(g, cp)
+    slack = calculate_slack(g, cp)
+
+    agg = aggregate_drag_slack_by_callpath(g, drag, slack)
+
+    assert sum(entry.total_drag for entry in agg.values()) == pytest.approx(drag.total_drag)
+    assert sum(entry.total_slack for entry in agg.values()) == pytest.approx(slack.total_slack)
+    assert sum(entry.span_count for entry in agg.values()) == len(g.nodeHT)
+    # Every call path present should have at least one span backing it.
+    assert all(entry.span_count > 0 for entry in agg.values())
+
+
+def test_per_method_slack_drag_dataclass_is_frozen():
+    entry = PerMethodSlackDrag(
+        call_path="[S1] OR",
+        span_count=1,
+        total_drag=1.0,
+        avg_drag=1.0,
+        total_slack=0.0,
+        avg_slack=0.0,
+    )
+    with pytest.raises(AttributeError):
+        entry.span_count = 2
+
+
+# --- merge_per_method_slack_drag: cross-trace aggregation. ---
+
+
+def test_merge_sums_weighted_not_average_of_per_trace_averages():
+    # trace1 saw this call path 3 times (avg 10); trace2 saw it once (avg 100).
+    # A naive average-of-averages would report (10 + 100) / 2 == 55. The correct,
+    # weighted answer -- summing span_count/total_drag first -- is 130 / 4 == 32.5.
+    trace1 = {
+        "cp": PerMethodSlackDrag(call_path="cp", span_count=3, total_drag=30.0, avg_drag=10.0, total_slack=0.0, avg_slack=0.0),
+    }
+    trace2 = {
+        "cp": PerMethodSlackDrag(call_path="cp", span_count=1, total_drag=100.0, avg_drag=100.0, total_slack=0.0, avg_slack=0.0),
+    }
+
+    merged = merge_per_method_slack_drag([trace1, trace2])
+
+    assert merged["cp"].span_count == 4
+    assert merged["cp"].total_drag == 130.0
+    assert merged["cp"].avg_drag == pytest.approx(32.5)
+    assert merged["cp"].avg_drag != pytest.approx(55.0)
+
+
+def test_merge_unions_call_paths_present_in_only_some_traces():
+    trace1 = {
+        "a": PerMethodSlackDrag("a", 1, 10.0, 10.0, 0.0, 0.0),
+        "b": PerMethodSlackDrag("b", 2, 20.0, 10.0, 4.0, 2.0),
+    }
+    trace2 = {
+        "b": PerMethodSlackDrag("b", 1, 5.0, 5.0, 1.0, 1.0),
+        "c": PerMethodSlackDrag("c", 1, 7.0, 7.0, 0.0, 0.0),
+    }
+
+    merged = merge_per_method_slack_drag([trace1, trace2])
+
+    assert set(merged.keys()) == {"a", "b", "c"}
+    assert merged["a"].span_count == 1
+    assert merged["a"].total_drag == 10.0
+    assert merged["b"].span_count == 3
+    assert merged["b"].total_drag == 25.0
+    assert merged["b"].total_slack == 5.0
+    assert merged["b"].avg_drag == pytest.approx(25.0 / 3)
+    assert merged["c"].span_count == 1
+    assert merged["c"].total_drag == 7.0
+
+
+def test_merge_empty_iterable_returns_empty_dict():
+    assert merge_per_method_slack_drag([]) == {}
+    assert merge_per_method_slack_drag(iter([])) == {}
+
+
+def test_merge_single_trace_is_identity():
+    g = fanout_same_callpath_off_cp_graph()
+    cp = g.findCriticalPath()
+    drag = calculate_drag(g, cp)
+    slack = calculate_slack(g, cp)
+    agg = aggregate_drag_slack_by_callpath(g, drag, slack)
+
+    merged = merge_per_method_slack_drag([agg])
+
+    assert merged == agg
+
+
+def test_merge_many_identical_traces_scales_totals_but_preserves_average():
+    g = fanout_same_callpath_off_cp_graph()
+    cp = g.findCriticalPath()
+    drag = calculate_drag(g, cp)
+    slack = calculate_slack(g, cp)
+    agg = aggregate_drag_slack_by_callpath(g, drag, slack)
+
+    num_copies = 5
+    merged = merge_per_method_slack_drag([agg] * num_copies)
+
+    for call_path, single_trace_entry in agg.items():
+        merged_entry = merged[call_path]
+        assert merged_entry.span_count == single_trace_entry.span_count * num_copies
+        assert merged_entry.total_drag == pytest.approx(single_trace_entry.total_drag * num_copies)
+        assert merged_entry.total_slack == pytest.approx(single_trace_entry.total_slack * num_copies)
+        # Identical traces -> the merged average must equal each trace's own average.
+        assert merged_entry.avg_drag == pytest.approx(single_trace_entry.avg_drag)
+        assert merged_entry.avg_slack == pytest.approx(single_trace_entry.avg_slack)
+
+
+def test_aggregate_then_merge_end_to_end_across_two_different_traces():
+    # Two traces sharing every call path (same op/service names, see
+    # linear_chain_graph_variant's docstring) but with different durations --
+    # exercises the full aggregate-per-trace-then-merge-across-traces pipeline
+    # that process_trace.py wires together, cross-checked against the real
+    # calculate_drag/calculate_slack outputs rather than hand-predicted numbers.
+    g1 = linear_chain_graph()
+    g2 = linear_chain_graph_variant()
+
+    agg1 = aggregate_drag_slack_by_callpath(g1, calculate_drag(g1, g1.findCriticalPath()), calculate_slack(g1, g1.findCriticalPath()))
+    agg2 = aggregate_drag_slack_by_callpath(g2, calculate_drag(g2, g2.findCriticalPath()), calculate_slack(g2, g2.findCriticalPath()))
+
+    merged = merge_per_method_slack_drag([agg1, agg2])
+
+    assert set(merged.keys()) == set(agg1.keys()) == set(agg2.keys())
+    for call_path in merged:
+        expected_span_count = agg1[call_path].span_count + agg2[call_path].span_count
+        expected_total_drag = agg1[call_path].total_drag + agg2[call_path].total_drag
+        expected_total_slack = agg1[call_path].total_slack + agg2[call_path].total_slack
+
+        assert merged[call_path].span_count == expected_span_count
+        assert merged[call_path].total_drag == pytest.approx(expected_total_drag)
+        assert merged[call_path].total_slack == pytest.approx(expected_total_slack)
+        assert merged[call_path].avg_drag == pytest.approx(expected_total_drag / expected_span_count)
+        assert merged[call_path].avg_slack == pytest.approx(expected_total_slack / expected_span_count)


### PR DESCRIPTION
## Summary
Adds an opt-in `--computeSlackDrag` flag (default off, output unchanged when unset) that computes per-span drag and slack for each trace via the existing `Graph.calculateDrag()`/`calculateSlack()` hooks, aggregates them onto call-path identity via new `PerMethodSlackDrag` / `aggregate_drag_slack_by_callpath()` in `slack_drag.py`, merges the per-trace aggregates across all traces in a run via `merge_per_method_slack_drag()` (weighted by span count, not a naive average of per-trace averages), and writes the result to a new `slackDrag.csv` (`callPath`, `spanCount`, `avgDrag`, `totalDrag`, `avgSlack`, `totalSlack`), sorted by descending `avgDrag`. Wires `Metrics.slackDragPerCallPath` and `Config.computeSlackDrag` through `process()`/`performCriticalPathAnalysis()` in `process_trace.py`.

## Test plan
- `pytest`: 591 passed.
- `bazel test //...`: 31/31 targets pass.
- Manually ran the pipeline with and without `--computeSlackDrag`: `slackDrag.csv` only appears when the flag is set, and every other output file is byte-identical either way — also covered by a new regression test in `tests/test_e2e.py`.