### PR TITLE
feat: port single-node retime simulation (retimer.py)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ py_test(
         "//crisp:exceptions",
         "//crisp:process_trace",
         "//crisp:dependency_graph",
+        "//crisp:retimer",
         "//crisp:slack_drag",
         "//crisp:server",
         "//crisp/service:service",
@@ -168,6 +169,20 @@ py_test(
         "//crisp:graph",
         "//crisp:dependency_graph",
         "//crisp/shared:shared",
+        "@pypi//pytest",
+    ],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_retimer",
+    size = "small",
+    srcs = ["tests/test_retimer.py"],
+    data = glob(["test_cases/**"]),
+    deps = [
+        "//crisp:retimer",
+        "//crisp:graph",
+        "//crisp:dependency_graph",
         "@pypi//pytest",
     ],
     imports = ["."],

--- a/crisp/BUILD.bazel
+++ b/crisp/BUILD.bazel
@@ -55,7 +55,9 @@ py_library(
         ":common",
         ":configuration",
         ":constants",
+        ":dependency_graph",
         ":pkg",
+        ":retimer",
         ":slack_drag",
         "//crisp/shared:shared",
         "//crisp/utils:utils",
@@ -81,6 +83,18 @@ py_library(
     # evaluated at runtime) -- it has no real runtime dependency on `:graph`.
     # A `:graph` dep here would create a Bazel-level cycle now that `slack_drag`
     # (a real dependency of `:graph`) also depends on `:dependency_graph`.
+    deps = [],
+)
+
+py_library(
+    name = "retimer",
+    srcs = ["retimer.py"],
+    visibility = ["//visibility:public"],
+    # NOTE: like dependency_graph.py, retimer.py only references DependencyGraph
+    # and Graph/GraphNode under `if TYPE_CHECKING:` (with `from __future__ import
+    # annotations`) -- it has no real runtime dependency on `:dependency_graph`
+    # or `:graph`. A real dep here would create a Bazel-level cycle now that
+    # `:graph` (which `:retimer` is used from) also depends on `:retimer`.
     deps = [],
 )
 

--- a/crisp/graph.py
+++ b/crisp/graph.py
@@ -40,6 +40,8 @@ from crisp.utils.dict_utils import (
     accumulateInDict, getCPSize
 )
 from crisp.slack_drag import calculate_drag, calculate_slack
+from crisp.dependency_graph import DependencyGraph
+from crisp.retimer import Retimer
 
 # Re-export for backward compatibility
 __all__ = ['Graph', 'accumulateInDict', 'bcolors', 'getCPSize']
@@ -258,6 +260,7 @@ class Graph:
         self.proxyNodes = {}  # maps sid to child count, for sanity checks
         self.filterProxy = filterProxy
         self.numProxyRoots = 0  # number of proxy nodes that are roots
+        self.retimed = False  # set to True once Retimer.retime_node has mutated this Graph
         self.exclusionSet = (
             exclusionSet if exclusionSet else {}
         )  # operations to exlude from the graph
@@ -1986,6 +1989,25 @@ class Graph:
         if cp is None:
             cp = self.findCriticalPath()
         return calculate_slack(self, cp, dependency_graph)
+
+    def retimeNodeWithDependencyGraph(self, node_span_id, new_start, new_end, dependency_graph=None, freeze_starts=True):
+        """Retime one node in this Graph, cascading the effect to siblings/ancestors.
+
+        See :meth:`Retimer.retime_node` for full semantics. Unlike
+        calculateDrag/calculateSlack (pure, read-only), this MUTATES this
+        Graph in place with no built-in restore.
+
+        Args:
+            node_span_id: the span id of the node to retime.
+            new_start: the node's new start time.
+            new_end: the node's new end time.
+            dependency_graph: Optional pre-built DependencyGraph. If None,
+                builds one internally via DependencyGraph(graph=self).
+            freeze_starts: see Retimer.retime_node.
+        """
+        if dependency_graph is None:
+            dependency_graph = DependencyGraph(graph=self)
+        Retimer(dependency_graph).retime_node(self, node_span_id, new_start, new_end, freeze_starts)
 
     def findErrorsOnCriticalPath(self, rootNode=None):
         """Find errors on the critical path starting from the given root node.

--- a/crisp/retimer.py
+++ b/crisp/retimer.py
@@ -1,0 +1,199 @@
+"""Single-node retime simulation for a critical path call tree.
+
+This module ports the "retimer" concept from Google's `calligator` project
+(Apache-2.0, see https://github.com/google/calligator/blob/main/retimer.py,
+class ``Retimer``, method ``retime_node``) to this codebase's
+:class:`~crisp.graph.Graph` and :class:`~crisp.graph.GraphNode`.
+
+Given a node's new start/end times, :meth:`Retimer.retime_node` mutates that
+node in place, shifts any true sibling that the :class:`DependencyGraph`
+says genuinely happens after it (by real timestamp, not just call-path
+identity), and -- if the node became its parent's new earliest-starting or
+latest-ending child -- recurses to retime the parent too. This is strictly
+more accurate than :meth:`Graph.computeProjectedCPMetrics`'s ancestor-only
+cascade, which has no notion of siblings at all. The two are intentionally
+kept separate -- ``retime_node`` is a library-only, opt-in entry point that
+is never called from ``computeProjectedCPMetrics``/``--deltaMicroSec``, and
+the two may legitimately disagree on graphs with parallel siblings.
+
+Unlike every other mutating operation in this codebase (e.g.
+``Graph.computeProjectedCPMetrics``), ``retime_node`` has no built-in
+restore -- it permanently mutates ``g`` to simulate a "what-if" retimed
+state. Callers that need the original graph back afterward should take a
+:meth:`Retimer.snapshot` before retiming and pass it to
+:meth:`Retimer.restore` when done (cheaper than deep-copying the whole
+``Graph``, since retiming only ever touches node timing fields), or call
+``retime_node`` a second time with the original ``(startTime, endTime)``
+(see the round-trip tests in ``tests/test_retimer.py``).
+
+Node identity is :meth:`Graph.getCallPath`, matching ``dependency_graph.py``
+and ``slack_drag.py``. As documented on ``DependencyGraphNode.happens_before``,
+that set can legitimately contain a node's own call-path name (a parent
+fanning out to the same call-path more than once in series). Every
+name-based ``happens_before``/``child_dependents`` lookup below is paired
+with a genuine per-span check (excluding the node's own span id, or
+comparing real timestamps) -- never a bare name-membership test -- so that
+self-referential entries cascade delays correctly without ever mutating a
+node based on its own happens-before edge to itself.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from crisp.dependency_graph import DependencyGraph
+    from crisp.graph import Graph, GraphNode
+
+
+def _original_end_time(node: GraphNode) -> float:
+    """A node's end time as originally constructed, never mutated by retiming."""
+    return node.originalStartTime + node.originalDuration
+
+
+class Retimer:
+    """Retimes nodes in one or more Graphs using a single DependencyGraph.
+
+    A ``Retimer`` holds one :class:`DependencyGraph` and can be reused to
+    retime any number of nodes, across any number of ``Graph`` instances
+    (mirrors calligator's own ``Retimer`` docstring).
+    """
+
+    def __init__(self, dependency_graph: DependencyGraph):
+        self.dependency_graph = dependency_graph
+
+    @staticmethod
+    def snapshot(g: Graph) -> dict[str, tuple[float, float, float]]:
+        """Capture every node's (startTime, endTime, duration) for a later :meth:`restore`."""
+        return {sid: (n.startTime, n.endTime, n.duration) for sid, n in g.nodeHT.items()}
+
+    @staticmethod
+    def restore(g: Graph, snapshot: dict[str, tuple[float, float, float]]) -> None:
+        """Write back a :meth:`snapshot` taken before any ``retime_node`` calls on ``g``."""
+        for sid, (start, end, duration) in snapshot.items():
+            node = g.nodeHT[sid]
+            node.startTime, node.endTime, node.duration = start, end, duration
+        g.retimed = False
+
+    def retime_node(
+        self,
+        g: Graph,
+        node_span_id: str,
+        new_start: float,
+        new_end: float,
+        freeze_starts: bool = True,
+    ) -> None:
+        """Retime one node, cascading the effect to siblings and ancestors.
+
+        Assumptions (carried over from calligator): the new start/end do not
+        conflict with the node's own children; the graph only has
+        happens-before relationships between spans; the new times don't
+        violate any such relationship; and a parent span takes constant time
+        to dispatch/aggregate its children, so it only needs retiming when
+        the changed node becomes its new earliest-starting or
+        latest-(non-async-)ending child.
+
+        Args:
+            g: the Graph to mutate.
+            node_span_id: span id of the node to retime.
+            new_start: the node's new start time.
+            new_end: the node's new end time.
+            freeze_starts: if True, this node's own parent's startTime is
+                left untouched even if propagation would otherwise move it
+                (useful when retiming several nodes in parallel against the
+                same parent). Only applies to the immediate parent -- any
+                further propagation to a grandparent (and beyond) always
+                recurses with the default (True), matching calligator.
+
+        Raises:
+            ValueError: if ``new_start > new_end``.
+        """
+        deps = self.dependency_graph.deps
+        node = g.nodeHT[node_span_id]
+
+        if new_start == node.startTime and new_end == node.endTime:
+            return  # nothing to change
+
+        if new_start > new_end:
+            raise ValueError(
+                f"New start time {new_start} is greater than new end time {new_end} for node {node.pid}.{node.opName}.",
+            )
+
+        g.retimed = True
+
+        delay = new_end - node.endTime  # positive = ends later, negative = ends sooner
+        parent = node.parent
+
+        # Snapshot of the parent's own dispatch/aggregation overhead, taken before
+        # this node's mutation below, to preserve if the parent needs retiming.
+        parent_start_delay = 0
+        parent_end_delay = 0
+        if parent is not None:
+            by_start = sorted(parent.children, key=lambda c: c.startTime)
+            parent_start_delay = by_start[0].startTime - parent.startTime if by_start else 0
+
+            by_end = sorted(parent.children, key=lambda c: c.endTime)
+            non_async_children = [c for c in by_end if c.endTime <= parent.endTime]
+            parent_end_delay = parent.endTime - non_async_children[-1].endTime if non_async_children else 0
+
+        original_node_end = node.endTime  # compared against siblings below
+        node.startTime = new_start
+        node.endTime = new_end
+        node.duration = new_end - new_start
+
+        if parent is None:
+            return  # no parent to propagate to
+
+        # Shift true siblings with a genuine happens-before relationship to this
+        # node. `c.sid != node_span_id` (below) excludes the node itself BEFORE any
+        # name-based happens_before lookup -- required so a same-call-path fan-out
+        # (see module docstring) never treats the node as its own predecessor.
+        node_name = g.getCallPath(node)
+        siblings = [c for c in parent.children if c.sid != node_span_id]
+        for sibling in siblings:
+            sibling_dep = deps.get(g.getCallPath(sibling))
+            if sibling_dep is not None and node_name in sibling_dep.happens_before and sibling.startTime > original_node_end:
+                sibling.startTime += delay
+                sibling.endTime += delay
+            # else: no happens-before relationship -- unaffected by this delay/rush.
+
+        # Find the earliest-starting and latest-(non-async-)ending true sibling,
+        # including this node itself post-mutation.
+        siblings.append(node)
+        first_sibling_after_parent_start = node
+        last_sibling_before_parent_end = node
+
+        parent_dep = deps.get(g.getCallPath(parent))
+        child_dependents = parent_dep.child_dependents if parent_dep is not None else set()
+        dependent_siblings = [c for c in siblings if g.getCallPath(c) in child_dependents and _original_end_time(c) <= _original_end_time(parent)]
+        if dependent_siblings:
+            last_sibling_before_parent_end = max(dependent_siblings, key=lambda c: c.endTime)
+
+        for sibling in siblings:
+            if parent.startTime <= sibling.startTime < first_sibling_after_parent_start.startTime:
+                first_sibling_after_parent_start = sibling
+            if (
+                sibling.endTime <= parent.endTime
+                and sibling.endTime > last_sibling_before_parent_end.endTime
+                and _original_end_time(sibling) <= _original_end_time(parent)
+            ):
+                last_sibling_before_parent_end = sibling
+
+        if freeze_starts:
+            new_parent_start = parent.startTime
+        elif parent_start_delay > 0:
+            new_parent_start = first_sibling_after_parent_start.startTime - parent_start_delay
+        else:
+            new_parent_start = min(parent.startTime, first_sibling_after_parent_start.startTime)
+
+        if _original_end_time(last_sibling_before_parent_end) > _original_end_time(parent):
+            new_parent_end = parent.endTime
+        else:
+            new_parent_end = parent_end_delay + last_sibling_before_parent_end.endTime
+
+        if new_parent_start > new_parent_end:
+            return
+
+        # Matches calligator: propagation beyond the immediate parent always uses
+        # the default freeze_starts (True), regardless of what the caller passed.
+        self.retime_node(g, parent.sid, new_parent_start, new_parent_end)

--- a/tests/test_retimer.py
+++ b/tests/test_retimer.py
@@ -1,0 +1,535 @@
+# ruff: noqa: I001
+import json
+import os
+
+import pytest
+
+from crisp.graph import Graph
+from crisp.dependency_graph import DependencyGraph
+from crisp.retimer import Retimer
+
+
+def _span(span_id, op, pid, start, duration, parent_id=None):
+    return {
+        "traceID": "T",
+        "spanID": span_id,
+        "operationName": op,
+        "startTime": start,
+        "duration": duration,
+        "processID": pid,
+        "warnings": None,
+        "references": ([] if parent_id is None else [{"refType": "CHILD_OF", "traceID": "T", "spanID": parent_id}]),
+    }
+
+
+def _build_graph(spans, processes, root_service, root_op):
+    jsonData = {
+        "data": [
+            {
+                "processes": {pid: {"serviceName": svc, "tags": []} for pid, svc in processes.items()},
+                "traceID": "T",
+                "spans": spans,
+            },
+        ],
+    }
+    return Graph(jsonData, root_service, root_op, "", "")
+
+
+def _load_test_case(filename):
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(test_dir, "..", "test_cases", filename)
+    with open(path) as f:
+        data = json.load(f)
+    return Graph(data, "S1", "O1", path)
+
+
+# R ([S1] OR) -> X ([S2] OX)
+# R runs 0-300; X runs 50-250 (R's only child -- no true sibling to compete with).
+def only_child_graph():
+    spans = [
+        _span("R", "OR", "S1", 0, 300),
+        _span("X", "OX", "S2", 50, 200, parent_id="R"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "OR")
+
+
+# R ([S1] OR) -> A ([S2] OA)
+#             -> B ([S2] OB)
+# R runs 0-1000. A runs 0-200; B runs 300-600, well after A ends -- a genuine
+# happens-before edge (A -> B) is inferred by the real DependencyGraph.
+def two_siblings_dependent_graph():
+    spans = [
+        _span("R", "OR", "S1", 0, 1000),
+        _span("A", "OA", "S2", 0, 200, parent_id="R"),
+        _span("B", "OB", "S2", 300, 300, parent_id="R"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "OR")
+
+
+# R ([S1] OR) -> A ([S2] OA)
+#             -> B ([S2] OB)
+#             -> C ([S2] OC)
+# R runs 0-1000. A runs 0-100; B runs 200-500; C runs 700-900. Each earlier
+# sibling ends well before the next starts, so DependencyGraph infers a full
+# chain of happens-before edges: A -> B, A -> C, B -> C.
+def three_siblings_chain_graph():
+    spans = [
+        _span("R", "OR", "S1", 0, 1000),
+        _span("A", "OA", "S2", 0, 100, parent_id="R"),
+        _span("B", "OB", "S2", 200, 300, parent_id="R"),
+        _span("C", "OC", "S2", 700, 200, parent_id="R"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "OR")
+
+
+# R ([S1] OR) -> A ([S2] OA)  -- a long-running sibling spanning most of R.
+#             -> B ([S2] OB)  -- runs entirely inside A's window; no happens-before
+#                                relationship is inferred either way (A starts
+#                                before B and ends after B, so neither "ends
+#                                before the other starts").
+def spanning_sibling_and_nested_sibling_graph():
+    spans = [
+        _span("R", "OR", "S1", 0, 1000),
+        _span("A", "OA", "S2", 0, 900, parent_id="R"),
+        _span("B", "OB", "S2", 100, 100, parent_id="R"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2"}, "S1", "OR")
+
+
+# P ([S1] OP) -> B1 ([S2] Ob)  -- runs 0-100
+#             -> B2 ([S2] Ob)  -- runs 200-300, a second, later instance of the
+#                                 SAME call path ("Ob")
+#             -> C ([S3] Oc)   -- runs 0-1000, spans all of P
+# Since B1 (an earlier instance of "Ob") finishes before B2 starts, DependencyGraph
+# records a self-referential happens_before edge for "Ob" (see dependency_graph.py).
+def fanout_same_callpath_graph():
+    spans = [
+        _span("P", "OP", "S1", 0, 1000),
+        _span("B1", "Ob", "S2", 0, 100, parent_id="P"),
+        _span("B2", "Ob", "S2", 200, 100, parent_id="P"),
+        _span("C", "Oc", "S3", 0, 1000, parent_id="P"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2", "S3": "S3"}, "S1", "OP")
+
+
+# GG ([S1] OGG) -> P ([S2] OP) -- GG's only child, 150-950
+#                    -> A ([S3] OA) -- 150-250
+#                    -> B ([S3] OB) -- 300-500, happens-before A
+# Three levels deep: retiming A can cascade through P up to GG.
+def three_level_graph():
+    spans = [
+        _span("GG", "OGG", "S1", 100, 900),
+        _span("P", "OP", "S2", 150, 800, parent_id="GG"),
+        _span("A", "OA", "S3", 150, 100, parent_id="P"),
+        _span("B", "OB", "S3", 300, 200, parent_id="P"),
+    ]
+    return _build_graph(spans, {"S1": "S1", "S2": "S2", "S3": "S3"}, "S1", "OGG")
+
+
+# R ([S1] OR) -- a leaf root with no children and no parent.
+def root_only_graph():
+    spans = [_span("R", "OR", "S1", 0, 100)]
+    return _build_graph(spans, {"S1": "S1"}, "S1", "OR")
+
+
+# --- No-op and validation. ---
+
+
+def test_no_op_when_new_times_equal_current_makes_no_changes_and_does_not_set_retimed():
+    g = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g)
+    before = Retimer.snapshot(g)
+
+    Retimer(dep).retime_node(g, "A", g.nodeHT["A"].startTime, g.nodeHT["A"].endTime)
+
+    assert Retimer.snapshot(g) == before
+    assert g.retimed is False
+
+
+def test_new_start_greater_than_new_end_raises_value_error():
+    g = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g)
+
+    with pytest.raises(ValueError, match="greater than new end time"):
+        Retimer(dep).retime_node(g, "A", 300, 100)
+
+
+# --- Leaf retime with zero siblings (only child): always the extremum. ---
+
+
+def test_only_child_retime_later_propagates_full_delay_to_parent():
+    g = only_child_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "X", 50, 300)  # delayed by 50
+
+    assert (g.nodeHT["X"].startTime, g.nodeHT["X"].endTime) == (50, 300)
+    # X is R's only child, so it's always the extremum -- R's end must extend
+    # by the same 50, preserving the original 50-unit aggregation gap (300-250).
+    assert (g.nodeHT["R"].startTime, g.nodeHT["R"].endTime) == (0, 350)
+
+
+def test_only_child_retime_earlier_propagates_full_rush_to_parent():
+    g = only_child_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "X", 50, 200)  # rushed earlier by 50
+
+    assert (g.nodeHT["X"].startTime, g.nodeHT["X"].endTime) == (50, 200)
+    assert (g.nodeHT["R"].startTime, g.nodeHT["R"].endTime) == (0, 250)
+
+
+# --- Root/no-parent retime. ---
+
+
+def test_root_node_retime_mutates_self_and_returns_cleanly():
+    g = root_only_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "R", 0, 150)
+
+    assert (g.nodeHT["R"].startTime, g.nodeHT["R"].endTime, g.nodeHT["R"].duration) == (0, 150, 150)
+    assert g.retimed is True
+
+
+# --- Sibling shift is gated on a genuine happens-before relationship. ---
+
+
+@pytest.mark.parametrize(
+    ("new_end", "expected_delay"),
+    [(250, 50), (150, -50)],
+    ids=["delayed_later", "rushed_earlier"],
+)
+def test_dependent_sibling_shifts_by_exactly_the_delay(new_end, expected_delay):
+    g = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g)
+    a_name = g.getCallPath(g.nodeHT["A"])
+    b_name = g.getCallPath(g.nodeHT["B"])
+    assert dep.deps[b_name].happens_before == {a_name}
+
+    b_before = (g.nodeHT["B"].startTime, g.nodeHT["B"].endTime)
+    Retimer(dep).retime_node(g, "A", 0, new_end)
+    b_after = (g.nodeHT["B"].startTime, g.nodeHT["B"].endTime)
+
+    assert b_after == (b_before[0] + expected_delay, b_before[1] + expected_delay)
+
+
+def test_delay_cascades_through_a_chain_of_dependent_siblings():
+    g = three_siblings_chain_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "B", 200, 600)  # B delayed by 100 (was 200-500)
+
+    assert (g.nodeHT["A"].startTime, g.nodeHT["A"].endTime) == (0, 100)  # unaffected: nothing precedes A
+    assert (g.nodeHT["B"].startTime, g.nodeHT["B"].endTime) == (200, 600)
+    # C happens-before-depends on B, so it cascades by the same 100-unit delay.
+    assert (g.nodeHT["C"].startTime, g.nodeHT["C"].endTime) == (800, 1000)
+    # C becomes R's new latest-ending child, extending R's end by the same delay.
+    assert (g.nodeHT["R"].startTime, g.nodeHT["R"].endTime) == (0, 1100)
+
+
+def test_sibling_with_no_happens_before_relationship_never_shifts():
+    g = spanning_sibling_and_nested_sibling_graph()
+    dep = DependencyGraph(graph=g)
+    a_name = g.getCallPath(g.nodeHT["A"])
+    b_name = g.getCallPath(g.nodeHT["B"])
+    assert a_name not in dep.deps[b_name].happens_before
+    assert b_name not in dep.deps[a_name].happens_before
+
+    Retimer(dep).retime_node(g, "B", 150, 250)  # delayed by 50
+
+    # A has no happens-before relationship to B in either direction, so it must
+    # not move even though B's new end (250) is still well within A's span.
+    assert (g.nodeHT["A"].startTime, g.nodeHT["A"].endTime) == (0, 900)
+
+
+def test_manually_cleared_happens_before_edge_prevents_sibling_shift():
+    # Simulates a multi-trace aggregate where a counter-example dropped the edge
+    # (see dependency_graph.py's aggregation rule) -- retime_node must respect
+    # whatever DependencyGraph.deps says, not re-derive the relationship itself.
+    g = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g)
+    b_name = g.getCallPath(g.nodeHT["B"])
+    assert dep.deps[b_name].happens_before  # sanity: the edge exists before clearing
+    dep.deps[b_name].happens_before.clear()
+
+    Retimer(dep).retime_node(g, "A", 0, 250)
+
+    assert (g.nodeHT["B"].startTime, g.nodeHT["B"].endTime) == (300, 600)
+
+
+# --- Parent propagation: extremum vs. non-extremum children. ---
+
+
+def test_child_becoming_new_latest_ending_sibling_extends_parent_end():
+    g = spanning_sibling_and_nested_sibling_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "B", 850, 950)  # B now ends later than A (900)
+
+    assert (g.nodeHT["A"].startTime, g.nodeHT["A"].endTime) == (0, 900)  # untouched
+    # R's end extends by the same 100-unit gap it originally had past A (1000-900).
+    assert (g.nodeHT["R"].startTime, g.nodeHT["R"].endTime) == (0, 1050)
+
+
+def test_child_not_becoming_new_extremum_leaves_parent_untouched():
+    g = spanning_sibling_and_nested_sibling_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "B", 150, 250)  # still far short of A's endTime (900)
+
+    assert (g.nodeHT["A"].startTime, g.nodeHT["A"].endTime) == (0, 900)
+    assert (g.nodeHT["R"].startTime, g.nodeHT["R"].endTime) == (0, 1000)
+
+
+# --- freeze_starts. ---
+
+
+def test_freeze_starts_true_keeps_parent_start_fixed_when_child_moves_earlier():
+    g = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "A", -50, 150, freeze_starts=True)
+
+    assert g.nodeHT["A"].startTime == -50
+    assert g.nodeHT["R"].startTime == 0  # frozen, despite A now starting earlier
+
+
+def test_freeze_starts_false_moves_parent_start_when_child_becomes_new_earliest():
+    g = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "A", -50, 150, freeze_starts=False)
+
+    assert g.nodeHT["A"].startTime == -50
+    assert g.nodeHT["R"].startTime == -50  # follows A's new, earlier start
+
+
+def test_freeze_starts_only_applies_to_immediate_parent_not_grandparent():
+    g_frozen = three_level_graph()
+    Retimer(DependencyGraph(graph=g_frozen)).retime_node(g_frozen, "A", 50, 150, freeze_starts=True)
+
+    g_unfrozen = three_level_graph()
+    Retimer(DependencyGraph(graph=g_unfrozen)).retime_node(g_unfrozen, "A", 50, 150, freeze_starts=False)
+
+    # The immediate parent (P) differs between the two runs...
+    assert g_frozen.nodeHT["P"].startTime == 150
+    assert g_unfrozen.nodeHT["P"].startTime == 50
+    assert g_frozen.nodeHT["P"].startTime != g_unfrozen.nodeHT["P"].startTime
+
+    # ...but propagation beyond the immediate parent always uses freeze_starts=True,
+    # regardless of what the top-level caller passed -- so GG's start is identical.
+    assert g_frozen.nodeHT["GG"].startTime == g_unfrozen.nodeHT["GG"].startTime == 100
+
+
+# --- Multi-level propagation. ---
+
+
+def test_multilevel_propagation_cascades_through_parent_and_grandparent():
+    g = three_level_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "A", 150, 250 + 40)  # A delayed by 40
+
+    assert g.nodeHT["A"].endTime == 290
+    # B happens-before-depends on A, so it cascades by the same 40-unit delay.
+    assert (g.nodeHT["B"].startTime, g.nodeHT["B"].endTime) == (340, 540)
+    # B becomes P's new latest-ending child, so P's end extends by 40 too
+    # (preserving P's original 450-unit gap past B: 950-500).
+    assert g.nodeHT["P"].endTime == 990
+    # And P is GG's only child, so GG's end extends by the same 40 in turn.
+    assert g.nodeHT["GG"].endTime == 1040
+
+
+# --- Same-call-path fanout: the sid-based self-guard. ---
+
+
+def test_fanout_retiming_later_instance_does_not_affect_earlier_instance():
+    g = fanout_same_callpath_graph()
+    dep = DependencyGraph(graph=g)
+    ob_name = g.getCallPath(g.nodeHT["B1"])
+    assert dep.deps[ob_name].happens_before == {ob_name}  # self-referential, by design
+
+    # Jump B2 forward (not just stretch it) so a naive, un-guarded check (that
+    # failed to exclude the node's own span id before the happens_before lookup)
+    # would spuriously re-match B2 against its own self-referential edge.
+    Retimer(dep).retime_node(g, "B2", 500, 600)
+
+    assert (g.nodeHT["B1"].startTime, g.nodeHT["B1"].endTime) == (0, 100)
+    assert (g.nodeHT["B2"].startTime, g.nodeHT["B2"].endTime) == (500, 600)
+
+
+def test_fanout_retiming_earlier_instance_cascades_delay_to_later_instance():
+    g = fanout_same_callpath_graph()
+    dep = DependencyGraph(graph=g)
+
+    Retimer(dep).retime_node(g, "B1", 0, 150)  # B1 delayed by 50
+
+    assert (g.nodeHT["B1"].startTime, g.nodeHT["B1"].endTime) == (0, 150)
+    # B2, the later instance of the same call path, cascades by the same delay,
+    # via the legitimate self-referential happens_before edge -- not a self-match.
+    assert (g.nodeHT["B2"].startTime, g.nodeHT["B2"].endTime) == (250, 350)
+
+
+# --- Round trip: retime forward, then back, restores the graph exactly. ---
+
+
+def test_round_trip_retime_forward_then_back_restores_every_node_exactly():
+    g = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g)
+    before = Retimer.snapshot(g)
+    a = g.nodeHT["A"]
+    original_start, original_end = a.startTime, a.endTime
+
+    Retimer(dep).retime_node(g, "A", original_start, original_end + 75)
+    assert Retimer.snapshot(g) != before  # sanity: the forward retime really changed something
+
+    Retimer(dep).retime_node(g, "A", original_start, original_end)
+
+    assert Retimer.snapshot(g) == before
+
+
+def test_round_trip_multilevel_restores_every_node_exactly():
+    g = three_level_graph()
+    dep = DependencyGraph(graph=g)
+    before = Retimer.snapshot(g)
+    a = g.nodeHT["A"]
+    original_start, original_end = a.startTime, a.endTime
+
+    Retimer(dep).retime_node(g, "A", original_start - 20, original_end - 20)
+    assert Retimer.snapshot(g) != before
+
+    Retimer(dep).retime_node(g, "A", original_start, original_end)
+
+    assert Retimer.snapshot(g) == before
+
+
+# --- snapshot()/restore(): explicit alternative to a second retime_node call. ---
+
+
+def test_restore_undoes_a_multilevel_cascade_without_a_second_retime_call():
+    g = three_level_graph()
+    dep = DependencyGraph(graph=g)
+    before = Retimer.snapshot(g)
+    a = g.nodeHT["A"]
+
+    Retimer(dep).retime_node(g, "A", a.startTime - 20, a.endTime - 20)
+    assert Retimer.snapshot(g) != before  # sanity: the cascade really touched the graph
+    assert g.retimed is True
+
+    Retimer.restore(g, before)
+
+    assert Retimer.snapshot(g) == before
+    assert g.retimed is False
+
+
+def test_restore_is_exact_even_when_the_touched_node_set_is_unknown_in_advance():
+    # Unlike computeProjectedCPMetrics, callers can't predict which nodes
+    # retime_node will touch ahead of time (sibling shifts + cascading parent
+    # propagation), so restore() must work from a snapshot of the whole graph.
+    g = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g)
+    before = Retimer.snapshot(g)
+
+    b = g.nodeHT["B"]
+    Retimer(dep).retime_node(g, "B", b.startTime, b.endTime + 40)
+
+    Retimer.restore(g, before)
+
+    assert Retimer.snapshot(g) == before
+
+
+# --- Graceful degradation with an unrelated/mismatched DependencyGraph. ---
+
+
+def test_missing_dependency_graph_entries_does_not_crash_and_skips_unknown_shifts():
+    unrelated_graph = _build_graph([_span("Z", "OZ", "SX", 0, 50)], {"SX": "SX"}, "SX", "OZ")
+    dep = DependencyGraph(graph=unrelated_graph)  # knows nothing about g below
+
+    g = two_siblings_dependent_graph()
+
+    Retimer(dep).retime_node(g, "A", 0, 250)  # must not KeyError
+
+    # No happens_before info is available for B's call path, so it can't be
+    # known to depend on A -- it must not shift.
+    assert (g.nodeHT["B"].startTime, g.nodeHT["B"].endTime) == (300, 600)
+
+
+# --- Graph.retimeNodeWithDependencyGraph hook. ---
+
+
+def test_graph_hook_matches_direct_retimer_usage():
+    g_hook = two_siblings_dependent_graph()
+    g_direct = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g_direct)
+
+    g_hook.retimeNodeWithDependencyGraph("A", 0, 260)
+    Retimer(dep).retime_node(g_direct, "A", 0, 260)
+
+    assert Retimer.snapshot(g_hook) == Retimer.snapshot(g_direct)
+
+
+def test_graph_hook_builds_dependency_graph_internally_when_none_passed():
+    g = two_siblings_dependent_graph()
+
+    g.retimeNodeWithDependencyGraph("A", 0, 260)
+
+    # The internally-built DependencyGraph must still infer the real
+    # happens-before edge, so B cascades exactly as it would with an explicit one.
+    assert (g.nodeHT["B"].startTime, g.nodeHT["B"].endTime) == (360, 660)
+
+
+def test_graph_hook_accepts_an_explicit_prebuilt_dependency_graph():
+    g = two_siblings_dependent_graph()
+    dep = DependencyGraph(graph=g)
+
+    g.retimeNodeWithDependencyGraph("A", 0, 260, dependency_graph=dep)
+
+    assert (g.nodeHT["B"].startTime, g.nodeHT["B"].endTime) == (360, 660)
+
+
+# --- Graph.retimed flag. ---
+
+
+def test_retimed_flag_starts_false_and_flips_true_after_a_real_mutation():
+    g = two_siblings_dependent_graph()
+    assert g.retimed is False
+
+    Retimer(DependencyGraph(graph=g)).retime_node(g, "A", 0, 260)
+
+    assert g.retimed is True
+
+
+# --- One Retimer/DependencyGraph reused across multiple, unrelated Graphs. ---
+
+
+def test_retimer_instance_reused_across_multiple_graphs():
+    g1 = only_child_graph()
+    g2 = only_child_graph()
+    dep = DependencyGraph(graph=g1)
+    retimer = Retimer(dep)
+
+    retimer.retime_node(g1, "X", 50, 300)
+    retimer.retime_node(g2, "X", 50, 200)
+
+    assert (g1.nodeHT["R"].startTime, g1.nodeHT["R"].endTime) == (0, 350)
+    assert (g2.nodeHT["R"].startTime, g2.nodeHT["R"].endTime) == (0, 250)
+
+
+# --- Realistic fixtures from test_cases/*.json. ---
+
+
+@pytest.mark.parametrize("filename", ["3.json", "5.json"])
+def test_realistic_fixture_leaf_retime_does_not_crash_and_updates_root(filename):
+    g = _load_test_case(filename)
+    assert g.rootNode is not None
+
+    leaf = next(n for n in g.nodeHT.values() if not n.children and n.parent is not None)
+    root_end_before = g.rootNode.endTime
+
+    dep = DependencyGraph(graph=g)
+    Retimer(dep).retime_node(g, leaf.sid, leaf.startTime, leaf.endTime + 10)
+
+    assert leaf.endTime == leaf.startTime + leaf.duration
+    assert g.rootNode.endTime >= root_end_before
+    assert g.retimed is True


### PR DESCRIPTION
Ports the `Retimer`/`retime_node` concept, originally from Google's [calligator](https://github.com/google/calligator/blob/main/retimer.py) project (Apache-2.0), to this codebase's `Graph`/`GraphNode`/`DependencyGraph`.

Given a node's new start/end times, `Retimer.retime_node` mutates that node in place, cascades the delay/rush to any true sibling that `DependencyGraph` says genuinely happens after it (by real timestamp, not just call-path identity), and — if the node became its parent's new earliest-starting or latest-ending child — recurses to retime the parent too.

This is a library-only, opt-in entry point (`Graph.retimeNodeWithDependencyGraph`) that is never called from `computeProjectedCPMetrics`/`--deltaMicroSec`, and is intentionally kept separate from that ancestor-only cascade — the two may legitimately disagree on graphs with parallel siblings.

## What's included

- `crisp/retimer.py`: the `Retimer` class, `retime_node`, and `snapshot`/`restore` helpers for undoing a retime without a second call.
- `Graph.retimeNodeWithDependencyGraph` and `Graph.retimed` hook in `crisp/graph.py`.
- `tests/test_retimer.py`: 30 tests covering sibling cascades, multi-level propagation, `freeze_starts` semantics, same-call-path fanout self-guards, round-trip restoration, and realistic fixture graphs.
- Bazel wiring for the new library and test targets.

## Verification

- Verified against the actual upstream calligator `retimer.py` source before porting — the only deviations are defensive `.get()`-based dependency lookups (vs. upstream's bare `deps[name]`) and using this codebase's existing `node.parent`/`Graph.getCallPath` idioms instead of calligator's `parentSpanId`-lookup helpers.
- `pytest` (621 passed) and `bazel test //...` (32/32 targets) both green.