### PR TITLE
ci: bound and auto-retry the Install dependencies step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
   python:
     name: Python 3.11 (pytest + test.sh)
     runs-on: ubuntu-latest
+    # Overall backstop: this job normally finishes in ~1 minute, so 20
+    # minutes is already generous margin over the retried-install worst
+    # case below, while still failing well short of GitHub's 6h default.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -28,10 +32,21 @@ jobs:
           cache: pip
           cache-dependency-path: requirements_lock.txt
 
+      # requirements_lock.txt is pinned, so this step normally takes ~20s;
+      # a hang here in the wild has taken 30 minutes (a stalled TCP read
+      # that pip's own retry logic didn't catch). --timeout/--retries bound
+      # each individual pip network operation, and wrapping the whole step
+      # in nick-fields/retry re-attempts it from scratch (fresh connections/
+      # DNS) up to 3 times, each capped at 3 minutes, so a stall now
+      # self-heals in CI instead of requiring a manual cancel + rerun.
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements_lock.txt
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          command: |
+            python -m pip install --upgrade pip
+            pip install --timeout 60 --retries 3 -r requirements_lock.txt
 
       # Keep in sync with scripts/ci-local.sh (pytest -q + test.sh).
       - name: Unit + trace tests


### PR DESCRIPTION
## Why

`pip install -r requirements_lock.txt` normally takes ~20s since the lockfile is pinned, but in the wild a stalled TCP read once hung the step for ~30 minutes, and the runner was slow to honor a manual cancellation on top of that. This adds three layers of defense so a transient network stall self-heals instead of silently blocking CI until a human notices and reruns it.

## What changed

- Added `--timeout 60 --retries 3` to the `pip install` call, bounding each individual pip network operation so a stalled connection fails fast and retries within a single attempt.
- Wrapped the whole "Install dependencies" step in `nick-fields/retry@v3` (`max_attempts: 3`, `timeout_minutes: 3` per attempt), so if a stall slips past pip's own retry logic, the step restarts from scratch with fresh connections/DNS.
- Added a `timeout-minutes: 20` job-level backstop (the job normally finishes in ~1 minute), in case something other than dependency install ever hangs.

## Testing

Validated the workflow YAML parses correctly; the underlying `pip install` and test commands are unchanged aside from the added flags/retry wrapper.