### PR TITLE
feat: bound pipeline work items with a per-item timeout

### DIFF
--- a/crisp/pipeline.py
+++ b/crisp/pipeline.py
@@ -1,14 +1,28 @@
 import logging
 import multiprocessing as mp
+import os
 import shutil
 import time
 import traceback
+import typing
 from collections.abc import Callable
 
 import crisp.common as common
 
 # TODO: Dynamically compute the max workers based on the pipeline steps, number of cores, and intra-step parallelism.
 MAX_WORKERS = 16
+
+# Default ceiling on how long a single work item is allowed to run before we
+# forcibly terminate its worker process. Chosen from production experience:
+# legitimately slow (but successful) work items have taken up to ~90
+# minutes, while a genuinely hung one can block the pipeline for many hours
+# with no further progress. 120 minutes gives meaningful headroom over the
+# slowest known-good case while still bounding the pipeline to a sane
+# wall-clock limit. Overridable via env var so it can be tuned without a
+# code change. Only applies to non-serialize (multiprocess) phases: a
+# serialize=True handler runs synchronously in-process before the
+# timeout-aware wait loop is ever entered, so it is not bounded by this value.
+WORKITEM_TIMEOUT_SEC = int(os.environ.get("CRISP_WORKITEM_TIMEOUT_SEC", 120 * 60))
 
 
 class WorkItem:
@@ -44,8 +58,8 @@ def cleanupWrapper(c: common.Config, resultQ: mp.Queue) -> common.Config:
     )
 
 
-# TODO: Use timeouts to prevent waiting forever on an multiprocess handler.
-# TODO: Use error handling to prevent a crash in a single workitem bringing down the entire pipeline.
+# TODO: Use error handling to prevent an outright crash (e.g. OOM-kill, segfault) in a
+# single workitem's process from bringing down the entire pipeline.
 class Worker:
     def __init__(
         self,
@@ -67,6 +81,7 @@ class Worker:
         self.handler = handler
         self.serialize = serialize
         self.storedResult = None
+        self.startTime = time.time()
         # Nop for last item.
         if isLast:
             return
@@ -87,6 +102,9 @@ class Worker:
             raise ValueError("getWaitable called on a last worker")
         return self.q._reader
 
+    def elapsedSec(self) -> float:
+        return time.time() - self.startTime
+
     def getResult(self) -> common.Config:
         if self.isLast:
             return self.c
@@ -101,6 +119,102 @@ class Worker:
         self.q.close()
         return self.storedResult
 
+    def terminateForTimeout(self, workItemTimeoutSec: float = WORKITEM_TIMEOUT_SEC) -> common.Config:
+        """Force-terminate a worker process that exceeded workItemTimeoutSec.
+
+        Prevents a single stuck work item (e.g. an oversized or edge-case
+        trace) from blocking the entire pipeline stage indefinitely. If the
+        worker happened to finish right as it was being reaped, its real
+        result is returned unmodified; otherwise a Config marked as failed
+        is returned so it can flow through the pipeline like any other
+        (unsuccessful) result. Either way, the underlying process is
+        guaranteed to be terminated before this method returns -- a worker
+        that wrote its result but then hangs afterwards (e.g. in cleanup
+        code) would otherwise leak a zombie process.
+        """
+        logging.error(
+            f"{self.name}: work item for {self.c.serviceName}::{self.c.operationName} "
+            f"exceeded the {workItemTimeoutSec}s timeout after running for "
+            f"{self.elapsedSec():.0f}s; terminating its worker process.",
+        )
+        # Courtesy check: the worker may have finished right as we decided to
+        # reap it. Grab the result if it's already there instead of discarding it.
+        try:
+            self.storedResult = self.q.get_nowait()
+        except Exception:  # noqa: BLE001 - queue.Empty or a closed/broken queue, both mean "not ready".
+            self.storedResult = None
+
+        if self.storedResult is None:
+            self.c.failed = True
+            self.c.failedLog.append(
+                f"{self.name}: timed out after {self.elapsedSec():.0f}s (limit {workItemTimeoutSec}s)",
+            )
+            self.storedResult = self.c
+
+        if self.process.is_alive():
+            self.process.terminate()
+            self.process.join(timeout=10)
+        if self.process.is_alive():
+            self.process.kill()
+            self.process.join(timeout=10)
+        self.q.close()
+        return self.storedResult
+
+
+def _flushReadyItems(
+    name: str,
+    finishedRequests: dict,
+    outputQ: mp.Queue,
+    bottomMark: int,
+    processingOrder: int,
+) -> int:
+    """Push completed items to outputQ in their original input order.
+
+    Items may finish out of order (parallel workers), so we only emit a
+    contiguous prefix starting at bottomMark, buffering the rest until their
+    turn comes up. Returns the updated bottomMark.
+    """
+    for i in range(bottomMark, processingOrder):
+        if i in finishedRequests and i == bottomMark:
+            logging.info(name + ": enqueuing index " + str(i) + " to outputQ")
+            outputQ.put(finishedRequests[i])
+            del finishedRequests[i]
+            bottomMark += 1
+        else:
+            break
+    return bottomMark
+
+
+def _nextDeadlineSec(outstandingRequests: dict, workItemTimeoutSec: float = WORKITEM_TIMEOUT_SEC) -> typing.Optional[float]:
+    """Seconds until the soonest outstanding item hits workItemTimeoutSec.
+
+    Returns None if there's nothing outstanding to bound (mp.connection.wait
+    can then block indefinitely, matching the pre-timeout behavior for the
+    "just waiting on new input" case).
+    """
+    if not outstandingRequests:
+        return None
+    now = time.time()
+    remaining = [worker.startTime + workItemTimeoutSec - now for worker, _item, _order in outstandingRequests.values()]
+    return max(0.0, min(remaining))
+
+
+def _reapTimedOutWorkers(
+    name: str,
+    outstandingRequests: dict,
+    workItemTimeoutSec: float = WORKITEM_TIMEOUT_SEC,
+) -> list[tuple[int, "WorkItem"]]:
+    """Force-terminate and remove any outstanding item over workItemTimeoutSec."""
+    timedOutKeys = [f for f, (worker, _item, _order) in outstandingRequests.items() if worker.elapsedSec() >= workItemTimeoutSec]
+    if timedOutKeys:
+        logging.error(name + f": reaping {len(timedOutKeys)} timed-out work item(s)")
+    reaped = []
+    for f in timedOutKeys:
+        worker, item, order = outstandingRequests.pop(f)
+        item.config = worker.terminateForTimeout(workItemTimeoutSec)
+        reaped.append((order, item))
+    return reaped
+
 
 def pipelineWorker(
     name: str,
@@ -109,9 +223,10 @@ def pipelineWorker(
     errorQ: mp.Queue,
     handler: Callable[[common.Config, mp.Queue], None],
     serialize=False,
+    workItemTimeoutSec: float = WORKITEM_TIMEOUT_SEC,
 ):
     try:
-        pipelineWorkerReal(name, inputQ, outputQ, handler, serialize)
+        pipelineWorkerReal(name, inputQ, outputQ, handler, serialize, workItemTimeoutSec)
     except Exception as ex:
         exceptionStr = "".join(traceback.TracebackException.from_exception(ex).format())
         logging.error(f"Exception in pipelineWorker {name}: {exceptionStr}")
@@ -129,6 +244,7 @@ def pipelineWorkerReal(
     outputQ: mp.Queue,
     handler: Callable[[common.Config, mp.Queue], None],
     serialize=False,
+    workItemTimeoutSec: float = WORKITEM_TIMEOUT_SEC,
 ):
     if not name:
         raise ValueError("name cannot be None or empty")
@@ -165,7 +281,17 @@ def pipelineWorkerReal(
             logging.info(name + ": has nothing to wait for")
             break
 
-        finished = mp.connection.wait(waitList)
+        # Bound the wait so a hung work item can't block this stage forever;
+        # wake up in time to reap anything that has exceeded workItemTimeoutSec.
+        finished = mp.connection.wait(waitList, timeout=_nextDeadlineSec(outstandingRequests, workItemTimeoutSec))
+
+        if not finished:
+            # Nothing completed before the deadline: reap whatever timed out and
+            # loop back around to recompute waitList/deadlines from scratch.
+            finishedRequests.update(dict(_reapTimedOutWorkers(name, outstandingRequests, workItemTimeoutSec)))
+            bottomMark = _flushReadyItems(name, finishedRequests, outputQ, bottomMark, processingOrder)
+            continue
+
         for f in finished:
             if len(qGet) > 0 and f == qGet[0]:  # new item in inputQ
                 logging.info(name + ": has new item in the inputQ")
@@ -223,17 +349,7 @@ def pipelineWorkerReal(
                 # remove the finished item from the outstandingRequests.
                 del outstandingRequests[f]
                 finishedRequests[order] = itemToPush
-                # push all items from the bottomMark out until sequential order is preserved in the outputQ.
-                for i in range(bottomMark, processingOrder):
-                    if i in finishedRequests and i == bottomMark:
-                        logging.info(
-                            name + ": enqueuing index " + str(i) + " to outputQ",
-                        )
-                        outputQ.put(finishedRequests[i])
-                        del finishedRequests[i]
-                        bottomMark += 1
-                    else:
-                        break
+                bottomMark = _flushReadyItems(name, finishedRequests, outputQ, bottomMark, processingOrder)
     outputQ.put(lastItem)
     outputQ.close()
     logging.info(name + ": finished")
@@ -243,6 +359,7 @@ def Pipeline(
     workItemsIn: list[WorkItem],
     lst: list[common.PipelinePhase],
     allSerilized=False,
+    workItemTimeoutSec: float = WORKITEM_TIMEOUT_SEC,
 ):
     # Create the last item.
     w = WorkItem(len(workItemsIn), common.Config(numTrace=0), True)
@@ -279,6 +396,7 @@ def Pipeline(
                 errQ,
                 lst[i].func,
                 shouldSerialize,
+                workItemTimeoutSec,
             ),
         )
         workers.append(worker)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,7 @@
+import functools
 import multiprocessing as mp
+import signal
+import time
 from unittest import TestCase
 import unittest
 from unittest.mock import MagicMock, patch
@@ -20,6 +23,52 @@ def dummyWorker(c: common.Config, resultQ: mp.Queue) -> common.Config:
         resultQ.put(c)
         resultQ.close()
     return c
+
+
+def hangingWorker(c: common.Config, resultQ: mp.Queue) -> common.Config:
+    """Simulates a work item that never returns in time (e.g. a genuine hang)."""
+    time.sleep(30)
+    if resultQ:
+        resultQ.put(c)
+        resultQ.close()
+    return c
+
+
+def sigtermIgnoringWorker(c: common.Config, resultQ: mp.Queue, readyEvent=None) -> common.Config:
+    """Simulates a stuck work item whose process doesn't die from SIGTERM alone,
+    forcing terminateForTimeout to escalate to SIGKILL. Signals readyEvent once
+    the SIGTERM handler is installed so callers can synchronize on that instead
+    of sleeping for an arbitrary guess at how long process startup takes."""
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    if readyEvent is not None:
+        readyEvent.set()
+    time.sleep(30)
+    if resultQ:
+        resultQ.put(c)
+        resultQ.close()
+    return c
+
+
+class RecordingQueue:
+    """Minimal outputQ stand-in for calling pipelineWorkerReal/pipelineWorker
+    directly instead of via mp.Process.
+
+    Both functions only ever call put()/close() on outputQ, never get(). A
+    real mp.Queue's close() makes it unreadable via that same object -- fine
+    when the two calls happen from different processes/handles (as in
+    production), but not when calling the function directly in the test's
+    own process. A plain in-memory list sidesteps that entirely and lets the
+    test inspect what was produced after the call returns.
+    """
+
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+    def close(self):
+        pass
 
 
 def dummyWorkerList():
@@ -67,7 +116,7 @@ class PipelineWorkerTestCase(unittest.TestCase):
         """Test pipelineWorker when pipelineWorkerReal runs without exceptions."""
         # Set up queues
         inputQ = mp.Queue()
-        outputQ = mp.Queue()
+        outputQ = RecordingQueue()
         errorQ = mp.Queue()
 
         # Create a work item and put it in the input queue
@@ -75,19 +124,14 @@ class PipelineWorkerTestCase(unittest.TestCase):
         workItem.isLast = True  # To signal the last item
         inputQ.put(workItem)
 
-        # Start the pipeline worker in a process
-        worker_process = mp.Process(
-            target=pipeline.pipelineWorker,
-            args=("test_worker", inputQ, outputQ, errorQ, dummyWorker, False),
-        )
-        worker_process.start()
-
-        # Wait for the worker process to finish
-        worker_process.join()
+        # pipelineWorker/pipelineWorkerReal are plain blocking functions -- no
+        # need for an extra mp.Process wrapper here (the actual per-item work,
+        # if any, is already isolated in its own process by Worker).
+        pipeline.pipelineWorker("test_worker", inputQ, outputQ, errorQ, dummyWorker, False)
 
         # Check the output queue
-        self.assertFalse(outputQ.empty(), "Output queue should not be empty.")
-        result_item = outputQ.get()
+        self.assertEqual(len(outputQ.items), 1, "Output queue should have exactly one item.")
+        result_item = outputQ.items[0]
         self.assertEqual(result_item.itemId, 0)
         self.assertEqual(result_item.isLast, True)
         self.assertIsInstance(result_item.config, common.Config)
@@ -107,24 +151,25 @@ class PipelineWorkerTestCase(unittest.TestCase):
         workItem.isLast = True  # To signal the last item
         inputQ.put(workItem)
 
-        # Mock pipelineWorkerReal to raise an exception
+        # Mock pipelineWorkerReal to raise an exception. Calling pipelineWorker
+        # directly (rather than via mp.Process) means the mock reliably applies
+        # regardless of the platform's multiprocessing start method.
         with patch("crisp.pipeline.pipelineWorkerReal", side_effect=Exception("Intentional Exception for testing")):
-            # Start the pipeline worker in a process
-            worker_process = mp.Process(
-                target=pipeline.pipelineWorker,
-                args=("faulty_worker", inputQ, outputQ, errorQ, None, False),
-            )
-            worker_process.start()
-
-            # Wait for the worker process to finish
-            worker_process.join()
+            pipeline.pipelineWorker("faulty_worker", inputQ, outputQ, errorQ, None, False)
 
             # Ensure the output queue is empty, as the exception should prevent any output
             self.assertTrue(outputQ.empty(), "Output queue should be empty due to exception.")
 
-            # The error queue should contain the worker's name
-            self.assertFalse(errorQ.empty(), "Error queue should contain the worker's name.")
-            error_name = errorQ.get()
+            # The error queue should contain the worker's name. Use a blocking get()
+            # with a timeout rather than checking empty() first: mp.Queue.put() hands
+            # off to a background feeder thread, so an empty()/get() check immediately
+            # after put() (now that pipelineWorker runs directly in this process rather
+            # than in a separate mp.Process we'd join() first) can race and see "empty"
+            # before the feeder thread has actually written to the underlying pipe.
+            try:
+                error_name = errorQ.get(timeout=5)
+            except Exception:
+                self.fail("Error queue should contain the worker's name.")
             self.assertEqual(error_name, "faulty_worker")
 
 class PipelineWorkerRealTestCase(unittest.TestCase):
@@ -173,36 +218,53 @@ class PipelineWorkerRealTestCase(unittest.TestCase):
     def test_pipelineWorkerReal_serial_execution(self):
         """Test pipelineWorkerReal in serial mode."""
         inputQ = mp.Queue()
-        outputQ = mp.Queue()
+        outputQ = RecordingQueue()
 
         # Create a work item and put it in the input queue
         workItem = pipeline.WorkItem(0, common.Config())
         workItem.isLast = True  # Signal the last item
         inputQ.put(workItem)
 
-        # Start pipelineWorkerReal in a separate process for serial execution
-        process = mp.Process(
-            target=pipeline.pipelineWorkerReal,
-            args=("test_worker_serial", inputQ, outputQ, dummyWorker, True),
-        )
-        process.start()
-        process.join()
+        # pipelineWorkerReal is a plain blocking function; call it directly.
+        pipeline.pipelineWorkerReal("test_worker_serial", inputQ, outputQ, dummyWorker, True)
 
         # Check the output queue
-        self.assertFalse(outputQ.empty(), "Output queue should not be empty.")
-        result_item = outputQ.get()
+        self.assertEqual(len(outputQ.items), 1, "Output queue should have exactly one item.")
+        result_item = outputQ.items[0]
         self.assertEqual(result_item.itemId, 0)
         self.assertTrue(result_item.isLast)
         self.assertIsInstance(result_item.config, common.Config)
 
-        # Clean up queues
+        # Clean up queue
         inputQ.close()
-        outputQ.close()
+
+    def test_pipelineWorkerReal_serial_execution_processes_real_item(self):
+        """Test pipelineWorkerReal in serial mode actually runs the handler for a real (non-last) item."""
+        inputQ = mp.Queue()
+        outputQ = RecordingQueue()
+
+        workItem = pipeline.WorkItem(0, common.Config())
+        inputQ.put(workItem)
+        lastItem = pipeline.WorkItem(1, common.Config(), isLast=True)
+        inputQ.put(lastItem)
+
+        pipeline.pipelineWorkerReal("test_worker_serial", inputQ, outputQ, dummyWorker, True)
+
+        self.assertEqual(len(outputQ.items), 2)
+        result_item = outputQ.items[0]
+        self.assertEqual(result_item.itemId, 0)
+        self.assertFalse(result_item.isLast)
+        self.assertIn(("test_worker_serial", 0), result_item.log)
+
+        last_output_item = outputQ.items[1]
+        self.assertTrue(last_output_item.isLast)
+
+        inputQ.close()
 
     def test_pipelineWorkerReal_parallel_execution(self):
         """Test pipelineWorkerReal in parallel mode."""
         inputQ = mp.Queue()
-        outputQ = mp.Queue()
+        outputQ = RecordingQueue()
 
         # Create multiple work items and put them in the input queue
         workItems = [pipeline.WorkItem(i, common.Config()) for i in range(3)]
@@ -213,23 +275,13 @@ class PipelineWorkerRealTestCase(unittest.TestCase):
         lastItem = pipeline.WorkItem(len(workItems), common.Config(), isLast=True)
         inputQ.put(lastItem)
 
-        # Run pipelineWorkerReal in parallel mode in a separate process
-        process = mp.Process(
-            target=pipeline.pipelineWorkerReal,
-            args=("test_worker_parallel", inputQ, outputQ, dummyWorker, False),
-        )
-        process.start()
-        process.join()
-
-        # Drain the output queue and collect items
-        output_items = []
-        while True:
-            try:
-                output_items.append(outputQ.get_nowait())
-            except Exception:
-                break
+        # Run pipelineWorkerReal in parallel mode. Each item's actual handler
+        # still runs in its own process via Worker; only the driving loop runs
+        # directly here.
+        pipeline.pipelineWorkerReal("test_worker_parallel", inputQ, outputQ, dummyWorker, False)
 
         # Check that the output queue contains all items in the correct order
+        output_items = outputQ.items
         self.assertEqual(len(output_items), len(workItems) + 1)
         for i in range(len(workItems)):
             result_item = output_items[i]
@@ -241,14 +293,13 @@ class PipelineWorkerRealTestCase(unittest.TestCase):
         self.assertEqual(result_item.itemId, len(workItems))
         self.assertTrue(result_item.isLast)
 
-        # Clean up queues
+        # Clean up queue
         inputQ.close()
-        outputQ.close()
 
     def test_pipelineWorkerReal_order_preservation(self):
         """Test pipelineWorkerReal maintains input order in output queue."""
         inputQ = mp.Queue()
-        outputQ = mp.Queue()
+        outputQ = RecordingQueue()
 
         # Create work items in ascending order
         workItems = [pipeline.WorkItem(i, common.Config()) for i in range(3)]
@@ -259,20 +310,11 @@ class PipelineWorkerRealTestCase(unittest.TestCase):
         lastItem = pipeline.WorkItem(len(workItems), common.Config(), isLast=True)
         inputQ.put(lastItem)
 
-        # Run pipelineWorkerReal with serialize=False to allow parallel execution
-        process = mp.Process(
-            target=pipeline.pipelineWorkerReal,
-            args=("test_worker_order", inputQ, outputQ, dummyWorker, False),
-        )
-        process.start()
-        process.join()
-
-        # Retrieve and check the processing order from each item's log
-        output_items = []
-        while not outputQ.empty():
-            output_items.append(outputQ.get())
+        # Run pipelineWorkerReal with serialize=False to allow parallel execution.
+        pipeline.pipelineWorkerReal("test_worker_order", inputQ, outputQ, dummyWorker, False)
 
         # Ensure that items are processed in the correct order (0, 1, 2)
+        output_items = outputQ.items
         for idx, item in enumerate(output_items[:-1]):  # Exclude the last item
             self.assertEqual(item.itemId, idx)
             self.assertIsInstance(item.config, common.Config)
@@ -283,9 +325,129 @@ class PipelineWorkerRealTestCase(unittest.TestCase):
         self.assertTrue(last_output_item.isLast)
         self.assertEqual(last_output_item.itemId, 3)
 
-        # Clean up queues
+        # Clean up queue
         inputQ.close()
-        outputQ.close()
+
+
+def test_nextDeadlineSec_returns_none_when_no_outstanding_requests():
+    assert pipeline._nextDeadlineSec({}) is None
+
+
+def test_nextDeadlineSec_returns_soonest_remaining_time():
+    timeoutSec = 100
+    soonWorker = pipeline.Worker("w", common.Config(), True, dummyWorker)
+    soonWorker.startTime = time.time() - 90  # 10s left until timeout
+    laterWorker = pipeline.Worker("w", common.Config(), True, dummyWorker)
+    laterWorker.startTime = time.time() - 10  # 90s left until timeout
+
+    outstanding = {1: (soonWorker, None, 0), 2: (laterWorker, None, 1)}
+
+    remaining = pipeline._nextDeadlineSec(outstanding, timeoutSec)
+
+    assert 0 <= remaining <= 10
+
+
+def test_terminateForTimeout_marks_config_failed_and_kills_process():
+    worker = pipeline.Worker("test_worker", common.Config(), False, hangingWorker)
+    assert worker.process.is_alive()
+
+    result = worker.terminateForTimeout()
+
+    assert result.failed is True
+    assert any("timed out" in msg for msg in result.failedLog)
+    worker.process.join(timeout=5)
+    assert not worker.process.is_alive()
+
+
+def test_terminateForTimeout_escalates_to_kill_when_terminate_is_ignored():
+    """If the worker process survives SIGTERM (terminate()), we must escalate to SIGKILL
+    rather than leaving a zombie process behind."""
+    readyEvent = mp.Event()
+    handler = functools.partial(sigtermIgnoringWorker, readyEvent=readyEvent)
+    worker = pipeline.Worker("test_worker", common.Config(), False, handler)
+    assert worker.process.is_alive()
+    # Wait for the child to actually confirm it has installed the SIGTERM
+    # handler, rather than guessing how long that takes with a fixed sleep.
+    assert readyEvent.wait(timeout=5), "child did not install its SIGTERM handler in time"
+
+    result = worker.terminateForTimeout()
+
+    assert result.failed is True
+    worker.process.join(timeout=5)
+    assert not worker.process.is_alive(), "process ignoring SIGTERM should still be killed via SIGKILL"
+
+
+def test_reapTimedOutWorkers_removes_only_expired_items():
+    timeoutSec = 60
+    expiredWorker = pipeline.Worker("test_worker", common.Config(), False, hangingWorker)
+    expiredWorker.startTime = time.time() - (timeoutSec + 60)
+    freshWorker = pipeline.Worker("test_worker", common.Config(), False, dummyWorker)
+
+    expiredItem = pipeline.WorkItem(0, common.Config())
+    freshItem = pipeline.WorkItem(1, common.Config())
+    outstanding = {
+        expiredWorker.getWaitable(): (expiredWorker, expiredItem, 0),
+        freshWorker.getWaitable(): (freshWorker, freshItem, 1),
+    }
+
+    reaped = pipeline._reapTimedOutWorkers("test_worker", outstanding, timeoutSec)
+
+    assert [order for order, _item in reaped] == [0]
+    assert reaped[0][1].config.failed is True
+    assert list(outstanding.keys()) == [freshWorker.getWaitable()]
+
+    freshWorker.process.join(timeout=5)
+
+
+def test_pipelineWorkerReal_reaps_hung_worker_instead_of_blocking_forever():
+    """A single hung work item should be killed and marked failed, not block the whole stage."""
+    inputQ = mp.Queue()
+    outputQ = RecordingQueue()
+
+    workItem = pipeline.WorkItem(0, common.Config())
+    inputQ.put(workItem)
+    lastItem = pipeline.WorkItem(1, common.Config(), isLast=True)
+    inputQ.put(lastItem)
+
+    # pipelineWorkerReal is a plain blocking function: calling it directly
+    # with a short workItemTimeoutSec means this call returns on its own once
+    # the hung item is reaped, rather than hanging forever, with no need for
+    # an outer mp.Process/join/is_alive dance to bound the wait from the test
+    # side. The hung item's own handler still runs in a real subprocess via
+    # Worker, so the actual termination/kill logic under test is exercised faithfully.
+    pipeline.pipelineWorkerReal("test_worker_timeout", inputQ, outputQ, hangingWorker, False, 1)
+
+    assert len(outputQ.items) == 2
+    result_item = outputQ.items[0]
+    assert result_item.itemId == 0
+    assert result_item.config.failed is True
+
+    last_output_item = outputQ.items[1]
+    assert last_output_item.isLast
+
+    inputQ.close()
+
+
+def test_flushReadyItems_emits_contiguous_prefix_and_buffers_the_rest():
+    outputQ = mp.Queue()
+    finishedRequests = {0: "item-0", 2: "item-2"}
+
+    bottomMark = pipeline._flushReadyItems("test_worker", finishedRequests, outputQ, bottomMark=0, processingOrder=3)
+
+    # Only index 0 is contiguous from bottomMark; index 2 is buffered since index 1 hasn't finished yet.
+    assert bottomMark == 1
+    assert finishedRequests == {2: "item-2"}
+    assert outputQ.get(timeout=5) == "item-0"
+    assert outputQ.empty()
+
+    # Once index 1 arrives, both 1 and 2 should flush through in order.
+    finishedRequests[1] = "item-1"
+    bottomMark = pipeline._flushReadyItems("test_worker", finishedRequests, outputQ, bottomMark=bottomMark, processingOrder=3)
+
+    assert bottomMark == 3
+    assert finishedRequests == {}
+    assert outputQ.get(timeout=5) == "item-1"
+    assert outputQ.get(timeout=5) == "item-2"
 
 
 class TestMemoryAwareWorkers(TestCase):


### PR DESCRIPTION
## Summary
- Add `WORKITEM_TIMEOUT_SEC` (default 120min, override via `CRISP_WORKITEM_TIMEOUT_SEC`) to `crisp/pipeline.py`: a work item running longer than this gets its worker process force-killed (`terminate()`, escalating to `kill()` if needed) and its `Config` marked `failed`, instead of blocking the pipeline stage forever.
- `pipelineWorkerReal`'s wait loop now bounds `mp.connection.wait(...)` by the soonest deadline and reaps expired workers each time it times out. Only applies to non-serialize (multiprocess) phases.
- Extracted the existing out-of-order completion flush logic into a shared `_flushReadyItems()` helper.
- Added tests for the timeout/kill-escalation/reaping logic, plus an end-to-end test confirming a hung work item gets reaped instead of hanging the stage.

## Test plan
- [x] `pytest` full suite passes (647 passed)
- [x] `bazel test //...` passes (33/33 targets)