### PR TITLE
feat: always compute Drag in slackDrag.csv, keep Slack opt-in behind --computeSlackDrag

### DIFF
--- a/crisp/graph.py
+++ b/crisp/graph.py
@@ -2,7 +2,7 @@
 import heapq
 import logging
 import os
-from typing import Callable
+from typing import Callable, Optional
 
 import crisp.common as common
 from crisp.shared.models import (
@@ -261,6 +261,10 @@ class Graph:
         self.filterProxy = filterProxy
         self.numProxyRoots = 0  # number of proxy nodes that are roots
         self.retimed = False  # set to True once Retimer.retime_node has mutated this Graph
+        # Lazily built by calculateSlack() and reused across every root of a multi-root
+        # trace (DependencyGraph depends only on nodeHT, not on which root/cp is being
+        # analyzed). Invalidated by Retimer whenever it mutates this Graph's timings.
+        self._dependencyGraphCache: Optional[DependencyGraph] = None
         self.exclusionSet = (
             exclusionSet if exclusionSet else {}
         )  # operations to exlude from the graph
@@ -1983,11 +1987,19 @@ class Graph:
                 calculate slack against. If None, uses findCriticalPath() on
                 this Graph's own rootNode.
             dependency_graph: Optional pre-built DependencyGraph. If None,
-                calculate_slack builds one internally via
-                DependencyGraph(graph=self).
+                reuses this Graph's cached DependencyGraph (building it once,
+                lazily) since DependencyGraph depends only on nodeHT, not on
+                which root/cp is being analyzed. This makes repeated calls on
+                a multi-root trace O(nodeHT) once instead of once per root.
+                The cache is invalidated by Retimer whenever it mutates this
+                Graph's timings.
         """
         if cp is None:
             cp = self.findCriticalPath()
+        if dependency_graph is None:
+            if self._dependencyGraphCache is None:
+                self._dependencyGraphCache = DependencyGraph(graph=self)
+            dependency_graph = self._dependencyGraphCache
         return calculate_slack(self, cp, dependency_graph)
 
     def retimeNodeWithDependencyGraph(self, node_span_id, new_start, new_end, dependency_graph=None, freeze_starts=True):

--- a/crisp/process_trace.py
+++ b/crisp/process_trace.py
@@ -371,8 +371,11 @@ def initArgs():
         default=False,
         required=False,
         help=(
-            "Compute per-method Drag/Slack (see slack_drag.py) and emit a slackDrag.csv "
-            "output file (default=false). Opt-in: when not set, output is unchanged."
+            "Additionally compute per-method Slack (see slack_drag.py) in the slackDrag.csv "
+            "output file (default=false). Drag is always computed and included in that file "
+            "regardless of this flag -- it's cheap and never affects latency-savings "
+            "projections. Slack is opt-in because it's much more expensive on large/"
+            "multi-root traces and is purely informational."
         ),
     )
 
@@ -647,9 +650,15 @@ def process(filename: str, config: common.Config) -> Any:
         {},
     )
 
-    if config.computeSlackDrag and metrics:
+    if metrics:
+        # Drag is always computed: it's cheap (sub-millisecond, even on huge traces)
+        # and never affects any latency-savings projection, so there's no reason to
+        # gate it. Slack stays opt-in behind --computeSlackDrag since it requires
+        # building a DependencyGraph, which is orders of magnitude more expensive on
+        # large/multi-root traces and -- unlike drag -- is only ever consumed by the
+        # informational slackDrag.csv report (see aggregate_drag_slack_by_callpath).
         drag = graph.calculateDrag(cp=criticalPath)
-        slack = graph.calculateSlack(cp=criticalPath)
+        slack = graph.calculateSlack(cp=criticalPath) if config.computeSlackDrag else None
         metrics.slackDragPerCallPath = aggregate_drag_slack_by_callpath(graph, drag, slack)
 
     logging.debug("critical path: %s", criticalPath)
@@ -2096,11 +2105,12 @@ def performCriticalPathAnalysis(c: common.Config) -> int:
     logging.info("Starting genCrossRegionCallsCSVFile")
     crossRegionCallsCSVFile = genCrossRegionCallsCSVFile(metrics, c, filename=common.CROSS_REGION_CALLS_CSV)
 
-    slackDragCSVFile = None
-    if c.computeSlackDrag:
-        logging.info("Starting genSlackDragCSVFile")
-        mergedSlackDragPerCallPath = merge_per_method_slack_drag(m.slackDragPerCallPath for m in metrics if m.slackDragPerCallPath)
-        slackDragCSVFile = genSlackDragCSVFile(mergedSlackDragPerCallPath, c, filename=common.SLACK_DRAG_CSV)
+    # Unconditional: drag is always computed above (see process()), so this report is
+    # always meaningful. The slack columns are simply 0.0 for every call path unless
+    # --computeSlackDrag was also passed.
+    logging.info("Starting genSlackDragCSVFile")
+    mergedSlackDragPerCallPath = merge_per_method_slack_drag(m.slackDragPerCallPath for m in metrics if m.slackDragPerCallPath)
+    slackDragCSVFile = genSlackDragCSVFile(mergedSlackDragPerCallPath, c, filename=common.SLACK_DRAG_CSV)
 
     logging.info("Starting genHypoLatencyCSVFile")
     hypoLatencyCSVFile = genHypoLatencyCSVFile(headLatencyPercentile, hypoLatencyPercentile, c)
@@ -2170,6 +2180,16 @@ def lightProcess(c: common.Config) -> int:
     outputDir = c.getOutputDir()
     cctFile = os.path.join(outputDir, "light-flame-graph-P100.cct")
     _writeCCTOutputs(cctFile, flameGraphStr, merged_cpp, c.maxExemplars)
+
+    # Drag is always populated per trace (see process()); slack columns are 0.0
+    # unless --computeSlackDrag was also passed. Unconditional, like the heavy
+    # path's genSlackDragCSVFile call, since drag alone is cheap and always
+    # meaningful.
+    logging.info("Starting genSlackDragCSVFile")
+    mergedSlackDragPerCallPath = merge_per_method_slack_drag(
+        m.slackDragPerCallPath for m in validMetrics if m.slackDragPerCallPath
+    )
+    genSlackDragCSVFile(mergedSlackDragPerCallPath, c, filename=common.SLACK_DRAG_CSV)
 
     if c.projectionEnabled:
         projected_metrics = [

--- a/crisp/retimer.py
+++ b/crisp/retimer.py
@@ -123,6 +123,7 @@ class Retimer:
             node = g.nodeHT[sid]
             node.startTime, node.endTime, node.duration = start, end, duration
         g.retimed = False
+        g._dependencyGraphCache = None  # timings changed; cached dependency deltas are stale
 
     def retime_node(
         self,
@@ -169,6 +170,7 @@ class Retimer:
             )
 
         g.retimed = True
+        g._dependencyGraphCache = None  # timings about to change; cached dependency deltas are stale
 
         delay = new_end - node.endTime  # positive = ends later, negative = ends sooner
         parent = node.parent

--- a/crisp/slack_drag.py
+++ b/crisp/slack_drag.py
@@ -464,7 +464,7 @@ def _sum_slack_drag_by_callpath(
 def aggregate_drag_slack_by_callpath(
     graph: Graph,
     drag: Drag,
-    slack: Slack,
+    slack: Slack | None = None,
 ) -> dict[str, PerMethodSlackDrag]:
     """Aggregate one graph's per-span drag/slack onto call-path identity.
 
@@ -474,7 +474,14 @@ def aggregate_drag_slack_by_callpath(
     Args:
         graph: the Graph that ``drag``/``slack`` were computed from.
         drag: per-span drag, as returned by ``calculate_drag``.
-        slack: per-span slack, as returned by ``calculate_slack``.
+        slack: per-span slack, as returned by ``calculate_slack``. Optional
+            because slack is much more expensive than drag on large/multi-root
+            traces (it requires building a DependencyGraph) and is only ever
+            consumed for the informational slackDrag.csv report -- unlike
+            drag, it's never used in any latency-savings projection. When
+            None, every span's slack contribution is 0.0, so callers that
+            don't need slack can skip computing it without changing drag's
+            aggregation at all.
 
     Returns:
         Mapping from call path to its aggregated :class:`PerMethodSlackDrag`.
@@ -484,7 +491,7 @@ def aggregate_drag_slack_by_callpath(
             graph.getCallPath(node),
             1,
             drag.drag_per_span.get(node.sid, 0.0),
-            slack.slack_per_span.get(node.sid, 0.0),
+            slack.slack_per_span.get(node.sid, 0.0) if slack is not None else 0.0,
         )
         for node in graph.nodeHT.values()
     )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -14,6 +14,8 @@ import sys
 import tempfile
 from unittest import TestCase, mock
 
+import pandas as pd
+
 import crisp.process_trace as process_trace
 from crisp.proto import analyzer_pb2
 
@@ -183,11 +185,32 @@ class TestCriticalPathE2E(TestCase):
 
 
 def _synthetic_two_root_child_trace(trace_id: str, scale: int = 1) -> dict:
-    """Two-service, two-root-child trace (R -> A, B) with non-trivial drag/slack.
+    """Trace with a root and three children (R -> A, B, D) with non-trivial
+    drag *and* slack.
+
+    A (0-100) and D (700-1000) end up on the critical path; B (300-750)
+    overlaps D's start by 5% -- past happensBefore's fuzzy-overlap tolerance
+    -- so it's excluded from cp and has real (nonzero) slack, matching
+    ``happens_before_chain_constrains_sibling_slack_graph`` in
+    test_slack_drag.py.
 
     ``scale`` avoids duration ties across traces, which some unrelated
     aggregation steps break via nondeterministic object identity.
     """
+    def _span(span_id, op, start, duration):
+        return {
+            "traceID": trace_id,
+            "spanID": span_id,
+            "operationName": op,
+            "references": [{"refType": "CHILD_OF", "traceID": trace_id, "spanID": "R"}],
+            "startTime": start * scale,
+            "duration": duration * scale,
+            "processID": "P2",
+            "tags": [],
+            "logs": [],
+            "warnings": None,
+        }
+
     return {
         "data": [
             {
@@ -209,34 +232,9 @@ def _synthetic_two_root_child_trace(trace_id: str, scale: int = 1) -> dict:
                         "logs": [],
                         "warnings": None,
                     },
-                    {
-                        "traceID": trace_id,
-                        "spanID": "A",
-                        "operationName": "OA",
-                        "references": [
-                            {"refType": "CHILD_OF", "traceID": trace_id, "spanID": "R"},
-                        ],
-                        "startTime": 0,
-                        "duration": 400 * scale,
-                        "processID": "P2",
-                        "tags": [],
-                        "logs": [],
-                        "warnings": None,
-                    },
-                    {
-                        "traceID": trace_id,
-                        "spanID": "B",
-                        "operationName": "OB",
-                        "references": [
-                            {"refType": "CHILD_OF", "traceID": trace_id, "spanID": "R"},
-                        ],
-                        "startTime": 500 * scale,
-                        "duration": 500 * scale,
-                        "processID": "P2",
-                        "tags": [],
-                        "logs": [],
-                        "warnings": None,
-                    },
+                    _span("A", "OA", 0, 100),
+                    _span("B", "OB", 300, 450),
+                    _span("D", "OD", 700, 300),
                 ],
             },
         ],
@@ -251,12 +249,13 @@ def _write_synthetic_traces(traces_dir: str, num_traces: int = 2) -> None:
 
 
 class TestComputeSlackDragFlag(TestCase):
-    """--computeSlackDrag is opt-in/default-off: verify slackDrag.csv only
-    appears when requested, and that turning it on/off never changes any
-    *other* output file.
+    """Drag is always computed (cheap, never affects latency-savings projections);
+    --computeSlackDrag only gates the much more expensive Slack columns. Verify
+    that turning the flag on/off never changes any output *other than* the slack
+    columns inside slackDrag.csv.
     """
 
-    def test_slack_drag_csv_only_written_when_flag_enabled(self):
+    def test_slack_drag_csv_always_written_slack_columns_only_when_flag_enabled(self):
         with tempfile.TemporaryDirectory() as tmpdir_off, tempfile.TemporaryDirectory() as tmpdir_on:
             _write_synthetic_traces(tmpdir_off)
             _write_synthetic_traces(tmpdir_on)
@@ -264,15 +263,31 @@ class TestComputeSlackDragFlag(TestCase):
             self.assertEqual(0, _run_dir(tmpdir_off))
             self.assertEqual(0, _run_dir(tmpdir_on, extra_args=["--computeSlackDrag"]))
 
-            self.assertFalse(os.path.exists(os.path.join(tmpdir_off, "slackDrag.csv")))
-            self.assertTrue(os.path.exists(os.path.join(tmpdir_on, "slackDrag.csv")))
+            path_off = os.path.join(tmpdir_off, "slackDrag.csv")
+            path_on = os.path.join(tmpdir_on, "slackDrag.csv")
+            self.assertTrue(os.path.exists(path_off))
+            self.assertTrue(os.path.exists(path_on))
 
-            with open(os.path.join(tmpdir_on, "slackDrag.csv")) as f:
-                content = f.read()
-            self.assertIn("callPath,spanCount,avgDrag,totalDrag,avgSlack,totalSlack", content)
+            df_off = pd.read_csv(path_off)
+            df_on = pd.read_csv(path_on)
+            self.assertListEqual(
+                list(df_off.columns),
+                ["callPath", "spanCount", "avgDrag", "totalDrag", "avgSlack", "totalSlack"],
+            )
+            # Drag columns are identical regardless of the flag.
+            pd.testing.assert_frame_equal(
+                df_off[["callPath", "spanCount", "avgDrag", "totalDrag"]],
+                df_on[["callPath", "spanCount", "avgDrag", "totalDrag"]],
+            )
+            self.assertTrue((df_off["avgSlack"] == 0.0).all())
+            self.assertTrue((df_off["totalSlack"] == 0.0).all())
+            self.assertTrue((df_on["totalSlack"] > 0.0).any())
 
     def test_all_other_output_files_byte_identical_regardless_of_flag(self):
-        """Every output file other than slackDrag.csv must be byte-identical regardless of --computeSlackDrag."""
+        """Every output file other than slackDrag.csv's slack columns must be
+        byte-identical regardless of --computeSlackDrag (slackDrag.csv itself is
+        always produced, since drag is always computed).
+        """
         with tempfile.TemporaryDirectory() as tmpdir_off, tempfile.TemporaryDirectory() as tmpdir_on:
             _write_synthetic_traces(tmpdir_off)
             _write_synthetic_traces(tmpdir_on)
@@ -284,15 +299,18 @@ class TestComputeSlackDragFlag(TestCase):
             files_off = set(os.listdir(tmpdir_off)) - input_filenames
             files_on = set(os.listdir(tmpdir_on)) - input_filenames
 
-            # The only allowed difference in the generated file *set* is the new CSV.
-            self.assertNotIn("slackDrag.csv", files_off)
-            self.assertIn("slackDrag.csv", files_on)
-            self.assertEqual(files_on - {"slackDrag.csv"}, files_off)
+            # The generated file *set* is now identical either way -- slackDrag.csv
+            # is unconditional. Only its slack columns are allowed to differ.
+            self.assertEqual(files_on, files_off)
 
             for filename in sorted(files_off):
                 path_off = os.path.join(tmpdir_off, filename)
                 path_on = os.path.join(tmpdir_on, filename)
                 if os.path.isdir(path_off):
+                    continue
+                if filename == "slackDrag.csv":
+                    # Covered separately by
+                    # test_slack_drag_csv_always_written_slack_columns_only_when_flag_enabled.
                     continue
                 if filename.endswith(".svg"):
                     # flamegraph.pl (the external tool that renders these) picks
@@ -327,3 +345,28 @@ class TestComputeSlackDragFlag(TestCase):
                     content_on,
                     f"{filename} must be byte-identical regardless of --computeSlackDrag",
                 )
+
+
+class TestLightModeSlackDrag(TestCase):
+    """lightProcess() must also always emit slackDrag.csv (drag always computed;
+    slack columns gated behind --computeSlackDrag), mirroring the heavy path.
+    """
+
+    def test_light_mode_always_writes_slack_drag_csv(self):
+        with tempfile.TemporaryDirectory() as tmpdir_off, tempfile.TemporaryDirectory() as tmpdir_on:
+            _write_synthetic_traces(tmpdir_off)
+            _write_synthetic_traces(tmpdir_on)
+
+            self.assertEqual(0, _run_dir(tmpdir_off, extra_args=["--lightMode"]))
+            self.assertEqual(0, _run_dir(tmpdir_on, extra_args=["--lightMode", "--computeSlackDrag"]))
+
+            path_off = os.path.join(tmpdir_off, "slackDrag.csv")
+            path_on = os.path.join(tmpdir_on, "slackDrag.csv")
+            self.assertTrue(os.path.exists(path_off))
+            self.assertTrue(os.path.exists(path_on))
+
+            df_off = pd.read_csv(path_off)
+            df_on = pd.read_csv(path_on)
+            self.assertTrue((df_off["totalDrag"] > 0.0).any())
+            self.assertTrue((df_off["totalSlack"] == 0.0).all())
+            self.assertTrue((df_on["totalSlack"] > 0.0).any())

--- a/tests/test_slack_drag.py
+++ b/tests/test_slack_drag.py
@@ -7,6 +7,7 @@ import pytest
 from crisp.graph import Graph, GraphNode
 from crisp.shared.models import SpanKind
 from crisp.dependency_graph import DependencyGraph
+from crisp.retimer import Retimer
 from crisp.slack_drag import (
     Drag,
     Slack,
@@ -958,6 +959,61 @@ def test_graph_calculate_slack_hook_defaults_cp_and_dependency_graph():
     assert via_default.slack_per_span
 
 
+# --- Graph._dependencyGraphCache: reused across roots, invalidated by Retimer. ---
+
+
+def test_calculate_slack_builds_and_reuses_a_cached_dependency_graph():
+    g = happens_before_chain_constrains_sibling_slack_graph()
+    assert g._dependencyGraphCache is None
+
+    g.calculateSlack()
+    cached = g._dependencyGraphCache
+    assert cached is not None
+
+    # A second call (e.g. a second root of a multi-root trace) must reuse the
+    # exact same DependencyGraph instance rather than rebuilding it.
+    g.calculateSlack()
+    assert g._dependencyGraphCache is cached
+
+
+def test_calculate_slack_with_explicit_dependency_graph_does_not_touch_the_cache():
+    g = happens_before_chain_constrains_sibling_slack_graph()
+    explicit_dep = DependencyGraph(graph=g)
+
+    g.calculateSlack(dependency_graph=explicit_dep)
+
+    assert g._dependencyGraphCache is None
+
+
+def test_retimer_retime_node_invalidates_the_cached_dependency_graph():
+    g = happens_before_chain_constrains_sibling_slack_graph()
+    g.calculateSlack()
+    cached = g._dependencyGraphCache
+    assert cached is not None
+
+    Retimer(cached).retime_node(g, "A", 0, 50)
+
+    assert g._dependencyGraphCache is None
+    # Recomputing after a retime must rebuild against the new timings, not
+    # silently keep serving the stale cached instance.
+    g.calculateSlack()
+    assert g._dependencyGraphCache is not None
+    assert g._dependencyGraphCache is not cached
+
+
+def test_retimer_restore_invalidates_the_cached_dependency_graph():
+    g = happens_before_chain_constrains_sibling_slack_graph()
+    snapshot = Retimer.snapshot(g)
+    g.calculateSlack()
+    cached = g._dependencyGraphCache
+    assert cached is not None
+
+    Retimer(cached).retime_node(g, "A", 0, 50)
+    Retimer.restore(g, snapshot)
+
+    assert g._dependencyGraphCache is None
+
+
 # --- Realistic fixtures from test_cases/*.json. ---
 
 
@@ -1022,6 +1078,27 @@ def test_aggregate_by_callpath_distinct_paths_matches_per_span_values_exactly():
         assert entry.avg_drag == entry.total_drag
         assert entry.total_slack == slack.slack_per_span[node.sid]
         assert entry.avg_slack == entry.total_slack
+
+
+def test_aggregate_by_callpath_omitted_slack_defaults_every_span_to_zero():
+    # slack is optional (much more expensive than drag on large/multi-root traces
+    # and only ever consumed by the informational slackDrag.csv report). Omitting
+    # it must not change drag's aggregation at all, and every slack column must
+    # come back as a clean 0.0 rather than raising or being left unset.
+    g = linear_chain_graph()
+    cp = g.findCriticalPath()
+    drag = calculate_drag(g, cp)
+    slack = calculate_slack(g, cp)
+
+    agg_with_slack = aggregate_drag_slack_by_callpath(g, drag, slack)
+    agg_without_slack = aggregate_drag_slack_by_callpath(g, drag)
+
+    assert set(agg_without_slack.keys()) == set(agg_with_slack.keys())
+    for call_path, entry in agg_without_slack.items():
+        assert entry.total_slack == 0.0
+        assert entry.avg_slack == 0.0
+        assert entry.total_drag == agg_with_slack[call_path].total_drag
+        assert entry.avg_drag == agg_with_slack[call_path].avg_drag
 
 
 def test_aggregate_by_callpath_groups_same_callpath_and_averages():


### PR DESCRIPTION
## Summary
- `process()`/`performCriticalPathAnalysis()`/`lightProcess()` (`crisp/process_trace.py`) now always compute per-call-path Drag and write it to `slackDrag.csv` — it's cheap (sub-millisecond even on huge traces) and never affects any latency-savings projection, so gating it behind a flag added no value. `--computeSlackDrag` now only gates the much more expensive Slack columns (0.0 when the flag is off), since Slack requires building a `DependencyGraph`.
- `aggregate_drag_slack_by_callpath`'s `slack` parameter (`crisp/slack_drag.py`) is now optional — `None` means every span's slack contribution is `0.0` — so callers that skip Slack don't need a dummy `Slack` object.
- Added `Graph._dependencyGraphCache` (`crisp/graph.py`): `calculateSlack()` lazily builds and reuses one `DependencyGraph` per `Graph`, since it depends only on `nodeHT`, not on which root/critical-path is being analyzed. `Retimer.retime_node`/`restore` (`crisp/retimer.py`) invalidate the cache whenever they mutate the `Graph`'s timings.
- Updated `tests/test_e2e.py` (`slackDrag.csv` is now always written; only its Slack columns are gated) and `tests/test_slack_drag.py` (optional-`slack` behavior, plus new tests for the cache reuse/invalidation itself).

## Test plan
- [x] `pytest` full suite passes (639 passed)
- [x] `bazel test //...` passes (33/33 targets)
